### PR TITLE
Update user role display labels and deduplication

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -698,7 +698,7 @@
 /*************
  * Group detail
  */
-"title_is_ambassador" = "Ambassadeur •" ;
+"title_is_ambassador" = "Animateur Entourage •" ;
 "title_is_admin" = "Administrateur •" ;
 
 "neighborhood_detail_button_join_member" = "عضو";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -703,7 +703,7 @@
 /*************
  * Group detail
  */
-"title_is_ambassador" = "Botschafter •";
+"title_is_ambassador" = "Animateur Entourage •";
 "title_is_admin" = "Administrator •";
 
 "neighborhood_detail_button_join_member" = "Mitglied";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -691,7 +691,7 @@
 "neighborhood_group_discover_empty_title" = "Oops, there are no other groups around you yet.";
 "neighborhood_group_discover_empty_subtitle" = "Don’t hesitate to create new groups of neighbors!";
 
-"title_is_ambassador" = "Ambassador •";
+"title_is_ambassador" = "Animateur Entourage •";
 "title_is_admin" = "Administrator •";
 
 "neighborhood_detail_button_join_member" = "Member";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -703,7 +703,7 @@
 /*************
  * Group detail
  */
-"title_is_ambassador" = "Embajador •";
+"title_is_ambassador" = "Animateur Entourage •";
 "title_is_admin" = "Administrador •";
 
 "neighborhood_detail_button_join_member" = "Miembro";
@@ -2128,7 +2128,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 /*************
  * Group detail
  */
-"title_is_ambassador" = "Embajador •";
+"title_is_ambassador" = "Animateur Entourage •";
 "title_is_admin" = "Administrador •";
 
 "neighborhood_detail_button_join_member" = "Miembro";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -715,7 +715,7 @@
 /*************
  * Group detail
  */
-"title_is_ambassador" = "Ambassadeur •" ;
+"title_is_ambassador" = "Animateur Entourage •" ;
 "title_is_admin" = "Administrateur •" ;
 
 "neighborhood_detail_button_join_member" = "Membre";

--- a/entourage/Assets/hr.lproj/Localizable.strings
+++ b/entourage/Assets/hr.lproj/Localizable.strings
@@ -697,7 +697,7 @@
 /*************
  * Group detail
  */
-"title_is_ambassador" = "Ambassadeur •" ;
+"title_is_ambassador" = "Animateur Entourage •" ;
 "title_is_admin" = "Administrateur •" ;
 
 "neighborhood_detail_button_join_member" = "Membre";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -715,7 +715,7 @@
 /*************
  * Group detail
  */
-"title_is_ambassador" = "Ambassadeur •" ;
+"title_is_ambassador" = "Animateur Entourage •" ;
 "title_is_admin" = "Administrateur •" ;
 
 "neighborhood_detail_button_join_member" = "Membre";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -707,7 +707,7 @@
 /*************
  * Group detail
  */
-"title_is_ambassador" = "Ambassadeur •" ;
+"title_is_ambassador" = "Animateur Entourage •" ;
 "title_is_admin" = "Administrateur •" ;
 
 "neighborhood_detail_button_join_member" = "Membru";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -703,7 +703,7 @@
 /*************
  * Group detail
  */
-"title_is_ambassador" = "Посол •";
+"title_is_ambassador" = "Animateur Entourage •";
 "title_is_admin" = "Адміністратор •";
 
 "neighborhood_detail_button_join_member" = "Член";

--- a/entourage/Models/User.swift
+++ b/entourage/Models/User.swift
@@ -277,22 +277,46 @@ struct UserLightNeighborhood: Codable {
                 roleStr = "Admin".localized
             }
            
-            for role in communityRoles {
-                if roleStr.count > 0 {
-                    roleStr = "\(roleStr) • \(role)"
+            var currentRole: String? = nil
+            if let firstRole = communityRoles.first {
+                currentRole = firstRole
+                if currentRole == "Ambassadeur" {
+                    currentRole = "Animateur Entourage"
+                } else if currentRole == "Équipe Entourage" {
+                    currentRole = "Équipe"
                 }
-                else {
-                    roleStr = role
-                }
-               
-                break
             }
+
             if let name = partner?.name {
+                var showRole = true
+                if let role = currentRole {
+                    if name.lowercased().contains(role.lowercased()) {
+                        showRole = false
+                    }
+                }
+
+                if showRole, let role = currentRole {
+                    if roleStr.count > 0 {
+                        roleStr = "\(roleStr) • \(role)"
+                    } else {
+                        roleStr = role
+                    }
+                }
+
                 if roleStr.count > 0 {
                     roleStr = "\(roleStr) • \(name)"
-                }
-                else {
+                } else {
                     roleStr = name
+                }
+            }
+            else {
+                if let role = currentRole {
+                    if roleStr.count > 0 {
+                        roleStr = "\(roleStr) • \(role)"
+                    }
+                    else {
+                        roleStr = role
+                    }
                 }
             }
             return roleStr


### PR DESCRIPTION
- Replaced "Ambassadeur" with "Animateur Entourage" in all Localizable.strings and in User model logic.
- Renamed "Équipe Entourage" to "Équipe" in User model logic.
- Implemented deduplication logic in `User.swift` to hide the role if the Partner Name contains the role name (e.g., "Association - Association Rockie" -> "Association Rockie").
- Preserved "Équipe • Entourage [City]" format as requested.

---
*PR created automatically by Jules for task [659878952090653363](https://jules.google.com/task/659878952090653363) started by @clemPerrousset*