### PR TITLE
Add deep links for SmallTalk and Event Creation

### DIFF
--- a/entourage/Managers/DeeplinkManager.swift
+++ b/entourage/Managers/DeeplinkManager.swift
@@ -617,6 +617,40 @@ struct DeepLinkManager {
             }
         }
     }
+
+    static func showSmallTalkIntro() {
+        if let vc = UIStoryboard(name: "SmallTalk", bundle: nil).instantiateInitialViewController() {
+             vc.modalPresentationStyle = .fullScreen
+             AppState.getTopViewController()?.present(vc, animated: true)
+        }
+    }
+
+    static func showEventCreation() {
+        let sb = UIStoryboard(name: StoryboardName.eventCreate, bundle: nil)
+        if let vc = sb.instantiateViewController(withIdentifier: "eventCreateVCMain") as? EventCreateMainViewController {
+            vc.modalPresentationStyle = .fullScreen
+            AppState.getTopViewController()?.present(vc, animated: true)
+        }
+    }
+
+    static func showSuggestedSmallTalkEvent() {
+        EventService.getSuggestedSmallTalkEvent { event in
+            guard let event = event else { return }
+            DispatchQueue.main.async {
+                if let navVc = UIStoryboard(name: StoryboardName.event, bundle: nil).instantiateViewController(withIdentifier: "eventDetailNav") as? UINavigationController, let vc = navVc.topViewController as? EventDetailFeedViewController  {
+                    vc.eventId = event.uid
+                    vc.event = event
+                    vc.isAfterCreation = false
+                    vc.modalPresentationStyle = .fullScreen
+                    AppState.getTopViewController()?.present(navVc, animated: true)
+                }
+            }
+        }
+    }
+
+    static func showWelcomeWebinar() {
+        // Not implemented yet
+    }
     
 }
 

--- a/entourage/Managers/UniversalLinkManager.swift
+++ b/entourage/Managers/UniversalLinkManager.swift
@@ -47,6 +47,16 @@ struct UniversalLinkManager {
                 if pathComponents.count > 3 + iterator , let _eventhashId = pathComponents[2+iterator] as? String, let _posthashId = pathComponents[3+iterator] as? String {
                     DeepLinkManager.showEventDetailMessageUniversalLink(instanceId: _eventhashId, postId: _posthashId)
                 }
+            }else if pathComponents.contains("outings") && pathComponents.contains("smalltalk") {
+                DeepLinkManager.showSuggestedSmallTalkEvent()
+            }else if pathComponents.contains("outings") && pathComponents.contains("webinar") {
+                DeepLinkManager.showWelcomeWebinar()
+            }else if pathComponents.contains("outings") && pathComponents.contains("create") {
+                DeepLinkManager.showEventCreation()
+            }else if pathComponents.contains("create-outing") {
+                DeepLinkManager.showEventCreation()
+            }else if pathComponents.contains("smalltalk") {
+                DeepLinkManager.showSmallTalkIntro()
             }else if pathComponents.contains("neighborhoods") && pathComponents.contains("chat_messages"){
                 if pathComponents.count > 3+iterator , let _grouphashId = pathComponents[2+iterator] as? String, let _posthashId = pathComponents[3+iterator] as? String {
                     DeepLinkManager.showNeighborhoodDetailMessageUniversalLink(instanceId: _grouphashId, postId: _posthashId)


### PR DESCRIPTION
Implemented new universal links in UniversalLinkManager and DeeplinkManager to support:
- `app/smalltalk` -> `SmallTalkIntro`
- `app/create-outing` (and `app/outings/create`) -> `EventCreateMainViewController`
- `app/outings/smalltalk` -> Fetches and opens suggested SmallTalk event.
- `app/outings/webinar` -> Placeholder for future implementation.

---
*PR created automatically by Jules for task [14296195302944244897](https://jules.google.com/task/14296195302944244897) started by @clemPerrousset*