### PR TITLE
Fix Enhanced Onboarding Asso Mode Display

### DIFF
--- a/entourage/Scenes/HomeV2/HomeV2ViewController.swift
+++ b/entourage/Scenes/HomeV2/HomeV2ViewController.swift
@@ -1339,6 +1339,9 @@ extension HomeV2ViewController {
     private func presentEnhancedOnboardingIntro() {
         let sb = UIStoryboard(name: "EnhancedOnboarding", bundle: nil)
         if let intro = sb.instantiateViewController(withIdentifier: "enhancedOnboardingIntro") as? EnhancedOnboardingIntro {
+            if let _ = UserDefaults.currentUser?.partner {
+                intro.isAssociationGoal = true
+            }
             intro.modalPresentationStyle = .fullScreen
             if presentedViewController != nil {
                 dismiss(animated: false)


### PR DESCRIPTION
This PR fixes an issue where the Enhanced Onboarding screen would always display in "User" mode (Classic) instead of "Association" mode for users belonging to an association (Partner). 

The fix involves checking for the existence of `UserDefaults.currentUser?.partner` before presenting the `EnhancedOnboardingIntro` view controller and setting its `isAssociationGoal` property accordingly.

Additionally, confirmed that the logic to prevent the onboarding from reappearing (cookie/UserDefaults flag) is already present and functioning in `runHomeEntryGatingIfNeeded`.

---
*PR created automatically by Jules for task [10165983856188731379](https://jules.google.com/task/10165983856188731379) started by @clemPerrousset*