### PR TITLE
Customize profile display for association users

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -1683,3 +1683,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "رجل";
 "editUser_gender_female" = "امرأة";
 "editUser_gender_secret" = "غير محدد";
+"orientation_share" = "Relayer vos événements de convivialité sur l'application";
+"orientation_guide" = "Orienter vos bénéficiaires aux événements de convivialité";
+"orientation_both_actions" = "Donner ou solliciter un coup de pouce";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -1744,3 +1744,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Mann";
 "editUser_gender_female" = "Frau";
 "editUser_gender_secret" = "Keine Angabe";
+"orientation_share" = "Relayer vos événements de convivialité sur l'application";
+"orientation_guide" = "Orienter vos bénéficiaires aux événements de convivialité";
+"orientation_both_actions" = "Donner ou solliciter un coup de pouce";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -1944,3 +1944,6 @@
 "editUser_gender_male" = "Man";
 "editUser_gender_female" = "Woman";
 "editUser_gender_secret" = "Not specified";
+"orientation_share" = "Relayer vos événements de convivialité sur l'application";
+"orientation_guide" = "Orienter vos bénéficiaires aux événements de convivialité";
+"orientation_both_actions" = "Donner ou solliciter un coup de pouce";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -3167,3 +3167,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Hombre";
 "editUser_gender_female" = "Mujer";
 "editUser_gender_secret" = "No especificado";
+"orientation_share" = "Relayer vos événements de convivialité sur l'application";
+"orientation_guide" = "Orienter vos bénéficiaires aux événements de convivialité";
+"orientation_both_actions" = "Donner ou solliciter un coup de pouce";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1937,3 +1937,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Homme";
 "editUser_gender_female" = "Femme";
 "editUser_gender_secret" = "Non renseigné";
+"orientation_share" = "Relayer vos événements de convivialité sur l'application";
+"orientation_guide" = "Orienter vos bénéficiaires aux événements de convivialité";
+"orientation_both_actions" = "Donner ou solliciter un coup de pouce";

--- a/entourage/Assets/hr.lproj/Localizable.strings
+++ b/entourage/Assets/hr.lproj/Localizable.strings
@@ -1425,3 +1425,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Muškarac";
 "editUser_gender_female" = "Žena";
 "editUser_gender_secret" = "Nije navedeno";
+"orientation_share" = "Relayer vos événements de convivialité sur l'application";
+"orientation_guide" = "Orienter vos bénéficiaires aux événements de convivialité";
+"orientation_both_actions" = "Donner ou solliciter un coup de pouce";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -1758,3 +1758,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Mężczyzna";
 "editUser_gender_female" = "Kobieta";
 "editUser_gender_secret" = "Nie podano";
+"orientation_share" = "Relayer vos événements de convivialité sur l'application";
+"orientation_guide" = "Orienter vos bénéficiaires aux événements de convivialité";
+"orientation_both_actions" = "Donner ou solliciter un coup de pouce";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -1647,3 +1647,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Bărbat";
 "editUser_gender_female" = "Femeie";
 "editUser_gender_secret" = "Nespecificat";
+"orientation_share" = "Relayer vos événements de convivialité sur l'application";
+"orientation_guide" = "Orienter vos bénéficiaires aux événements de convivialité";
+"orientation_both_actions" = "Donner ou solliciter un coup de pouce";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -1724,3 +1724,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Чоловік";
 "editUser_gender_female" = "Жінка";
 "editUser_gender_secret" = "Не вказано";
+"orientation_share" = "Relayer vos événements de convivialité sur l'application";
+"orientation_guide" = "Orienter vos bénéficiaires aux événements de convivialité";
+"orientation_both_actions" = "Donner ou solliciter un coup de pouce";

--- a/entourage/Models/Event.swift
+++ b/entourage/Models/Event.swift
@@ -786,4 +786,17 @@ class TagsUtils {
             return NSLocalizedString("interest_other".localized, comment: "")
         }
     }
