### PR TITLE
fix(Profile): correct gender display/update and ensure profile refresh

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -1679,3 +1679,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_phase_three_question_quartier" = "ما هو حيّك؟";
 "onboarding_phase_three_placeholder_quartier" = "عنوان المدينة أو المقاطعة";
 "photo" = "صورة";
+
+"editUser_gender_male" = "رجل";
+"editUser_gender_female" = "امرأة";
+"editUser_gender_secret" = "غير محدد";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -1740,3 +1740,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_phase_three_question_quartier" = "In welchem Viertel wohnen Sie?";
 "onboarding_phase_three_placeholder_quartier" = "Stadt oder Bezirksadresse";
 "photo" = "Foto";
+
+"editUser_gender_male" = "Mann";
+"editUser_gender_female" = "Frau";
+"editUser_gender_secret" = "Keine Angabe";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -1940,3 +1940,7 @@
 "editUserTitleGender" = "I am";
 "editUserPlaceholderGender" = "Select from the list";
 "photo" = "Photo";
+
+"editUser_gender_male" = "Man";
+"editUser_gender_female" = "Woman";
+"editUser_gender_secret" = "Not specified";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -3163,3 +3163,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_phase_three_question_quartier" = "¿Cuál es tu barrio?";
 "onboarding_phase_three_placeholder_quartier" = "Dirección de ciudad o departamento";
 "photo" = "Foto";
+
+"editUser_gender_male" = "Hombre";
+"editUser_gender_female" = "Mujer";
+"editUser_gender_secret" = "No especificado";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1933,3 +1933,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUserTitleGender" = "Je suis";
 "editUserPlaceholderGender" = "Sélectionner dans la liste";
 "photo" = "Photo";
+
+"editUser_gender_male" = "Homme";
+"editUser_gender_female" = "Femme";
+"editUser_gender_secret" = "Non renseigné";

--- a/entourage/Assets/hr.lproj/Localizable.strings
+++ b/entourage/Assets/hr.lproj/Localizable.strings
@@ -1421,3 +1421,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_hz_item_title" = "Tiens, ça semble un peu calme par ici…";
 "home_v2_hz_item_subtitle" = "Et si vous mettiez un peu de solidarité dans votre ville ? Entourage vous donne les clés pour vous lancer !";
 "home_v2_hz_item_button" = "En savoir plus";
+
+"editUser_gender_male" = "Muškarac";
+"editUser_gender_female" = "Žena";
+"editUser_gender_secret" = "Nije navedeno";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -1754,3 +1754,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_phase_three_question_quartier" = "Jaka jest twoja dzielnica?";
 "onboarding_phase_three_placeholder_quartier" = "Adres miasta lub regionu";
 "photo" = "Zdjęcie";
+
+"editUser_gender_male" = "Mężczyzna";
+"editUser_gender_female" = "Kobieta";
+"editUser_gender_secret" = "Nie podano";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -1643,3 +1643,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_phase_three_question_quartier" = "Care este cartierul tău?";
 "onboarding_phase_three_placeholder_quartier" = "Adresă oraș sau județ";
 "photo" = "Fotografie";
+
+"editUser_gender_male" = "Bărbat";
+"editUser_gender_female" = "Femeie";
+"editUser_gender_secret" = "Nespecificat";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -1720,3 +1720,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_phase_three_question_quartier" = "Який ваш район?";
 "onboarding_phase_three_placeholder_quartier" = "Адреса міста або області";
 "photo" = "Фото";
+
+"editUser_gender_male" = "Чоловік";
+"editUser_gender_female" = "Жінка";
+"editUser_gender_secret" = "Не вказано";

--- a/entourage/Scenes/Profile/Cells/EditProfileInfosCell.swift
+++ b/entourage/Scenes/Profile/Cells/EditProfileInfosCell.swift
@@ -69,7 +69,12 @@ class EditProfileInfosCell: UITableViewCell {
     var ui_view_gender: UIView?
     var ui_tf_gender: UITextField?
     var pickerGender = UIPickerView()
-    let genderOptions = ["Femme", "Homme", "Autre"]
+    // Modified to store display string and technical value
+    let genderOptions: [(display: String, value: String)] = [
+        ("editUser_gender_female".localized, "female"),
+        ("editUser_gender_male".localized, "male"),
+        ("editUser_gender_secret".localized, "secret")
+    ]
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -243,8 +248,8 @@ class EditProfileInfosCell: UITableViewCell {
         let row = pickerGender.selectedRow(inComponent: 0)
         if row < genderOptions.count {
             let selected = genderOptions[row]
-            ui_tf_gender?.text = selected
-            delegate?.updateGender(gender: selected)
+            ui_tf_gender?.text = selected.display // Show display name
+            delegate?.updateGender(gender: selected.value) // Send internal value
         }
         self.endEditing(true)
     }
@@ -273,7 +278,13 @@ class EditProfileInfosCell: UITableViewCell {
         ui_tf_birthday.text = birthdate
         ui_city_cp.text = cityName
         ui_phone.text = phone
-        ui_tf_gender?.text = gender
+
+        // Find matching display string for current gender value
+        if let currentGender = gender, let match = genderOptions.first(where: { $0.value == currentGender }) {
+            ui_tf_gender?.text = match.display
+        } else {
+            ui_tf_gender?.text = ""
+        }
         
         ui_tv_edit_bio.text = bio
         
@@ -351,14 +362,14 @@ extension EditProfileInfosCell: UIPickerViewDelegate, UIPickerViewDataSource {
     }
 
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return genderOptions[row]
+        return genderOptions[row].display
     }
 
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         // Optional: Update text field immediately or wait for Done button
         // let selected = genderOptions[row]
-        // ui_tf_gender?.text = selected
-        // delegate?.updateGender(gender: selected)
+        // ui_tf_gender?.text = selected.display
+        // delegate?.updateGender(gender: selected.value)
     }
 }
 

--- a/entourage/Scenes/ProfileFull/ProfilFullViewController.swift
+++ b/entourage/Scenes/ProfileFull/ProfilFullViewController.swift
@@ -201,6 +201,7 @@ class ProfilFullViewController: UIViewController {
         if let navVC = sb.instantiateViewController(withIdentifier: "editProfileMainNav") as? UINavigationController , let editVC = navVC.topViewController as? ProfileEditorViewController  {
             editVC.profilFullDelegate = self
             editVC.currentUser = self.user
+            navVC.modalPresentationStyle = .fullScreen
             self.present(navVC, animated: true)
 
         }


### PR DESCRIPTION
This PR addresses three main points for the Profile Editor:
1.  **Localized Gender Display:** Instead of hardcoded values, the gender picker now displays localized strings ("Homme", "Femme", "Non renseigné", etc.) corresponding to the technical values `male`, `female`, and `secret`.
2.  **Correct API Value:** When a user selects a gender, the technical value (`male`, `female`, or `secret`) is now sent to the backend instead of the displayed string.
3.  **Profile Refresh:** The `ProfileEditorViewController` is now presented in `.fullScreen` mode. This ensures that `viewDidAppear` is reliably called on the parent `ProfilFullViewController` when the editor is dismissed, triggering a refresh of the user profile data.

---
*PR created automatically by Jules for task [10729875389335533582](https://jules.google.com/task/10729875389335533582) started by @clemPerrousset*