### PR TITLE
Fix fallback to old profile screen

### DIFF
--- a/entourage/Scenes/Home/HomeMainViewController.swift
+++ b/entourage/Scenes/Home/HomeMainViewController.swift
@@ -209,7 +209,7 @@ class HomeMainViewController: UIViewController {
     
     @IBAction func action_show_profile(_ sender: Any) {
         AnalyticsLoggerManager.logEvent(name: Home_action_profile)
-        let navVC = UIStoryboard.init(name: StoryboardName.profileParams, bundle: nil).instantiateViewController(withIdentifier: "mainNavProfile")
+        let navVC = UIStoryboard.init(name: StoryboardName.profileParams, bundle: nil).instantiateViewController(withIdentifier: "profileFull")
         navVC.modalPresentationStyle = .fullScreen
         self.tabBarController?.present(navVC, animated: true)
     }

--- a/entourage/Scenes/HomeV2/HomeV2ViewController.swift
+++ b/entourage/Scenes/HomeV2/HomeV2ViewController.swift
@@ -226,7 +226,7 @@ class HomeV2ViewController: UIViewController {
         if config.isInterestsFromSetting {
             config.isInterestsFromSetting = false
             SVProgressHUD.dismiss()
-            let navVC = UIStoryboard.init(name: StoryboardName.profileParams, bundle: nil).instantiateViewController(withIdentifier: "mainNavProfile")
+            let navVC = UIStoryboard.init(name: StoryboardName.profileParams, bundle: nil).instantiateViewController(withIdentifier: "profileFull")
             navVC.modalPresentationStyle = .fullScreen
             self.tabBarController?.present(navVC, animated: false)
             return
@@ -235,7 +235,7 @@ class HomeV2ViewController: UIViewController {
         if config.isOnboardingFromSetting {
             config.isOnboardingFromSetting = false
             SVProgressHUD.dismiss()
-            let navVC = UIStoryboard.init(name: StoryboardName.profileParams, bundle: nil).instantiateViewController(withIdentifier: "mainNavProfile")
+            let navVC = UIStoryboard.init(name: StoryboardName.profileParams, bundle: nil).instantiateViewController(withIdentifier: "profileFull")
             navVC.modalPresentationStyle = .fullScreen
             self.tabBarController?.present(navVC, animated: false)
             return


### PR DESCRIPTION
Replaced legacy `mainNavProfile` with `profileFull` in `HomeV2ViewController` and `HomeMainViewController` to fix the issue where users would see the old profile screen instead of the new one. Verified that `ProfilFullViewController` handles both "Me" and "Other User" scenarios correctly (defaulting to "Me" when instantiated without parameters), which fits the usage contexts.

---
*PR created automatically by Jules for task [13780924148134019007](https://jules.google.com/task/13780924148134019007) started by @clemPerrousset*