### PR TITLE
Add time to short event date format

### DIFF
--- a/entourage/Tools/Utils.swift
+++ b/entourage/Tools/Utils.swift
@@ -294,11 +294,16 @@ import UIKit
     static func formatEventDateShort(date: Date?) -> String {
         guard let date = date else { return "-" }
 
+        let timeFormatter = DateFormatter()
+        timeFormatter.locale = Locale.getPreferredLocale()
+        timeFormatter.dateFormat = "HH:mm"
+        let timeStr = timeFormatter.string(from: date)
+
         if Calendar.current.isDateInToday(date) {
-            return "Today".localized
+            return "\("Today".localized), \(timeStr)"
         }
         else if Calendar.current.isDateInTomorrow(date) {
-            return "Tomorrow".localized
+            return "\("Tomorrow".localized), \(timeStr)"
         }
 
         let dayFormatter = DateFormatter()
@@ -317,7 +322,7 @@ import UIKit
         let monthStr = monthFormatter.string(from: date).capitalized
         let dayNum = dayNumFormatter.string(from: date)
 
-        return "\(dayStr). \(dayNum) \(monthStr)"
+        return "\(dayStr). \(dayNum) \(monthStr), \(timeStr)"
     }
 
     static func formatEventDateLong(date: Date?) -> String {


### PR DESCRIPTION
Updated the `formatEventDateShort` utility function to include the time in the formatted date string. This impacts lists where short dates are displayed (Home, Discussions, Events), changing the format from "Date" to "Date, HH:mm". The Event Detail view, which uses `formatEventDateLong`, is unaffected.

---
*PR created automatically by Jules for task [8477699645443394817](https://jules.google.com/task/8477699645443394817) started by @clemPerrousset*