### PR TITLE
fix/login-ui-changes

### DIFF
--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -96,7 +96,6 @@
 "login_title" = "Connexion";
 
 "login_forgot_code_title" = "Vous avez oublié votre code ?";
-"login_button_resend_code" = "Recevoir un nouveau code par sms";
 
 "login_label_change_phone_question" = "Vous avez changé de numéro de téléphone ?";
 "login_button_change_phone" = "Changer mon numéro";

--- a/entourage/Scenes/Login/OTLoginV2ViewController.swift
+++ b/entourage/Scenes/Login/OTLoginV2ViewController.swift
@@ -448,7 +448,7 @@ struct LoginView: View {
                     VStack(alignment: .leading, spacing: 6) {
                         PasswordFloatingField(
                             title: "login_label_code".localized, // "Saisir votre code"
-                            placeholder: "Ex : 123456",
+                            placeholder: "login_placeholder_code".localized,
                             text: $vm.password,
                             isSecured: $vm.isPasswordSecured
                         )
@@ -514,10 +514,10 @@ struct LoginView: View {
                     Text("login_button_connect".localized) // "Je me connecte"
                         .font(.custom("Quicksand-Bold", size: 18))
                         .foregroundColor(.white)
-                        .frame(height: 54) // Un peu plus haut
+                        .frame(height: 48) // Un peu plus haut
                         .frame(maxWidth: .infinity)
                         .background(Color(UIColor.appOrange))
-                        .cornerRadius(27)
+                        .cornerRadius(24)
                 }
             }
             .padding(.horizontal, 20)
@@ -550,6 +550,7 @@ struct LoginView: View {
         .onDisappear {
             vm.stopTimer()
         }
+        .ignoresSafeArea(edges: .bottom)
     }
 }
 


### PR DESCRIPTION
*   `OTLoginV2ViewController.swift`:
    *   Change "Je me connecte" button height to 48 and corner radius to 24.
    *   Update placeholder for code input to use localized string `login_placeholder_code`.
    *   Add `.ignoresSafeArea(edges: .bottom)` to `LoginView` to prevent the footer from being pushed up by the keyboard.
*   `entourage/Assets/fr.lproj/Localizable.strings`:
    *   Remove duplicate key `login_button_resend_code` ("Recevoir un nouveau code par sms") so that the correct value ("Redemander un code") is used.

---
*PR created automatically by Jules for task [2605137874043623897](https://jules.google.com/task/2605137874043623897) started by @clemPerrousset*