### PR TITLE
Fix birthday update in iOS profile edition

### DIFF
--- a/entourage/Scenes/Profile/Cells/EditProfileInfosCell.swift
+++ b/entourage/Scenes/Profile/Cells/EditProfileInfosCell.swift
@@ -59,7 +59,7 @@ class EditProfileInfosCell: UITableViewCell {
     let bioColor = UIColor.black
     let maxCharsBioString = "/\(ApplicationTheme.maxCharsBio)"
     
-    var pickerDayDateView = MJDayMonthPicker()
+    var pickerDayDateView = UIDatePicker()
     
     var hasNoErrorFirstname = false
     var hasNoErrorLastname = false
@@ -126,6 +126,14 @@ class EditProfileInfosCell: UITableViewCell {
         ui_tf_lastname.placeholder = "editUserPlaceholderLastname".localized
         setupTextFieldStyle(ui_tf_lastname)
         ui_tf_birthday.placeholder = "editUserPlaceholderBirthday".localized
+
+        if #available(iOS 13.4, *) {
+            pickerDayDateView.preferredDatePickerStyle = .wheels
+        }
+        pickerDayDateView.datePickerMode = .date
+        pickerDayDateView.locale = Locale.init(identifier: "fr_FR")
+        pickerDayDateView.maximumDate = Date()
+
         setupPickerDayMonthView()
         ui_tf_email.placeholder = "editUserPlaceholderEMail".localized
         setupTextFieldStyle(ui_tf_email)
@@ -275,7 +283,29 @@ class EditProfileInfosCell: UITableViewCell {
         ui_tf_firstname.text = firstname
         ui_tf_lastname.text = lastname
         ui_tf_email.text = email
-        ui_tf_birthday.text = birthdate
+
+        //Transformation de la date type yyyy-mm-dd (api) vers dd/mm/yyyy (affichage)
+        var birthdateDisplay = birthdate
+        if let _birthdate = birthdate {
+            let dateFormat = DateFormatter()
+            dateFormat.locale = Locale.init(identifier: "fr_FR")
+            dateFormat.dateFormat = "yyyy-MM-dd"
+            if let _date = dateFormat.date(from: _birthdate) {
+                pickerDayDateView.date = _date
+                dateFormat.dateFormat = "dd/MM/yyyy"
+                birthdateDisplay = dateFormat.string(from: _date)
+            }
+            else {
+                //If it's local date type dd/MM/yyyy
+                dateFormat.dateFormat = "dd/MM/yyyy"
+                if let _date = dateFormat.date(from: _birthdate) {
+                    pickerDayDateView.date = _date
+                    birthdateDisplay = _birthdate
+                }
+            }
+        }
+
+        ui_tf_birthday.text = birthdateDisplay
         ui_city_cp.text = cityName
         ui_phone.text = phone
 
@@ -340,7 +370,10 @@ class EditProfileInfosCell: UITableViewCell {
     }
     
     @objc func donedatePicker(){
-        ui_tf_birthday.text = String.init(format: "%@-%@", pickerDayDateView.getDateSelected().day,pickerDayDateView.getDateSelected().month)
+        let dateFormat = DateFormatter()
+        dateFormat.locale = Locale.init(identifier: "fr_FR")
+        dateFormat.dateFormat = "dd/MM/yyyy"
+        ui_tf_birthday.text = dateFormat.string(from: pickerDayDateView.date)
         delegate?.updateBirthDate(birthdate: ui_tf_birthday.text)
         self.contentView.endEditing(true)
     }

--- a/entourage/Scenes/Profile/ProfileEditorViewController.swift
+++ b/entourage/Scenes/Profile/ProfileEditorViewController.swift
@@ -170,8 +170,18 @@ class ProfileEditorViewController: UIViewController {
         }
         
         if birth_date_new?.count ?? 0 > 0 {
-            if let birth_date_new = birth_date_new, birth_date_new.matchesRegEx("^(0[1-9]|1[0-9]|2[0-9]|3[0-1])-(0[1-9]|1[0-2])")  {
-                newUser?.birthdate = birth_date_new
+            if let birth_date_new = birth_date_new, birth_date_new.matchesRegEx("^([0-2][0-9]|(3)[0-1])(\/)(((0)[0-9])|((1)[0-2]))(\/)\d{4}$")  {
+                let dateFormat = DateFormatter()
+                dateFormat.locale = Locale.init(identifier: "fr_FR")
+                dateFormat.dateFormat = "dd/MM/yyyy"
+                if let _date = dateFormat.date(from: birth_date_new) {
+                    dateFormat.dateFormat = "yyyy-MM-dd"
+                    newUser?.birthdate = dateFormat.string(from: _date)
+                }
+                else {
+                    showError(message: "editUser_error_birthday".localized)
+                    return
+                }
             }
             else {
                 showError(message: "editUser_error_birthday".localized)


### PR DESCRIPTION
Replaced the day/month picker with a full date picker (UIDatePicker) in EditProfileInfosCell to allow year selection. Updated ProfileEditorViewController to validate dd/MM/yyyy format and convert it to yyyy-MM-dd for the API, resolving the issue where birthday updates were failing or sending incorrect formats.

---
*PR created automatically by Jules for task [4955152226777913960](https://jules.google.com/task/4955152226777913960) started by @clemPerrousset*