+
+    static func showOrientationTranslated(_ section: String) -> String {
+        switch section {
+        case "share":
+            return "orientation_share".localized
+        case "guide":
+            return "orientation_guide".localized
+        case "both_actions":
+            return "orientation_both_actions".localized
+        default:
+            return showTagTranslated(section)
+        }
+    }
 }

--- a/entourage/Scenes/ProfileFull/ProfilFullViewController.swift
+++ b/entourage/Scenes/ProfileFull/ProfilFullViewController.swift
@@ -217,6 +217,7 @@ class ProfilFullViewController: UIViewController {
             // On spécifie le mode (interest, concern, involvement ou choiceDisponibility)
             EnhancedOnboardingConfiguration.shared.isInterestsFromSetting = true
             vc.mode = mode
+            vc.isAssociationGoal = (self.user?.partner != nil)
             vc.modalPresentationStyle = .fullScreen
             present(vc, animated: true, completion: nil)
         }
@@ -299,6 +300,7 @@ class ProfilFullViewController: UIViewController {
         tableDTO.removeAll()
         
         guard let user = user else { return }
+        let isAssociation = user.partner != nil
         
         // 1) Header
         tableDTO.append(.header(user: user))
@@ -323,13 +325,19 @@ class ProfilFullViewController: UIViewController {
         }
         
         // (B) Envies d’agir
-        let userInvolvements = user.involvements ?? []
+        let userInvolvements = isAssociation ? (user.orientations ?? []) : (user.involvements ?? [])
         let involvementsDisplay: String
         if userInvolvements.isEmpty {
             involvementsDisplay = "no_data_available".localized
         } else {
             involvementsDisplay = userInvolvements
-                .map { TagsUtils.showTagTranslated($0) }
+                .map {
+                    if isAssociation {
+                        return TagsUtils.showOrientationTranslated($0)
+                    } else {
+                        return TagsUtils.showTagTranslated($0)
+                    }
+                }
                 .joined(separator: ", ")
         }
         
@@ -397,25 +405,27 @@ class ProfilFullViewController: UIViewController {
             subtitle: involvementsDisplay
         ))
         
-        // c) Catégories d’entraide
-        let categoriesTitle = isMe
+        if !isAssociation {
+            // c) Catégories d’entraide
+            let categoriesTitle = isMe
             ? "preferences_action_categories_title".localized
             : "preferences_action_categories_title_others".localized
-        tableDTO.append(.standard(
-            img: "ic_profil_full_action_category",
-            title: categoriesTitle,
-            subtitle: concernsDisplay
-        ))
-        
-        // d) Disponibilités
-        let availabilityTitle = isMe
+            tableDTO.append(.standard(
+                img: "ic_profil_full_action_category",
+                title: categoriesTitle,
+                subtitle: concernsDisplay
+            ))
+
+            // d) Disponibilités
+            let availabilityTitle = isMe
             ? "preferences_availability_title".localized
             : "preferences_availability_title_others".localized
-        tableDTO.append(.standard(
-            img: "ic_profil_full_disponibility",
-            title: availabilityTitle,
-            subtitle: availabilityDisplay
-        ))
+            tableDTO.append(.standard(
+                img: "ic_profil_full_disponibility",
+                title: availabilityTitle,
+                subtitle: availabilityDisplay
+            ))
+        }
         
         // --------------------------------------------------
         // SECTION : PARAMÈTRES (si c’est mon profil)


### PR DESCRIPTION
This change modifies the `ProfilFullViewController` to adapt the display for users linked to an association (partner).
- Association users now see their 'Orientations' in the 'Action Wishes' section instead of 'Involvements'.
- 'Help Categories' and 'Availability' sections are hidden for association users.
- `TagsUtils` has been updated to translate the specific keys used for orientations.
- When opening the edition screen (`EnhancedViewController`), the `isAssociationGoal` flag is now correctly set based on the user's partner status.

---
*PR created automatically by Jules for task [10474251792416966799](https://jules.google.com/task/10474251792416966799) started by @clemPerrousset*