### PR TITLE
Redirect to system settings when notifications are denied

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -1683,3 +1683,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "رجل";
 "editUser_gender_female" = "امرأة";
 "editUser_gender_secret" = "غير محدد";
+
+"error_settings_notifs_disabled_title" = "Notifications disabled";
+"error_settings_notifs_disabled_message" = "To receive notifications, you must enable them in your phone settings.";
+"error_settings_notifs_disabled_button_settings" = "Settings";
+"error_settings_notifs_disabled_button_cancel" = "Cancel";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -1744,3 +1744,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Mann";
 "editUser_gender_female" = "Frau";
 "editUser_gender_secret" = "Keine Angabe";
+
+"error_settings_notifs_disabled_title" = "Notifications disabled";
+"error_settings_notifs_disabled_message" = "To receive notifications, you must enable them in your phone settings.";
+"error_settings_notifs_disabled_button_settings" = "Settings";
+"error_settings_notifs_disabled_button_cancel" = "Cancel";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -1944,3 +1944,8 @@
 "editUser_gender_male" = "Man";
 "editUser_gender_female" = "Woman";
 "editUser_gender_secret" = "Not specified";
+
+"error_settings_notifs_disabled_title" = "Notifications disabled";
+"error_settings_notifs_disabled_message" = "To receive notifications, you must enable them in your phone settings.";
+"error_settings_notifs_disabled_button_settings" = "Settings";
+"error_settings_notifs_disabled_button_cancel" = "Cancel";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -3167,3 +3167,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Hombre";
 "editUser_gender_female" = "Mujer";
 "editUser_gender_secret" = "No especificado";
+
+"error_settings_notifs_disabled_title" = "Notifications disabled";
+"error_settings_notifs_disabled_message" = "To receive notifications, you must enable them in your phone settings.";
+"error_settings_notifs_disabled_button_settings" = "Settings";
+"error_settings_notifs_disabled_button_cancel" = "Cancel";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1937,3 +1937,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Homme";
 "editUser_gender_female" = "Femme";
 "editUser_gender_secret" = "Non renseigné";
+
+"error_settings_notifs_disabled_title" = "Notifications désactivées";
+"error_settings_notifs_disabled_message" = "Pour recevoir les notifications, vous devez les autoriser dans les paramètres de votre téléphone.";
+"error_settings_notifs_disabled_button_settings" = "Paramètres";
+"error_settings_notifs_disabled_button_cancel" = "Annuler";

--- a/entourage/Assets/hr.lproj/Localizable.strings
+++ b/entourage/Assets/hr.lproj/Localizable.strings
@@ -1425,3 +1425,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Muškarac";
 "editUser_gender_female" = "Žena";
 "editUser_gender_secret" = "Nije navedeno";
+
+"error_settings_notifs_disabled_title" = "Notifications disabled";
+"error_settings_notifs_disabled_message" = "To receive notifications, you must enable them in your phone settings.";
+"error_settings_notifs_disabled_button_settings" = "Settings";
+"error_settings_notifs_disabled_button_cancel" = "Cancel";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -1758,3 +1758,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Mężczyzna";
 "editUser_gender_female" = "Kobieta";
 "editUser_gender_secret" = "Nie podano";
+
+"error_settings_notifs_disabled_title" = "Notifications disabled";
+"error_settings_notifs_disabled_message" = "To receive notifications, you must enable them in your phone settings.";
+"error_settings_notifs_disabled_button_settings" = "Settings";
+"error_settings_notifs_disabled_button_cancel" = "Cancel";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -1647,3 +1647,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Bărbat";
 "editUser_gender_female" = "Femeie";
 "editUser_gender_secret" = "Nespecificat";
+
+"error_settings_notifs_disabled_title" = "Notifications disabled";
+"error_settings_notifs_disabled_message" = "To receive notifications, you must enable them in your phone settings.";
+"error_settings_notifs_disabled_button_settings" = "Settings";
+"error_settings_notifs_disabled_button_cancel" = "Cancel";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -1724,3 +1724,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "editUser_gender_male" = "Чоловік";
 "editUser_gender_female" = "Жінка";
 "editUser_gender_secret" = "Не вказано";
+
+"error_settings_notifs_disabled_title" = "Notifications disabled";
+"error_settings_notifs_disabled_message" = "To receive notifications, you must enable them in your phone settings.";
+"error_settings_notifs_disabled_button_settings" = "Settings";
+"error_settings_notifs_disabled_button_cancel" = "Cancel";

--- a/entourage/Scenes/Profile/ParamsNotifsViewController.swift
+++ b/entourage/Scenes/Profile/ParamsNotifsViewController.swift
@@ -95,7 +95,11 @@ class ParamsNotifsViewController: BasePopViewController {
         if sender.isOn {
             UNUserNotificationCenter.current().getNotificationSettings { (settings) in
                 DispatchQueue.main.async {
-                    if settings.authorizationStatus == .denied || settings.authorizationStatus == .notDetermined {
+                    if settings.authorizationStatus == .denied {
+                        self.showSettingsAlert(sender: sender)
+                        return
+                    }
+                    if settings.authorizationStatus == .notDetermined {
                         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
                             DispatchQueue.main.async {
                                 if granted {
@@ -119,6 +123,34 @@ class ParamsNotifsViewController: BasePopViewController {
         }
     }
     
+    func showSettingsAlert(sender: UISwitch) {
+        let alert = UIAlertController(
+            title: "error_settings_notifs_disabled_title".localized,
+            message: "error_settings_notifs_disabled_message".localized,
+            preferredStyle: .alert
+        )
+
+        let settingsAction = UIAlertAction(title: "error_settings_notifs_disabled_button_settings".localized, style: .default) { _ in
+            if let url = URL(string: UIApplication.openSettingsURLString) {
+                if UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                }
+            }
+            sender.setOn(false, animated: true)
+            self.setAllSwitch(isOn: false)
+        }
+
+        let cancelAction = UIAlertAction(title: "error_settings_notifs_disabled_button_cancel".localized, style: .cancel) { _ in
+            sender.setOn(false, animated: true)
+            self.setAllSwitch(isOn: false)
+        }
+
+        alert.addAction(cancelAction)
+        alert.addAction(settingsAction)
+
+        self.present(alert, animated: true, completion: nil)
+    }
+
     @IBAction func action_switch(_ sender: Any) {
         var notifPermissions = NotifInAppPermission()
         notifPermissions.action = ui_switch_actions.isOn


### PR DESCRIPTION
Redirects users to iOS system settings if they try to enable notifications in the app but have previously denied permissions.

---
*PR created automatically by Jules for task [528216294875499789](https://jules.google.com/task/528216294875499789) started by @clemPerrousset*