### PR TITLE
Login UI fixes: button size, placeholder, keyboard handling, and text update.

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -1694,3 +1694,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "حدث محتمل في الأسبوع،";
 "onboarding_zone_potential_event_plural" = "أحداث محتملة في الأسبوع،";
 "guide_help_orientation" = "المساعدة والتوجيه";
+"login_code_placeholder" = "Enter your code";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -1755,3 +1755,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "mögliches Event pro Woche,";
 "onboarding_zone_potential_event_plural" = "mögliche Events pro Woche,";
 "guide_help_orientation" = "Hilfe & Orientierung";
+"login_code_placeholder" = "Enter your code";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -1955,3 +1955,4 @@
 "onboarding_zone_potential_event_singular" = "potential event per week,";
 "onboarding_zone_potential_event_plural" = "potential events per week,";
 "guide_help_orientation" = "Help & orientation";
+"login_code_placeholder" = "Enter your code";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -3178,3 +3178,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "evento potencial por semana,";
 "onboarding_zone_potential_event_plural" = "eventos potenciales por semana,";
 "guide_help_orientation" = "Ayuda y orientación";
+"login_code_placeholder" = "Enter your code";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -96,7 +96,7 @@
 "login_title" = "Connexion";
 
 "login_forgot_code_title" = "Vous avez oublié votre code ?";
-"login_button_resend_code" = "Recevoir un nouveau code par sms";
+"login_button_resend_code" = "Redemander un code";
 
 "login_label_change_phone_question" = "Vous avez changé de numéro de téléphone ?";
 "login_button_change_phone" = "Changer mon numéro";
@@ -1948,3 +1948,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "événement potentiel par semaine,";
 "onboarding_zone_potential_event_plural" = "événements potentiels par semaine,";
 "guide_help_orientation" = "Aide & orientation";
+"login_code_placeholder" = "Saisir votre code";

--- a/entourage/Assets/hr.lproj/Localizable.strings
+++ b/entourage/Assets/hr.lproj/Localizable.strings
@@ -1434,3 +1434,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "orientation_guide" = "Orienter vos bénéficiaires aux événements de convivialité";
 "orientation_both_actions" = "Donner ou solliciter un coup de pouce";
 "guide_help_orientation" = "Pomoć i orijentacija";
+"login_code_placeholder" = "Enter your code";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -112,7 +112,7 @@
 "login_title" = "Connexion";
 
 "login_forgot_code_title" = "Vous avez oublié votre code ?";
-"login_button_resend_code" = "Recevoir un nouveau code par sms";
+"login_button_resend_code" = "Redemander un code";
 
 "login_label_change_phone_question" = "Vous avez changé de numéro de téléphone ?";
 "login_button_change_phone" = "Changer mon numéro";
@@ -1769,3 +1769,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "potencjalne wydarzenie w tygodniu,";
 "onboarding_zone_potential_event_plural" = "potencjalnych wydarzeń w tygodniu,";
 "guide_help_orientation" = "Pomoc i orientacja";
+"login_code_placeholder" = "Saisir votre code";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -1658,3 +1658,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "eveniment potențial pe săptămână,";
 "onboarding_zone_potential_event_plural" = "evenimente potențiale pe săptămână,";
 "guide_help_orientation" = "Ajutor și orientare";
+"login_code_placeholder" = "Enter your code";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -1735,3 +1735,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "потенційна подія на тиждень,";
 "onboarding_zone_potential_event_plural" = "потенційних подій на тиждень,";
 "guide_help_orientation" = "Допомога та орієнтація";
+"login_code_placeholder" = "Enter your code";

--- a/entourage/Scenes/Login/OTLoginV2ViewController.swift
+++ b/entourage/Scenes/Login/OTLoginV2ViewController.swift
@@ -448,7 +448,7 @@ struct LoginView: View {
                     VStack(alignment: .leading, spacing: 6) {
                         PasswordFloatingField(
                             title: "login_label_code".localized, // "Saisir votre code"
-                            placeholder: "Ex : 123456",
+                            placeholder: "login_code_placeholder".localized,
                             text: $vm.password,
                             isSecured: $vm.isPasswordSecured
                         )
@@ -514,7 +514,7 @@ struct LoginView: View {
                     Text("login_button_connect".localized) // "Je me connecte"
                         .font(.custom("Quicksand-Bold", size: 18))
                         .foregroundColor(.white)
-                        .frame(height: 54) // Un peu plus haut
+                        .frame(height: 48) // Un peu plus haut
                         .frame(maxWidth: .infinity)
                         .background(Color(UIColor.appOrange))
                         .cornerRadius(27)
@@ -547,6 +547,7 @@ struct LoginView: View {
                 )
             }
         )
+        .ignoreKeyboardForFooter()
         .onDisappear {
             vm.stopTimer()
         }
@@ -622,6 +623,18 @@ final class OTLoginV2ViewController: UIHostingController<LoginView> {
                 // OTDeepLinkService.init().handleDeepLink(link) // Décommenter si le service est dispo
                 self.deeplink = nil
             }
+        }
+    }
+}
+
+// MARK: - Safe Area Helper
+private extension View {
+    @ViewBuilder
+    func ignoreKeyboardForFooter() -> some View {
+        if #available(iOS 15.0, *) {
+            self.ignoresSafeArea(.keyboard)
+        } else {
+            self.ignoresSafeArea(.all, edges: .bottom)
         }
     }
 }


### PR DESCRIPTION
- Reduced "Je me connecte" button height to 48pt in `OTLoginV2ViewController`.
- Added `.ignoresSafeArea(.keyboard)` to `LoginView` (with iOS 14 fallback) to prevent the footer from moving up when the keyboard appears.
- Replaced hardcoded placeholder "Ex : 123456" with localized "Saisir votre code".
- Updated French localization for "Recevoir un nouveau code par sms" to "Redemander un code".
- Added `login_code_placeholder` key to all `Localizable.strings` files.

---
*PR created automatically by Jules for task [8565434066970826646](https://jules.google.com/task/8565434066970826646) started by @clemPerrousset*