### PR TITLE
Fix birthday display and notification handling

### DIFF
--- a/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUserCell.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUserCell.swift
@@ -94,16 +94,22 @@ class NeighborhoodUserCell: UITableViewCell {
                       isParticipating: Bool?,
                       isOrganizer: Bool?,
                       isCreator: Bool?,
-                      isConfirmed: Bool?) {
+                      isConfirmed: Bool?,
+                      isBirthday: Bool? = nil) {
 
         self.delegate = delegate
         self.tablePosition = position
 
+        var nameToDisplay = username
+        if isBirthday == true {
+            nameToDisplay += " 🎂"
+        }
+
         // Libellé uniquement si confirmed_at != nil
         if isConfirmed ?? false {
-            ui_username.text = "\(username) - Participation confirmée"
+            ui_username.text = "\(nameToDisplay) - Participation confirmée"
         } else {
-            ui_username.text = username
+            ui_username.text = nameToDisplay
         }
 
         if let r = role, !r.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {

--- a/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
@@ -323,7 +323,8 @@ extension NeighBorhoodEventListUsersViewController: UITableViewDataSource, UITab
                 isParticipating: isParticipating,
                 isOrganizer: isConfirmed,
                 isCreator: viewerCanUseCheckboxes,
-                isConfirmed: isConfirmed
+                isConfirmed: isConfirmed,
+                isBirthday: user.isBirthday
             )
             cell.hideSeparatorBarIfIsVote(isVote: self.isFromSurvey)
             return cell

--- a/entourage/Scenes/Home/NotificationsInAppViewController.swift
+++ b/entourage/Scenes/Home/NotificationsInAppViewController.swift
@@ -139,7 +139,9 @@ extension NotificationsInAppViewController: UITableViewDataSource, UITableViewDe
         
         self.dismiss(animated: true) {
             print("eho notif " , notif.getNotificationPushData())
-            DeepLinkManager.presentAction(notification: notif.getNotificationPushData())
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                DeepLinkManager.presentAction(notification: notif.getNotificationPushData())
+            }
         }
     }
     

--- a/entourage/Scenes/ProfileFull/cells/HeaderProfilFullCell.swift
+++ b/entourage/Scenes/ProfileFull/cells/HeaderProfilFullCell.swift
@@ -22,6 +22,7 @@ class HeaderProfilFullCell: UITableViewCell {
     @IBOutlet weak var ui_btn_modify: UIButton!
     @IBOutlet weak var ui_label_phone: UILabel!
     @IBOutlet weak var ui_label_mail: UILabel!
+    @IBOutlet weak var ui_label_birthdate: UILabel!
     @IBOutlet weak var ui_label_partner: UILabel!
     @IBOutlet weak var ui_label_role: UILabel!
     @IBOutlet weak var ui_stack_view: UIStackView!        // Contient les vues pour les rôles & le partenaire
@@ -129,10 +130,31 @@ class HeaderProfilFullCell: UITableViewCell {
             ui_label_mail.text = emailText
         }
         
+        // 🔹 Birthdate
+        if let birthdate = user.birthdate, !birthdate.isEmpty, let date = Utils.getDateFromWSDateString(birthdate) {
+            let birthdateText = Utils.formatEventDate(date: date)
+            ui_label_birthdate.text = birthdateText
+            ui_label_birthdate.isHidden = false
+        } else if let birthdate = user.birthdate, !birthdate.isEmpty {
+            // Fallback parsing for yyyy-MM-dd
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd"
+            if let date = formatter.date(from: birthdate) {
+                formatter.dateFormat = "dd/MM/yyyy"
+                ui_label_birthdate.text = formatter.string(from: date)
+                ui_label_birthdate.isHidden = false
+            } else {
+                ui_label_birthdate.isHidden = true
+            }
+        } else {
+            ui_label_birthdate.isHidden = true
+        }
+
         // Pour les profils autres que "moi", on masque téléphone et mail et on change le titre du bouton
         if !isMe {
             ui_label_phone.isHidden = true
             ui_label_mail.isHidden = true
+            ui_label_birthdate.isHidden = true
             self.ui_btn_modify.setTitle("detail_user_send_message".localized, for: .normal)
         } else {
             self.ui_btn_modify.setTitle("modify".localized, for: .normal)

--- a/entourage/Scenes/ProfileFull/cells/HeaderProfilFullCell.xib
+++ b/entourage/Scenes/ProfileFull/cells/HeaderProfilFullCell.xib
@@ -154,6 +154,12 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="01/01/1990" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bir-th-day">
+                                <rect key="frame" x="0.0" y="55.666666666666657" width="422" height="18"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0601886036" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f6m-UW-JfR">
                                 <rect key="frame" x="0.0" y="27.666666666666657" width="422" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
@@ -210,6 +216,7 @@
                 <outlet property="ui_label_city" destination="C4W-kd-9go" id="NRb-ir-8qZ"/>
                 <outlet property="ui_label_description" destination="Kqo-Mg-fmZ" id="Mew-Ka-MM6"/>
                 <outlet property="ui_label_mail" destination="njw-q2-O8I" id="ZW8-FK-LlT"/>
+                <outlet property="ui_label_birthdate" destination="bir-th-day" id="bir-th-d2y"/>
                 <outlet property="ui_label_name" destination="Att-vO-Y0s" id="weU-mw-PWO"/>
                 <outlet property="ui_label_partner" destination="Bpe-U4-r6b" id="3po-ul-gJO"/>
                 <outlet property="ui_label_phone" destination="f6m-UW-JfR" id="uXR-zL-dnz"/>


### PR DESCRIPTION
This PR addresses three issues related to the birthday feature:
1.  **Profile Display:** The `birthdate` field was not being displayed on the user profile. I added a label to `HeaderProfilFullCell` and populated it with the formatted date.
2.  **Group/Neighborhood Emoji:** Users celebrating their birthday did not have the cake emoji in the member list. I updated `NeighborhoodUserCell` and `NeighBorhoodEventListUsersViewController` to pass and display the emoji.
3.  **In-App Notification:** Clicking the birthday notification did nothing. I added a delay in `NotificationsInAppViewController` to ensure the dismissal animation completes before `DeepLinkManager` presents the `BirthdayViewController`.


---
*PR created automatically by Jules for task [2046054069830254229](https://jules.google.com/task/2046054069830254229) started by @clemPerrousset*