### PR TITLE
Replace Guide '+' button with 'Aide & orientation' link

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -1693,3 +1693,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "orientation_both_actions" = "Donner ou solliciter un coup de pouce";
 "onboarding_zone_potential_event_singular" = "حدث محتمل في الأسبوع،";
 "onboarding_zone_potential_event_plural" = "أحداث محتملة في الأسبوع،";
+"guide_help_orientation" = "المساعدة والتوجيه";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -1754,3 +1754,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "orientation_both_actions" = "Donner ou solliciter un coup de pouce";
 "onboarding_zone_potential_event_singular" = "mögliches Event pro Woche,";
 "onboarding_zone_potential_event_plural" = "mögliche Events pro Woche,";
+"guide_help_orientation" = "Hilfe & Orientierung";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -1954,3 +1954,4 @@
 "orientation_both_actions" = "Donner ou solliciter un coup de pouce";
 "onboarding_zone_potential_event_singular" = "potential event per week,";
 "onboarding_zone_potential_event_plural" = "potential events per week,";
+"guide_help_orientation" = "Help & orientation";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -3177,3 +3177,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "orientation_both_actions" = "Donner ou solliciter un coup de pouce";
 "onboarding_zone_potential_event_singular" = "evento potencial por semana,";
 "onboarding_zone_potential_event_plural" = "eventos potenciales por semana,";
+"guide_help_orientation" = "Ayuda y orientación";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1947,3 +1947,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "orientation_both_actions" = "Donner ou solliciter un coup de pouce";
 "onboarding_zone_potential_event_singular" = "événement potentiel par semaine,";
 "onboarding_zone_potential_event_plural" = "événements potentiels par semaine,";
+"guide_help_orientation" = "Aide & orientation";

--- a/entourage/Assets/hr.lproj/Localizable.strings
+++ b/entourage/Assets/hr.lproj/Localizable.strings
@@ -1433,3 +1433,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "orientation_share" = "Relayer vos événements de convivialité sur l'application";
 "orientation_guide" = "Orienter vos bénéficiaires aux événements de convivialité";
 "orientation_both_actions" = "Donner ou solliciter un coup de pouce";
+"guide_help_orientation" = "Pomoć i orijentacija";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -1768,3 +1768,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "orientation_both_actions" = "Donner ou solliciter un coup de pouce";
 "onboarding_zone_potential_event_singular" = "potencjalne wydarzenie w tygodniu,";
 "onboarding_zone_potential_event_plural" = "potencjalnych wydarzeń w tygodniu,";
+"guide_help_orientation" = "Pomoc i orientacja";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -1657,3 +1657,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "orientation_both_actions" = "Donner ou solliciter un coup de pouce";
 "onboarding_zone_potential_event_singular" = "eveniment potențial pe săptămână,";
 "onboarding_zone_potential_event_plural" = "evenimente potențiale pe săptămână,";
+"guide_help_orientation" = "Ajutor și orientare";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -1734,3 +1734,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "orientation_both_actions" = "Donner ou solliciter un coup de pouce";
 "onboarding_zone_potential_event_singular" = "потенційна подія на тиждень,";
 "onboarding_zone_potential_event_plural" = "потенційних подій на тиждень,";
+"guide_help_orientation" = "Допомога та орієнтація";

