### PR TITLE
Update Small Talk home screen wording

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -1694,3 +1694,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "حدث محتمل في الأسبوع،";
 "onboarding_zone_potential_event_plural" = "أحداث محتملة في الأسبوع،";
 "guide_help_orientation" = "المساعدة والتوجيه";
+
+// Added or updated automatically
+"home_smalltalk_title" = "الانضمام إلى مناقشة تضامنية";
+"small_talk_subtitle_match" = "نربطك بمجموعة صغيرة من الأشخاص الذين يشاركونك اهتماماتك، في أي مكان في فرنسا.";
+"home_v2_title_small_talk" = "الانضمام إلى مناقشة تضامنية";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -1755,3 +1755,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "mögliches Event pro Woche,";
 "onboarding_zone_potential_event_plural" = "mögliche Events pro Woche,";
 "guide_help_orientation" = "Hilfe & Orientierung";
+
+// Added or updated automatically
+"home_smalltalk_title" = "An einer solidarischen Diskussion teilnehmen";
+"small_talk_subtitle_match" = "Wir bringen Sie mit einer kleinen Gruppe von Menschen zusammen, die Ihre Interessen teilen, überall in Frankreich.";
+"home_v2_title_small_talk" = "An einer solidarischen Diskussion teilnehmen";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -1870,8 +1870,8 @@
 "small_talk_group_found_subtitle" = "Meet the people in your group";
 
 /* Home section */
-"home_v2_title_small_talk" = "Easy conversations";
-"small_talk_subtitle_match" = "We connect you with other members – a simple way to (re)build social ties.";
+"home_v2_title_small_talk" = "Join a solidarity discussion";
+"small_talk_subtitle_match" = "We connect you with a small group of people who share your interests, anywhere in France.";
 "small_talk_button_match" = "Chat";
 "small_talk_title_waiting" = "Waiting";
 "small_talk_subtitle_waiting" = "You’ll get a message as soon as a group is ready";
@@ -1955,3 +1955,6 @@
 "onboarding_zone_potential_event_singular" = "potential event per week,";
 "onboarding_zone_potential_event_plural" = "potential events per week,";
 "guide_help_orientation" = "Help & orientation";
+
+// Added or updated automatically
+"home_smalltalk_title" = "Join a solidarity discussion";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -3178,3 +3178,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "evento potencial por semana,";
 "onboarding_zone_potential_event_plural" = "eventos potenciales por semana,";
 "guide_help_orientation" = "Ayuda y orientación";
+
+// Added or updated automatically
+"home_smalltalk_title" = "Unirse a una discusión solidaria";
+"small_talk_subtitle_match" = "Te ponemos en contacto con un pequeño grupo de personas que comparten tus intereses, en cualquier parte de Francia.";
+"home_v2_title_small_talk" = "Unirse a una discusión solidaria";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1769,7 +1769,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 
 
 /* Section Papotages Smalltalks */
-"home_smalltalk_title" = "Partager des « Bonnes Ondes » !";
+"home_smalltalk_title" = "Rejoindre une discussion solidaire";
 "onboarding_title" = "Prêts à partager des Bonnes ondes ?";
 "onboarding_start_button" = "Je commence";
 "onboarding_end_button" = "Annuler";
@@ -1849,8 +1849,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "small_talk_group_found_subtitle" = "Découvrez les personnes de votre groupe.";
 
 /* Accueil SmallTalk */
-"home_v2_title_small_talk" = "Partager des « Bonnes Ondes » !";
-"small_talk_subtitle_match" = "Découvrez un nouveau moyen de discuter et de créer des liens qui durent dans le temps !";
+"home_v2_title_small_talk" = "Rejoindre une discussion solidaire";
+"small_talk_subtitle_match" = "On vous met en relation avec un petit groupe de personnes qui partagent vos centres d’intérêt, partout en France.";
 "small_talk_button_match" = "Discuter";
 "small_talk_title_waiting" = "Bientôt de nouvelles rencontres";
 "small_talk_subtitle_waiting" = "On vous prévient dès qu’on a trouvé des gens qui sont sur la même longueur d’onde ;)";

--- a/entourage/Assets/hr.lproj/Localizable.strings
+++ b/entourage/Assets/hr.lproj/Localizable.strings
@@ -1434,3 +1434,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "orientation_guide" = "Orienter vos bénéficiaires aux événements de convivialité";
 "orientation_both_actions" = "Donner ou solliciter un coup de pouce";
 "guide_help_orientation" = "Pomoć i orijentacija";
+
+// Added or updated automatically
+"home_smalltalk_title" = "Pridružite se solidarnoj raspravi";
+"small_talk_subtitle_match" = "Povezujemo vas s malom grupom ljudi koji dijele vaše interese, bilo gdje u Francuskoj.";
+"home_v2_title_small_talk" = "Pridružite se solidarnoj raspravi";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -1769,3 +1769,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "potencjalne wydarzenie w tygodniu,";
 "onboarding_zone_potential_event_plural" = "potencjalnych wydarzeń w tygodniu,";
 "guide_help_orientation" = "Pomoc i orientacja";
+
+// Added or updated automatically
+"home_smalltalk_title" = "Dołącz do solidarnej dyskusji";
+"small_talk_subtitle_match" = "Łączymy Cię z małą grupą osób o podobnych zainteresowaniach, w całej Francji.";
+"home_v2_title_small_talk" = "Dołącz do solidarnej dyskusji";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -1658,3 +1658,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "eveniment potențial pe săptămână,";
 "onboarding_zone_potential_event_plural" = "evenimente potențiale pe săptămână,";
 "guide_help_orientation" = "Ajutor și orientare";
+
+// Added or updated automatically
+"home_smalltalk_title" = "Alătură-te unei discuții solidare";
+"small_talk_subtitle_match" = "Te punem în legătură cu un grup mic de persoane care îți împărtășesc interesele, oriunde în Franța.";
+"home_v2_title_small_talk" = "Alătură-te unei discuții solidare";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -1735,3 +1735,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "потенційна подія на тиждень,";
 "onboarding_zone_potential_event_plural" = "потенційних подій на тиждень,";
 "guide_help_orientation" = "Допомога та орієнтація";
+
+// Added or updated automatically
+"home_smalltalk_title" = "Приєднатися до солідарної дискусії";
+"small_talk_subtitle_match" = "Ми з'єднуємо вас з невеликою групою людей, які поділяють ваші інтереси, в будь-якій точці Франції.";
+"home_v2_title_small_talk" = "Приєднатися до солідарної дискусії";


### PR DESCRIPTION
Updates the title and description for the "Small Talk" (Bonnes Ondes) section on the Home screen to be more descriptive and less branded, as requested.

- Updates `home_smalltalk_title` and `small_talk_subtitle_match` in `fr.lproj`.
- Propagates these changes to `en`, `es`, `de`, `pl`, `ro`, `uk`, `ar`, `hr` with machine translations.
- Updates `home_v2_title_small_talk` for consistency.

---
*PR created automatically by Jules for task [17513364498546728879](https://jules.google.com/task/17513364498546728879) started by @clemPerrousset*