### PR TITLE
Fix MainGuideViewController deep link handling crash

### DIFF
--- a/entourage/Scenes/Guide_detail/MainGuideViewController.swift
+++ b/entourage/Scenes/Guide_detail/MainGuideViewController.swift
@@ -577,7 +577,7 @@ class MainGuideViewController: UIViewController {
         let envConfigManager = EnvironmentConfigurationManager.sharedInstance
         let url = envConfigManager.runsOnProduction ? "https://www.entourage.social/app/resources/eOB7jU8NNODY" : "https://preprod.entourage.social/app/resources/eyck8DuIn3cI"
         if let _url = URL(string: url) {
-            SafariWebManager.launchUrlInApp(url: _url, viewController: self.navigationController)
+            WebLinkManager.openUrl(url: _url, openInApp: true, presenterViewController: self.navigationController)
         }
     }
     


### PR DESCRIPTION
This PR fixes a crash/issue when tapping the "Aide & Orientation" button in `MainGuideViewController`. 

The button was attempting to open an internal deep link (`/app/resources/...`) using `SafariWebManager.launchUrlInApp`, which forces a Safari View Controller. This behavior is incorrect for internal routes and was causing issues (specifically a crash on the simulator). 

The fix involves using `WebLinkManager.openUrl` instead, which checks if the URL matches the app's pattern and delegates to `UniversalLinkManager` to handle the navigation natively (opening the "pedago affilié" view), falling back to Safari only when appropriate.

---
*PR created automatically by Jules for task [8438599322389563082](https://jules.google.com/task/8438599322389563082) started by @clemPerrousset*