### PR TITLE
Update onboarding UI texts, buttons, and gender handling

### DIFF
--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1911,7 +1911,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboard_asso_title" = "Sélectionnez votre association";
 "onboard_asso_subtitle" = "Nom de votre association";
 "onboard_asso_dropdown_hint" = "Sélectionner dans la liste";
-"onboard_asso_info" = "Votre association ne figure pas dans la liste.\nCréez-en une nouvelle";
+"onboard_asso_info" = "Votre association ne figure pas dans la liste ? Ajoutez-la pour continuer.";
 "onboard_asso_other_label" = "Nom de votre association";
 "onboard_asso_other_placeholder" = "Ex. : Utopia 56 ou Femmes solidaires";
 "onboard_asso_other_required" = "Merci d’indiquer le nom de votre association.";

--- a/entourage/Network Managers/AuthService.swift
+++ b/entourage/Network Managers/AuthService.swift
@@ -24,7 +24,7 @@ struct AuthService: ParsingDataCodable {
             switch g.lowercased() {
             case "homme", "male":   return "male"
             case "femme", "female": return "female"
-            case "non binaire", "non-binaire", "non_binary", "autre", "other", "secret":
+            case "non binaire", "non-binaire", "non_binary", "autre", "other", "secret", "non renseigné", "non renseigne":
                 return "secret"
             default:
                 return nil // inconnu → on n’envoie pas

--- a/entourage/Scenes/Onboarding/OnboardingPhase1ViewController.swift
+++ b/entourage/Scenes/Onboarding/OnboardingPhase1ViewController.swift
@@ -187,7 +187,7 @@ final class OnboardingPhase1VM: ObservableObject {
         let n = normalized(label)
         if n.contains("femme") { return 0 }
         if n.contains("homme") { return 1 }
-        if n.contains("autre") || n.contains("non binaire") || n.contains("non-binaire") || n.contains("autres") { return 2 }
+        if n.contains("autre") || n.contains("non binaire") || n.contains("non-binaire") || n.contains("autres") || n.contains("non renseigné") || n.contains("non renseigne") { return 2 }
         return 3
     }
 
@@ -302,9 +302,17 @@ final class OnboardingPhase1VM: ObservableObject {
                     self.discoverySourcesMap = meta.user?.discoverySources ?? [:]
 
                     // Genders: ordre forcé Femme > Homme > Autre, puis le reste
-                    let labelsG = Array(self.gendersMap.values)
+                    var labelsG = Array(self.gendersMap.values)
+
+                    // On remplace "Autre" par "Non renseigné" pour l'affichage
+                    for (i, val) in labelsG.enumerated() {
+                        if val.caseInsensitiveCompare("autre") == .orderedSame {
+                            labelsG[i] = "Non renseigné"
+                        }
+                    }
+
                     if labelsG.isEmpty {
-                        self.genderOptions = ["Femme", "Homme", "Autre"]
+                        self.genderOptions = ["Femme", "Homme", "Non renseigné"]
                     } else {
                         self.genderOptions = labelsG.sorted { a, b in
                             let pa = self.genderPriority(a)
@@ -334,7 +342,7 @@ final class OnboardingPhase1VM: ObservableObject {
                 case .failure:
                     self.gendersMap = [:]
                     self.discoverySourcesMap = [:]
-                    self.genderOptions = ["Femme", "Homme", "Autre"]
+                    self.genderOptions = ["Femme", "Homme", "Non renseigné"]
                     self.howWeMetOptions = []
                 }
                 self.recomputeCanProceed()

--- a/entourage/Scenes/enhancedOnboarding/EnhancedViewController.swift
+++ b/entourage/Scenes/enhancedOnboarding/EnhancedViewController.swift
@@ -113,7 +113,7 @@ class EnhancedViewController: UIViewController, UIImagePickerControllerDelegate,
         buttonView.translatesAutoresizingMaskIntoConstraints = false
         self.stickyButtonView = buttonView
         
-        let height: CGFloat = 130
+        let height: CGFloat = 90
         
         NSLayoutConstraint.activate([
             buttonView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
@@ -243,7 +243,7 @@ class EnhancedViewController: UIViewController, UIImagePickerControllerDelegate,
         case .associationPresentation:
             AnalyticsLoggerManager.logEvent(name: "onboarding_association_view")
             tableDTO.append(.backArrow)
-            tableDTO.append(.title(title: "Présentez votre association", subtitle: "Ajoutez votre logo et une courte description."))
+            tableDTO.append(.title(title: "Présentez votre association à la communauté", subtitle: "Ajoutez votre logo et une courte description pour que les membres de la communauté sachent qui vous êtes et ce que vous faites."))
             
             // Chargement des données si nécessaire
             if associationDescription == nil && associationLogoImage == nil, let pid = currentPartnerId {
@@ -254,11 +254,26 @@ class EnhancedViewController: UIViewController, UIImagePickerControllerDelegate,
         }
         
         ui_tableview.reloadData()
+        updateStickyFooter()
         
         if hasChangedMod {
             hasChangedMod = false
             ui_tableview.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
         }
+    }
+
+    private func updateStickyFooter() {
+        guard let buttonView = stickyButtonView else { return }
+        let isSettings = EnhancedOnboardingConfiguration.shared.isInterestsFromSetting
+
+        var isLastStep = false
+        if isAssociationGoal {
+            isLastStep = (mode == .associationPresentation)
+        } else {
+            isLastStep = (mode == .choiceDisponibility)
+        }
+
+        buttonView.configure(isSettings: isSettings, isLastStep: isLastStep)
     }
 
     func presentViewControllerWithAnimation(identifier: String) {

--- a/entourage/Scenes/enhancedOnboarding/cells/AssociationPresentationCell.swift
+++ b/entourage/Scenes/enhancedOnboarding/cells/AssociationPresentationCell.swift
@@ -67,7 +67,7 @@ class AssociationPresentationCell: UITableViewCell, UITextViewDelegate {
     private let descriptionLabel: UILabel = {
         let label = UILabel()
         label.text = NSLocalizedString("description_association_label", value: "Description de votre association", comment: "")
-        label.font = UIFont.boldSystemFont(ofSize: 16)
+        label.font = ApplicationTheme.getFontQuickSandBold(size: 16)
         label.textColor = .black
         label.translatesAutoresizingMaskIntoConstraints = false
         return label

--- a/entourage/Scenes/enhancedOnboarding/cells/EnahancedOnboardingButtonCell.swift
+++ b/entourage/Scenes/enhancedOnboarding/cells/EnahancedOnboardingButtonCell.swift
@@ -22,25 +22,37 @@ class EnahancedOnboardingButtonCell:UITableViewCell{
     var delegate:EnhancedOnboardingButtonDelegate?
     
     override func awakeFromNib() {
+        super.awakeFromNib()
+        // Default configuration
         configureOrangeButton(ui_btn_next, withTitle: "enhanced_onboarding_button_title_next".localized)
         configureWhiteButton(ui_btn_configure_later, withTitle: "enhanced_onboarding_button_title_later".localized)
-        let config = EnhancedOnboardingConfiguration.shared
-        if config.isInterestsFromSetting{
-            configureOrangeButton(ui_btn_next, withTitle: "button_title_for_setting_onboarding".localized)
+    }
+    
+    func configure(isSettings: Bool, isLastStep: Bool) {
+        ui_btn_configure_later.addTarget(self, action: #selector(onConfigureLaterClick), for: .touchUpInside)
+        ui_btn_next.addTarget(self, action: #selector(onBtnNextClick), for: .touchUpInside)
+
+        if isSettings {
+            // Settings: Annuler / Valider
+            configureOrangeButton(ui_btn_next, withTitle: "validate".localized)
+            configureWhiteButton(ui_btn_configure_later, withTitle: "cancel".localized)
+        } else {
+            // Onboarding
+            let nextTitle = isLastStep ? "action_create_close_button".localized : "enhanced_onboarding_button_title_next".localized
+            let laterTitle = "enhanced_onboarding_button_title_later".localized
+
+            configureOrangeButton(ui_btn_next, withTitle: nextTitle)
+            configureWhiteButton(ui_btn_configure_later, withTitle: laterTitle)
         }
     }
-    
-    func configure(){
-        ui_btn_configure_later.addTarget(self, action: #selector(onConfigureLaterClick), for: .touchUpInside)
-        self.ui_btn_next.setTitle("validate".localized, for: .normal)
-        self.ui_btn_configure_later.setTitle("cancel".localized, for: .normal)
-        ui_btn_next.addTarget(self, action: #selector(onBtnNextClick), for: .touchUpInside)
+
+    func configure() {
+        // Fallback for compatibility if needed, though we should prefer the explicit method
+        configure(isSettings: false, isLastStep: false)
     }
     
-    func configureForMainFilter(){
-        self.configure()
-        self.ui_btn_next.setTitle("validate".localized, for: .normal)
-        self.ui_btn_configure_later.setTitle("cancel".localized, for: .normal)
+    func configureForMainFilter() {
+        configure(isSettings: true, isLastStep: false)
     }
     
     @objc func onConfigureLaterClick(){


### PR DESCRIPTION
This PR addresses several UI and logic updates for the Onboarding and Settings flows:

1.  **Gender Field Update**:
    *   Replaced the display label "Autre" with "Non renseigné" in the sign-up flow.
    *   Updated `AuthService.mapGender` to correctly map "Non renseigné" (and "non renseigne") to the backend value "secret".

2.  **Association Onboarding Text**:
    *   Updated the localized string `onboard_asso_info` to: "Votre association ne figure pas dans la liste ? Ajoutez-la pour continuer.".

3.  **Onboarding/Settings Buttons & Spacing**:
    *   Refactored `EnahancedOnboardingButtonCell` to dynamically configure button titles based on context:
        *   **Settings**: "Annuler" / "Valider".
        *   **Onboarding (Intermediate)**: "Terminer plus tard" / "Suivant".
        *   **Onboarding (Last Step)**: "Terminer plus tard" / "Terminer".
    *   Reduced the sticky footer height constraint in `EnhancedViewController` from 130 to 90 for a more compact look.

4.  **Association Presentation UI**:
    *   Updated the title to "Présentez votre association à la communauté" and the subtitle.
    *   Updated the "Description de votre association" label font to use `Quicksand-Bold` size 16.

---
*PR created automatically by Jules for task [14522611735563272698](https://jules.google.com/task/14522611735563272698) started by @clemPerrousset*