### PR TITLE
Add webinar deep link support

### DIFF
--- a/entourage/Managers/DeeplinkManager.swift
+++ b/entourage/Managers/DeeplinkManager.swift
@@ -649,7 +649,18 @@ struct DeepLinkManager {
     }
 
     static func showWelcomeWebinar() {
-        // Not implemented yet
+        EventService.getWebinarEvent { event in
+            guard let event = event else { return }
+            DispatchQueue.main.async {
+                if let navVc = UIStoryboard(name: StoryboardName.event, bundle: nil).instantiateViewController(withIdentifier: "eventDetailNav") as? UINavigationController, let vc = navVc.topViewController as? EventDetailFeedViewController  {
+                    vc.eventId = event.uid
+                    vc.event = event
+                    vc.isAfterCreation = false
+                    vc.modalPresentationStyle = .fullScreen
+                    AppState.getTopViewController()?.present(navVc, animated: true)
+                }
+            }
+        }
     }
     
 }

--- a/entourage/Network Managers/Endpoints.swift
+++ b/entourage/Network Managers/Endpoints.swift
@@ -117,6 +117,7 @@ let kAPIGetDetailsReactionEventPost = "outings/%d/chat_messages/%d/reactions/use
 let kAPIConfirmParticipation = "outings/%@/users/confirm?token=%@"
 let kAPIGetMyFilteredOutings = "users/%@/outings?token=%@&page=%d&per=%d&travel_distance=%.2f&latitude=%.6f&longitude=%.6f&interest_list=%@"
 let kAPIGetEventUsersQuery = "outings/%@/users?token=%@&query=%@"
+let kAPIEventSensibilisation = "outings/sensibilisation?token=%@"
 let kAPIParticipateForUser           = "outings/%@/users/%@/participate?token=%@"
 let kAPIAcceptPhotoForUser           = "outings/%@/users/%@/photo_acceptance?token=%@"
 let kAPICancelPhotoForUser           = "outings/%@/users/%@/cancel_photo_acceptance?token=%@"

--- a/entourage/Network Managers/EventService.swift
+++ b/entourage/Network Managers/EventService.swift
@@ -694,6 +694,19 @@ struct EventService:ParsingDataCodable {
             completion(wrapper?.outing)
         }
     }
+
+    static func getWebinarEvent(completion: @escaping (Event?) -> Void) {
+        let endpoint = "outings/sensibilisation?token=\(UserDefaults.token ?? "")"
+        NetworkManager.sharedInstance.requestGet(endPoint: endpoint, headers: nil, params: nil) { data, _, _ in
+            guard let data = data else {
+                completion(nil)
+                return
+            }
+
+            let wrapper = try? JSONDecoder().decode(OutingWrapper.self, from: data)
+            completion(wrapper?.outing)
+        }
+    }
     // MARK: - Admin actions on members (participate / cancel / photo acceptance)
 
     static func participateForUser(eventId: Int,

--- a/entourage/Network Managers/EventService.swift
+++ b/entourage/Network Managers/EventService.swift
@@ -696,7 +696,8 @@ struct EventService:ParsingDataCodable {
     }
 
     static func getWebinarEvent(completion: @escaping (Event?) -> Void) {
-        let endpoint = "outings/sensibilisation?token=\(UserDefaults.token ?? "")"
+        guard let token = UserDefaults.token else {return}
+        let endpoint = String.init(format: kAPIEventSensibilisation, token)
         NetworkManager.sharedInstance.requestGet(endPoint: endpoint, headers: nil, params: nil) { data, _, _ in
             guard let data = data else {
                 completion(nil)


### PR DESCRIPTION
This PR implements the handling for the `/outings/webinar` deep link. It adds a new service method `getWebinarEvent` in `EventService` that calls `GET /api/v1/outings/sensibilisation` (similar to the existing `smalltalk` implementation). The `DeeplinkManager` is updated to use this service and present the event details when the deep link is triggered.

---
*PR created automatically by Jules for task [17607676793026604018](https://jules.google.com/task/17607676793026604018) started by @clemPerrousset*