### PR TITLE
feat: Conditional display of 'Se sensibiliser' section on Home

### DIFF
--- a/entourage/Scenes/HomeV2/HomeV2ViewController.swift
+++ b/entourage/Scenes/HomeV2/HomeV2ViewController.swift
@@ -401,7 +401,13 @@ class HomeV2ViewController: UIViewController {
     func configureDTO() {
         self.tableDTO.removeAll()
         self.updateTopView()
-        if initialPedagos.count > 0 {
+
+        var showInitialPedago = false
+        if let user = UserDefaults.currentUser, let involvements = user.involvements, involvements.contains("resources") {
+            showInitialPedago = true
+        }
+
+        if showInitialPedago && initialPedagos.count > 0 {
             tableDTO.append(.cellTitle(title: "home_v2_title_initial_pedago".localized, subtitle: "home_v2_subtitle_initial_pedago".localized))
             tableDTO.append(.cellInitialPedago(pedagos: self.initialPedagos))
         }


### PR DESCRIPTION
This PR updates `HomeV2ViewController` to conditionally display the "Se sensibiliser" section. 
It checks if the current user has selected "resources" (S'informer/Se sensibiliser) in their action wishes (stored in `involvements`). 
If the user has not selected this option, the section is hidden. The "Tout savoir pour passer à l'action" section remains unaffected.

---
*PR created automatically by Jules for task [14285825578040851927](https://jules.google.com/task/14285825578040851927) started by @clemPerrousset*