### PR TITLE
Update Small Talk translations and layout height

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -1694,3 +1694,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "حدث محتمل في الأسبوع،";
 "onboarding_zone_potential_event_plural" = "أحداث محتملة في الأسبوع،";
 "guide_help_orientation" = "المساعدة والتوجيه";
+"home_v2_title_small_talk" = "انضم إلى مناقشة تضامنية";
+"small_talk_subtitle_match" = "نربطك بمجموعة صغيرة من الأشخاص الذين يشاركونك اهتماماتك، في أي مكان في فرنسا.";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -1755,3 +1755,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "mögliches Event pro Woche,";
 "onboarding_zone_potential_event_plural" = "mögliche Events pro Woche,";
 "guide_help_orientation" = "Hilfe & Orientierung";
+"home_v2_title_small_talk" = "An einer solidarischen Diskussion teilnehmen";
+"small_talk_subtitle_match" = "Wir verbinden Sie mit einer kleinen Gruppe von Menschen, die Ihre Interessen teilen, überall in Frankreich.";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -1870,8 +1870,8 @@
 "small_talk_group_found_subtitle" = "Meet the people in your group";
 
 /* Home section */
-"home_v2_title_small_talk" = "Easy conversations";
-"small_talk_subtitle_match" = "We connect you with other members – a simple way to (re)build social ties.";
+"home_v2_title_small_talk" = "Join a solidarity discussion";
+"small_talk_subtitle_match" = "We connect you with a small group of people who share your interests, anywhere in France.";
 "small_talk_button_match" = "Chat";
 "small_talk_title_waiting" = "Waiting";
 "small_talk_subtitle_waiting" = "You’ll get a message as soon as a group is ready";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -3178,3 +3178,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "evento potencial por semana,";
 "onboarding_zone_potential_event_plural" = "eventos potenciales por semana,";
 "guide_help_orientation" = "Ayuda y orientación";
+"home_v2_title_small_talk" = "Únete a una discusión solidaria";
+"small_talk_subtitle_match" = "Te conectamos con un pequeño grupo de personas que comparten tus intereses, en cualquier lugar de Francia.";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1769,7 +1769,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 
 
 /* Section Papotages Smalltalks */
-"home_smalltalk_title" = "Partager des « Bonnes Ondes » !";
 "onboarding_title" = "Prêts à partager des Bonnes ondes ?";
 "onboarding_start_button" = "Je commence";
 "onboarding_end_button" = "Annuler";
@@ -1849,8 +1848,8 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "small_talk_group_found_subtitle" = "Découvrez les personnes de votre groupe.";
 
 /* Accueil SmallTalk */
-"home_v2_title_small_talk" = "Partager des « Bonnes Ondes » !";
-"small_talk_subtitle_match" = "Découvrez un nouveau moyen de discuter et de créer des liens qui durent dans le temps !";
+"home_v2_title_small_talk" = "Rejoindre une discussion solidaire";
+"small_talk_subtitle_match" = "On vous met en relation avec un petit groupe de personnes qui partagent vos centres d’intérêt, partout en France.";
 "small_talk_button_match" = "Discuter";
 "small_talk_title_waiting" = "Bientôt de nouvelles rencontres";
 "small_talk_subtitle_waiting" = "On vous prévient dès qu’on a trouvé des gens qui sont sur la même longueur d’onde ;)";

--- a/entourage/Assets/hr.lproj/Localizable.strings
+++ b/entourage/Assets/hr.lproj/Localizable.strings
@@ -1434,3 +1434,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "orientation_guide" = "Orienter vos bénéficiaires aux événements de convivialité";
 "orientation_both_actions" = "Donner ou solliciter un coup de pouce";
 "guide_help_orientation" = "Pomoć i orijentacija";
+"home_v2_title_small_talk" = "Pridružite se solidarnoj raspravi";
+"small_talk_subtitle_match" = "Povezujemo vas s malom grupom ljudi koji dijele vaše interese, bilo gdje u Francuskoj.";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -1769,3 +1769,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "potencjalne wydarzenie w tygodniu,";
 "onboarding_zone_potential_event_plural" = "potencjalnych wydarzeń w tygodniu,";
 "guide_help_orientation" = "Pomoc i orientacja";
+"home_v2_title_small_talk" = "Dołącz do dyskusji solidarnościowej";
+"small_talk_subtitle_match" = "Łączymy Cię z małą grupą osób o podobnych zainteresowaniach, w całej Francji.";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -1658,3 +1658,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "eveniment potențial pe săptămână,";
 "onboarding_zone_potential_event_plural" = "evenimente potențiale pe săptămână,";
 "guide_help_orientation" = "Ajutor și orientare";
+"home_v2_title_small_talk" = "Alătură-te unei discuții solidare";
+"small_talk_subtitle_match" = "Te conectăm cu un grup mic de oameni care îți împărtășesc interesele, oriunde în Franța.";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -1735,3 +1735,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboarding_zone_potential_event_singular" = "потенційна подія на тиждень,";
 "onboarding_zone_potential_event_plural" = "потенційних подій на тиждень,";
 "guide_help_orientation" = "Допомога та орієнтація";
+"home_v2_title_small_talk" = "Приєднуйтесь до солідарної дискусії";
+"small_talk_subtitle_match" = "Ми з'єднуємо вас з невеликою групою людей, які поділяють ваші інтереси, по всій Франції.";

--- a/entourage/Scenes/HomeV2/HomeV2ViewController.swift
+++ b/entourage/Scenes/HomeV2/HomeV2ViewController.swift
@@ -412,7 +412,7 @@ class HomeV2ViewController: UIViewController {
             tableDTO.append(.cellInitialPedago(pedagos: self.initialPedagos))
         }
         //add condition
-        tableDTO.append(.cellTitle(title: "home_smalltalk_title".localized, subtitle: ""))
+        tableDTO.append(.cellTitle(title: "home_v2_title_small_talk".localized, subtitle: ""))
         tableDTO.append(.cellSmallTalk(userRequests: self.userSmallTalkRequests))
         if (allDemands.count > 0) {
             if isContributionPreference {
@@ -696,7 +696,7 @@ extension HomeV2ViewController: UITableViewDelegate, UITableViewDataSource {
         case .cellInitialPedago(pedagos: let pedagos):
             return 115
         case .cellSmallTalk(let userRequests):
-            return 200
+            return 250
         }
     }
 }


### PR DESCRIPTION
This change updates the title and description for the "Small Talk" section on the Home V2 screen. It switches the title key to `home_v2_title_small_talk` for consistency and provides updated translations for all supported languages. It also increases the cell height to 250 to accommodate the longer description text.

---
*PR created automatically by Jules for task [10202971357234229589](https://jules.google.com/task/10202971357234229589) started by @clemPerrousset*