### PR TITLE
Fix broken deep links on iOS preprod environment

### DIFF
--- a/entourage/Settings/entourage.entitlements
+++ b/entourage/Settings/entourage.entitlements
@@ -10,6 +10,7 @@
 		<string>applinks:entourage.social</string>
 		<string>applinks:app.entourage.social</string>
 		<string>applinks:entourage-webapp-preprod.herokuapp.com</string>
+		<string>applinks:preprod.entourage.social</string>
 		<string>webcredentials:example.com</string>
 		<string>applinks:api-preprod.entourage.social</string>
 	</array>


### PR DESCRIPTION
The pre-production environment domain `preprod.entourage.social` was missing from the Associated Domains capability in `entourage.entitlements`. This caused Universal Links to fail and open in Safari instead.
This change adds the missing domain to the entitlements file. The existing `UniversalLinkManager` logic already supports this domain.

---
*PR created automatically by Jules for task [14774457286368566524](https://jules.google.com/task/14774457286368566524) started by @clemPerrousset*