--- a/entourage/Scenes/Guide_detail/MainGuideViewController.swift
+++ b/entourage/Scenes/Guide_detail/MainGuideViewController.swift
@@ -20,6 +20,7 @@ class MainGuideViewController: UIViewController {
     @IBOutlet weak var ui_tableView: UITableView!
     @IBOutlet weak var ui_button_filters: UIButton!
     @IBOutlet weak var ui_button_map_list: UIButton!
+    @IBOutlet weak var ui_button_plus: UIButton!
     @IBOutlet weak var ui_view_top_info_gds: UIView!
     @IBOutlet weak var ui_label_info_web_gds: UILabel!
     @IBOutlet weak var ui_constraint_height_view_topinfo: NSLayoutConstraint!
@@ -51,7 +52,8 @@ class MainGuideViewController: UIViewController {
         fillCategories()
         configureOrangeButton(ui_button_filters, withTitle: "home_button_filters".localized)
         configureOrangeButton(ui_button_map_list, withTitle: "home_button_list".localized)
-      
+        configureOrangeButton(ui_button_plus, withTitle: "guide_help_orientation".localized)
+
         NotificationCenter.default.addObserver(self, selector: #selector(showCurrentLocation), name: NSNotification.Name(rawValue:  kNotificationShowFeedsMapCurrentLocation), object: nil)
     }
     
@@ -323,6 +325,7 @@ class MainGuideViewController: UIViewController {
     func setupButtons() {
         addEffectToButton(customButton:  self.ui_button_filters)
         addEffectToButton(customButton: self.ui_button_map_list)
+        addEffectToButton(customButton: self.ui_button_plus)
     }
     
     func addEffectToButton(customButton:UIView) {
@@ -571,13 +574,10 @@ class MainGuideViewController: UIViewController {
     }
     
     @IBAction func showProposalPoi(_ sender:Any) {
-        if let token = UserDefaults.currentUser?.token {
-            let _BaseUrl = NetworkManager.sharedInstance.getBaseUrl()
-            let url = String.init(format: PROPOSE_STRUCTURE_URL, _BaseUrl,token)
-
-            if let _url = URL(string: url) {
-                SafariWebManager.launchUrlInApp(url: _url, viewController: self.navigationController)
-            }
+        let envConfigManager = EnvironmentConfigurationManager.sharedInstance
+        let url = envConfigManager.runsOnProduction ? "https://www.entourage.social/app/resources/eOB7jU8NNODY" : "https://preprod.entourage.social/app/resources/eyck8DuIn3cI"
+        if let _url = URL(string: url) {
+            SafariWebManager.launchUrlInApp(url: _url, viewController: self.navigationController)
         }
     }
     

--- a/entourage/Storyboards/GuideSolidarity.storyboard
+++ b/entourage/Storyboards/GuideSolidarity.storyboard
@@ -1206,16 +1206,16 @@ un autre mot-clé ?</string>
                                 </connections>
                             </button>
                             <button clipsSubviews="YES" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H4M-Ln-Qsh">
-                                <rect key="frame" x="307" y="507" width="58" height="58"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <rect key="frame" x="207" y="521" width="148" height="30"/>
+                                <color key="backgroundColor" red="0.96078431369999995" green="0.37254901959999998" blue="0.14117647059999999" alpha="1" colorSpace="deviceRGB"/>
                                 <rect key="contentStretch" x="0.0" y="0.0" width="0.0" height="0.0"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="58" id="ZcV-xc-e0X"/>
-                                    <constraint firstAttribute="width" constant="58" id="o45-yF-Ee7"/>
+                                    <constraint firstAttribute="height" constant="30" id="ZcV-xc-e0X"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
-                                <state key="normal" title="+" image="icn_plus_map_solidarity">
-                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="10" maxY="0.0"/>
+                                <state key="normal" title="Aide &amp; orientation">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <state key="selected">
@@ -1376,6 +1376,7 @@ En tant que riverain, vous pouvez suggérer un lieu à une personne de la rue, m
                     <connections>
                         <outlet property="ui_button_filters" destination="B1J-ug-DMZ" id="W5o-8U-jsL"/>
                         <outlet property="ui_button_map_list" destination="di5-3y-k7k" id="Ieu-Wf-V4W"/>
+                        <outlet property="ui_button_plus" destination="H4M-Ln-Qsh" id="Qv4-Lz-P7H"/>
                         <outlet property="ui_constraint_height_view_topinfo" destination="fMb-5p-Hys" id="IAF-KE-bBi"/>
                         <outlet property="ui_label_info_web_gds" destination="PNq-RW-ZBO" id="Tay-lb-GR3"/>
                         <outlet property="ui_tableView" destination="Md1-ka-TuR" id="lJO-3y-clC"/>


### PR DESCRIPTION
Replaced the manual 'add structure' floating button on the Guide map with a new 'Aide & orientation' button. This button now redirects users to a pedagogical help web page, with different URLs for production and pre-production environments. The button UI has been updated to match the existing pill-shaped filter buttons.

---
*PR created automatically by Jules for task [2452210413088399329](https://jules.google.com/task/2452210413088399329) started by @clemPerrousset*