### PR TITLE
Fix Enhanced Onboarding grid height cutoff

### DIFF
--- a/entourage/Scenes/enhancedOnboarding/EnhancedViewController.swift
+++ b/entourage/Scenes/enhancedOnboarding/EnhancedViewController.swift
@@ -368,8 +368,11 @@ extension EnhancedViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         switch tableDTO[indexPath.row] {
-        case .collectionViewCell:
-            return 600
+        case .collectionViewCell(let choices):
+            let count = Double(choices.count)
+            let rows = ceil(count / 2.0)
+            let height = (rows * 170.0) + (max(0.0, rows - 1.0) * 5.0)
+            return CGFloat(height)
         default:
             return UITableView.automaticDimension
         }


### PR DESCRIPTION
Fixes an issue where the bottom items in the "Centres d'intérêt" grid were cut off in the Enhanced Onboarding flow.
- Modified `tableView(_:heightForRowAt:)` in `EnhancedViewController.swift`.
- Implemented dynamic height calculation for `.collectionViewCell` based on item count.
- Removed hardcoded limit of 600pt.

---
*PR created automatically by Jules for task [5780671544843421367](https://jules.google.com/task/5780671544843421367) started by @clemPerrousset*