### PR TITLE
Fix birthday notification not launching from in-app list

### DIFF
--- a/entourage/Managers/DeeplinkManager.swift
+++ b/entourage/Managers/DeeplinkManager.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct DeepLinkManager {
     
-    static func presentAction(notification:NotificationPushData) {
+    static func presentAction(notification:NotificationPushData, presenter:UIViewController? = nil) {
         
      //   print("notification" , notification)
         if notification.context == "outing_on_day_before"{
@@ -108,7 +108,7 @@ struct DeepLinkManager {
         case .almost_matches:
             showAlmostMatch()
         case .birthday:
-            showBirthday()
+            showBirthday(presenter: presenter)
         }
     }
     
@@ -240,10 +240,15 @@ struct DeepLinkManager {
         }
     }
     
-    static func showBirthday() {
+    static func showBirthday(presenter:UIViewController? = nil) {
         let vc = BirthdayViewController()
         vc.modalPresentationStyle = .fullScreen
-        AppState.getTopViewController()?.present(vc, animated: true)
+        if let presenter = presenter {
+            presenter.present(vc, animated: true)
+        }
+        else {
+            AppState.getTopViewController()?.present(vc, animated: true)
+        }
     }
 
     static func showResource(id:Int) {

--- a/entourage/Scenes/Home/NotificationsInAppViewController.swift
+++ b/entourage/Scenes/Home/NotificationsInAppViewController.swift
@@ -137,10 +137,11 @@ extension NotificationsInAppViewController: UITableViewDataSource, UITableViewDe
             return
         }
         
+        let presenter = self.navigationController?.presentingViewController ?? self.presentingViewController
         self.dismiss(animated: true) {
             print("eho notif " , notif.getNotificationPushData())
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                DeepLinkManager.presentAction(notification: notif.getNotificationPushData())
+                DeepLinkManager.presentAction(notification: notif.getNotificationPushData(), presenter: presenter)
             }
         }
     }


### PR DESCRIPTION
The user reported that clicking on a "birthday" type notification in the in-app notification center did not launch the birthday screen.
Investigation revealed that `NotificationsInAppViewController` dismisses itself and then attempts to present the next screen after a delay. However, relying on `AppState.getTopViewController()` during this transition is unreliable.
The fix involves capturing the valid `presentingViewController` before dismissal and passing it explicitly to the deep link manager to ensure the presentation occurs on a valid view controller.

---
*PR created automatically by Jules for task [1337746670620820130](https://jules.google.com/task/1337746670620820130) started by @clemPerrousset*