### PR TITLE
Update Date Formats

### DIFF
--- a/entourage/Models/Event.swift
+++ b/entourage/Models/Event.swift
@@ -117,13 +117,13 @@ struct Event:Codable {
     
     var startDateFormatted:String {
         get {
-            return Utils.formatEventDate(date:Utils.getDateFromWSDateString(metadata?.starts_at))
+            return Utils.formatEventDateShort(date:Utils.getDateFromWSDateString(metadata?.starts_at))
         }
     }
     
     var startDateNameFormatted:String {
         get {
-            return Utils.formatEventDateName(date:Utils.getDateFromWSDateString(metadata?.starts_at))
+            return Utils.formatEventDateLong(date:Utils.getDateFromWSDateString(metadata?.starts_at))
         }
     }
     

--- a/entourage/Models/GlobalObjects.swift
+++ b/entourage/Models/GlobalObjects.swift
@@ -29,6 +29,12 @@ struct PostMessage:Codable {
         }
     }
     
+    var createdDateLongFormatted:String {
+        get {
+            return Utils.formatEventDateLong(date:createdDate)
+        }
+    }
+
     var createdDateTimeFormatted:String {
         get {
             return Utils.formatEventDateTime(date:createdDate)

--- a/entourage/Scenes/Events/Cells/EventListCell.swift
+++ b/entourage/Scenes/Events/Cells/EventListCell.swift
@@ -97,7 +97,7 @@ class EventListCell: UITableViewCell {
     
         ui_view_separator.isHidden = hideSeparator
         
-        ui_date.text = event.startDateTimeFormatted
+        ui_date.text = event.startDateFormatted
         ui_location.text = event.addressName
         ui_members?.text = event.membersCount ?? 0 > 1 ? String.init(format: "event_members_cell_list".localized, event.membersCount!) : String.init(format: "event_member_cell_list".localized, event.membersCount!)
     }

--- a/entourage/Scenes/Groups - Neighborhoods/Cells/Message top cell/DetailMessageTopPostCell.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/Cells/Message top cell/DetailMessageTopPostCell.swift
@@ -52,7 +52,7 @@ class DetailMessageTopPostCell: UITableViewCell {
     
     func populateCell(message:PostMessage) {
         self.postMessage = message
-        ui_user.text = "\(message.user?.displayName ?? "-") le \(message.createdDateFormatted)"
+        ui_user.text = "\(message.user?.displayName ?? "-") le \(message.createdDateLongFormatted)"
         ui_comment.text = message.content
         if message.status == "deleted" {
             ui_comment.text = "deleted_post_text".localized

--- a/entourage/Tools/Utils.swift
+++ b/entourage/Tools/Utils.swift
@@ -291,6 +291,47 @@ import UIKit
         
         return dateString
     }
+    static func formatEventDateShort(date: Date?) -> String {
+        guard let date = date else { return "-" }
+        let dayFormatter = DateFormatter()
+        dayFormatter.locale = Locale.getPreferredLocale()
+        dayFormatter.dateFormat = "E"
+
+        let monthFormatter = DateFormatter()
+        monthFormatter.locale = Locale.getPreferredLocale()
+        monthFormatter.dateFormat = "MMM"
+
+        let dayNumFormatter = DateFormatter()
+        dayNumFormatter.locale = Locale.getPreferredLocale()
+        dayNumFormatter.dateFormat = "d"
+
+        let dayStr = dayFormatter.string(from: date).capitalized.replacingOccurrences(of: ".", with: "")
+        let monthStr = monthFormatter.string(from: date).capitalized
+        let dayNum = dayNumFormatter.string(from: date)
+
+        return "\(dayStr). \(dayNum) \(monthStr)"
+    }
+
+    static func formatEventDateLong(date: Date?) -> String {
+        guard let date = date else { return "-" }
+        let dayFormatter = DateFormatter()
+        dayFormatter.locale = Locale.getPreferredLocale()
+        dayFormatter.dateFormat = "EEEE"
+
+        let monthFormatter = DateFormatter()
+        monthFormatter.locale = Locale.getPreferredLocale()
+        monthFormatter.dateFormat = "MMMM"
+
+        let dayNumFormatter = DateFormatter()
+        dayNumFormatter.locale = Locale.getPreferredLocale()
+        dayNumFormatter.dateFormat = "d"
+
+        let dayStr = dayFormatter.string(from: date).capitalized
+        let monthStr = monthFormatter.string(from: date).capitalized
+        let dayNum = dayNumFormatter.string(from: date)
+
+        return "\(dayStr) \(dayNum) \(monthStr)"
+    }
 }
 
 class ImageLoaderSwift {


### PR DESCRIPTION
Updated date formatting for Home, Event List, Event Detail, and Discussion Detail to match new requirements:
- Short format (Ven. 30 Jan.) for Home and Lists.
- Long format (Vendredi 30 Janvier) for Details.
Added formatEventDateShort and formatEventDateLong to Utils.swift.
Updated Event.startDateFormatted and Event.startDateNameFormatted.
Updated PostMessage.createdDateLongFormatted.

---
*PR created automatically by Jules for task [6535519920966345099](https://jules.google.com/task/6535519920966345099) started by @clemPerrousset*