### PR TITLE
Add Reserved for Women option to Events

### DIFF
--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1951,3 +1951,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "birthday_title" = "Joyeux anniversaire !";
 "birthday_subtitle" = "Aujourd’hui, c’est votre jour.\nOn est heureux de vous compter parmi nous. Que cette journée soit pleine de chaleur humaine, d’échanges et de joie ✨";
 "birthday_button" = "Revenir à la page d'accueil";
+
+"event_create_reserved_female_title" = "Cet événement est-il réservé aux femmes ?";
+"event_detail_reserved_female_label" = "Cet événement est réservé aux femmes";

--- a/entourage/Models/Event.swift
+++ b/entourage/Models/Event.swift
@@ -48,6 +48,7 @@ struct Event:Codable {
     private var statusChangedAt:String? = nil
     private var createdAt:String? = nil
     private var updatedAt:String? = nil
+    var reservedFemale:Bool? = false
     
     func getChangedStatusDate() -> Date? {
         return statusChangedAt == nil ? nil : Utils.getDateFromWSDateString(statusChangedAt)
@@ -227,6 +228,7 @@ struct Event:Codable {
         case titleTranslations = "title_translations"
         case descriptionTranslations = "description_translations"
         case signable
+        case reservedFemale = "reserved_female"
     }
     
     func dictionaryForWS() -> [String:Any] {
@@ -347,6 +349,10 @@ struct Event:Codable {
 
         dict["metadata"] = metadatas
         
+        if let reservedFemale = reservedFemale {
+            dict["reserved_female"] = reservedFemale
+        }
+
         return dict
     }
     
@@ -525,6 +531,7 @@ struct EventEditing {
     var neighborhoods:[EventNeighborhood]? = nil
     
     var recurrence:EventRecurrence? = nil
+    var reservedFemale:Bool? = nil
     
     private var _startDate:Date? = nil
     var startDate:Date? {
@@ -616,6 +623,10 @@ struct EventEditing {
             }
         }
         
+        if let reservedFemale = reservedFemale {
+            dict["reserved_female"] = reservedFemale
+        }
+
         var metadatas = [String:Any]()
         if let newStartDate = metadata?.starts_at {
             metadatas["starts_at"] = newStartDate

--- a/entourage/Scenes/Events/Cells/EventListCell.swift
+++ b/entourage/Scenes/Events/Cells/EventListCell.swift
@@ -23,6 +23,7 @@ class EventListCell: UITableViewCell {
     @IBOutlet weak var ui_alpha_view: UIView!
     
     @IBOutlet weak var ic_entoutou: UIImageView!
+    @IBOutlet weak var ic_entoutou_woman: UIImageView!
     @IBOutlet weak var ui_label_canceled: UILabel!
     @IBOutlet weak var ui_label_admin: UILabel?
     @IBOutlet weak var ui_subscribed_label: UILabel!
@@ -64,19 +65,44 @@ class EventListCell: UITableViewCell {
             ui_label_canceled.isHidden = true
         }
         
+        var isAmbassador = false
         if let _author = event.author {
             if let _roles = _author.communityRoles{
                 if _roles.contains("Équipe Entourage") || _roles.contains("Animateur Entourage") {
-                    
-                    self.ic_entoutou.isHidden = false
-                }else {
-                    self.ic_entoutou.isHidden = true
+                    isAmbassador = true
                 }
-            }else{
-                self.ic_entoutou.isHidden = true
             }
         }
         
+        self.ic_entoutou.isHidden = !isAmbassador
+
+        if let reservedFemale = event.reservedFemale, reservedFemale {
+            self.ic_entoutou_woman.isHidden = false
+
+            if !isAmbassador {
+                 self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_little")
+                 self.ic_entoutou_woman.image = UIImage(named: "ic_entoutou_logo_woman")
+
+                 if !isAmbassador {
+                     self.ic_entoutou.isHidden = true
+
+                     self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_woman")
+                     self.ic_entoutou.isHidden = false
+                     self.ic_entoutou_woman.isHidden = true
+                 } else {
+                     self.ic_entoutou.isHidden = false
+                     self.ic_entoutou_woman.isHidden = false
+                 }
+            } else {
+                self.ic_entoutou_woman.isHidden = false
+                self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_little")
+            }
+        } else {
+            self.ic_entoutou_woman.isHidden = true
+            self.ic_entoutou.isHidden = !isAmbassador
+            self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_little")
+        }
+
         if event.isMember ?? false {
             ui_subscribed_label.isHidden = false
         }else{

--- a/entourage/Scenes/Events/Cells/EventListCell.xib
+++ b/entourage/Scenes/Events/Cells/EventListCell.xib
@@ -46,6 +46,13 @@
                             <constraint firstAttribute="height" constant="22" id="9yc-i2-Ayu"/>
                         </constraints>
                     </imageView>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_entoutou_logo_woman" translatesAutoresizingMaskIntoConstraints="NO" id="abc-12-wom">
+                        <rect key="frame" x="46" y="70" width="22" height="22"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="22" id="def-45-wom"/>
+                            <constraint firstAttribute="height" constant="22" id="ghi-78-wom"/>
+                        </constraints>
+                    </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="752" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rU3-kg-lsr">
                         <rect key="frame" x="139" y="29" width="32" height="18"/>
                         <fontDescription key="fontDescription" name="NunitoSans-Light" family="Nunito Sans" pointSize="13"/>
@@ -125,6 +132,8 @@
                     <constraint firstAttribute="bottom" secondItem="V4x-sb-dCg" secondAttribute="bottom" id="7Lg-G6-aPB"/>
                     <constraint firstItem="VxJ-kc-bBP" firstAttribute="leading" secondItem="q6g-Fy-0d4" secondAttribute="leading" constant="16" id="8VA-bP-f8R"/>
                     <constraint firstItem="MbV-11-mUk" firstAttribute="bottom" secondItem="VxJ-kc-bBP" secondAttribute="bottom" constant="-10" id="8yk-nP-hPa"/>
+                    <constraint firstItem="abc-12-wom" firstAttribute="bottom" secondItem="VxJ-kc-bBP" secondAttribute="bottom" constant="-10" id="jkl-01-wom"/>
+                    <constraint firstItem="abc-12-wom" firstAttribute="leading" secondItem="MbV-11-mUk" secondAttribute="trailing" constant="4" id="mno-23-wom"/>
                     <constraint firstItem="GXp-iK-TW2" firstAttribute="top" secondItem="VxJ-kc-bBP" secondAttribute="top" constant="-3" id="9xS-Ze-KwW"/>
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="19i-WM-5eN" secondAttribute="trailing" constant="8" id="AG1-Yg-hWj"/>
                     <constraint firstItem="cMP-w6-HKs" firstAttribute="leading" secondItem="AEp-eM-B3w" secondAttribute="leading" id="AYw-Iv-zb1"/>
@@ -157,6 +166,7 @@
             </tableViewCellContentView>
             <connections>
                 <outlet property="ic_entoutou" destination="MbV-11-mUk" id="aNd-c5-LNT"/>
+                <outlet property="ic_entoutou_woman" destination="abc-12-wom" id="pqr-45-wom"/>
                 <outlet property="ui_alpha_view" destination="wHr-6A-1Ud" id="Hrr-Mq-QIF"/>
                 <outlet property="ui_constraint_left_title" destination="2NI-HV-4zE" id="RUJ-rb-qvZ"/>
                 <outlet property="ui_date" destination="rU3-kg-lsr" id="uI1-Cg-sTY"/>

--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
@@ -46,6 +46,9 @@ class EventDetailTopFullCell: UITableViewCell {
     @IBOutlet weak var ui_mapview: MKMapView!
     @IBOutlet weak var ui_btn_i_participate: UIButton!
     
+    @IBOutlet weak var ui_view_reserved_female: UIView!
+    @IBOutlet weak var ui_constraint_height_reserved_female: NSLayoutConstraint!
+
     weak var delegate: EventDetailTopCellDelegate? = nil
     
     let topMarginConstraint: CGFloat = 24
@@ -85,6 +88,9 @@ class EventDetailTopFullCell: UITableViewCell {
         ui_img_member_2.layer.cornerRadius = ui_img_member_2.frame.height / 2
         ui_img_member_3.layer.cornerRadius = ui_img_member_3.frame.height / 2
         
+        ui_view_reserved_female.layer.cornerRadius = 16
+        ui_view_reserved_female.backgroundColor = UIColor.appViolet
+
         ui_view_place_limit.isHidden = true
         
         ui_btn_share.addTarget(self, action: #selector(onShareBtnClick), for: .touchUpInside)
@@ -210,6 +216,14 @@ class EventDetailTopFullCell: UITableViewCell {
             })
         }
         
+        if let reservedFemale = event.reservedFemale, reservedFemale {
+            ui_view_reserved_female.isHidden = false
+            ui_constraint_height_reserved_female.constant = 32
+        } else {
+            ui_view_reserved_female.isHidden = true
+            ui_constraint_height_reserved_female.constant = 0
+        }
+
         // --- PLACES LIMIT ---
         if let placeLimit = event.metadata?.place_limit, placeLimit > 0 {
             ui_view_place_limit.isHidden = false

--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
@@ -34,6 +34,29 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="abc-female-banner">
+                        <rect key="frame" x="20" y="62" width="366" height="0"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cet événement est réservé aux femmes" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="def-female-label">
+                                <rect key="frame" x="10" y="4" width="346" height="18"/>
+                                <fontDescription key="fontDescription" name="Quicksand-Bold" family="Quicksand" pointSize="15"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="0.49019607843137253" green="0.0" blue="0.96470588235294119" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0" id="hij-height-constraint"/>
+                            <constraint firstItem="def-female-label" firstAttribute="leading" secondItem="abc-female-banner" secondAttribute="leading" constant="10" id="klm-leading"/>
+                            <constraint firstAttribute="trailing" secondItem="def-female-label" secondAttribute="trailing" constant="10" id="nop-trailing"/>
+                            <constraint firstItem="def-female-label" firstAttribute="centerY" secondItem="abc-female-banner" secondAttribute="centerY" id="qrs-center-y"/>
+                        </constraints>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                <integer key="value" value="16"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nfw-W1-dO7">
                         <rect key="frame" x="20" y="72" width="376" height="25"/>
                         <subviews>
@@ -463,7 +486,10 @@
                     <constraint firstAttribute="trailing" secondItem="fuU-Rj-r2w" secondAttribute="trailing" constant="20" id="RgV-tb-QmG"/>
                     <constraint firstItem="UXs-ZL-Ra7" firstAttribute="leading" secondItem="klB-o1-C0m" secondAttribute="leading" id="UYw-0d-rgq"/>
                     <constraint firstItem="1xV-ay-YP1" firstAttribute="trailing" secondItem="1V4-oV-Dh3" secondAttribute="trailing" id="Ujl-4M-eMB"/>
-                    <constraint firstItem="Nfw-W1-dO7" firstAttribute="top" secondItem="klB-o1-C0m" secondAttribute="bottom" constant="15" id="VQC-kR-A9p"/>
+                            <constraint firstItem="abc-female-banner" firstAttribute="top" secondItem="klB-o1-C0m" secondAttribute="bottom" constant="5" id="tuv-banner-top"/>
+                            <constraint firstItem="abc-female-banner" firstAttribute="leading" secondItem="klB-o1-C0m" secondAttribute="leading" id="wxy-banner-leading"/>
+                            <constraint firstItem="abc-female-banner" firstAttribute="trailing" secondItem="klB-o1-C0m" secondAttribute="trailing" id="xyz-banner-trailing"/>
+                            <constraint firstItem="Nfw-W1-dO7" firstAttribute="top" secondItem="abc-female-banner" secondAttribute="bottom" constant="10" id="VQC-kR-A9p"/>
                     <constraint firstAttribute="bottom" secondItem="1xV-ay-YP1" secondAttribute="bottom" constant="20" id="Vpw-kr-Z8k"/>
                     <constraint firstItem="lgR-Y6-WWf" firstAttribute="leading" secondItem="klB-o1-C0m" secondAttribute="leading" id="Y0c-Lv-hqK"/>
                     <constraint firstItem="CsR-kO-usD" firstAttribute="leading" secondItem="UXs-ZL-Ra7" secondAttribute="leading" id="aoe-s2-pzF"/>
@@ -481,6 +507,8 @@
             <connections>
                 <outlet property="adress_view_top_constraint" destination="yX0-kE-283" id="tad-Gm-gRd"/>
                 <outlet property="ui_btn_agenda" destination="G9W-bu-4QC" id="BSR-SG-7Es"/>
+                <outlet property="ui_view_reserved_female" destination="abc-female-banner" id="out-view-reserved"/>
+                <outlet property="ui_constraint_height_reserved_female" destination="hij-height-constraint" id="out-constraint-height"/>
                 <outlet property="ui_btn_i_participate" destination="IR4-sb-IgC" id="2Bw-Ef-4tt"/>
                 <outlet property="ui_btn_participate" destination="1xV-ay-YP1" id="H26-cy-lt3"/>
                 <outlet property="ui_btn_share" destination="lgR-Y6-WWf" id="Lqp-Ta-LcQ"/>

--- a/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.swift
+++ b/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.swift
@@ -1,0 +1,35 @@
+//
+//  EventReservedFemaleCell.swift
+//  entourage
+//
+//
+
+import UIKit
+
+protocol EventReservedFemaleCellDelegate: AnyObject {
+    func updateReservedFemale(isReserved: Bool)
+}
+
+class EventReservedFemaleCell: UITableViewCell {
+
+    @IBOutlet weak var ui_title: UILabel!
+    @IBOutlet weak var ui_switch: UISwitch!
+
+    weak var delegate: EventReservedFemaleCellDelegate?
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        ui_title.setupFontAndColor(style: ApplicationTheme.getFontCourantBoldNoir())
+        ui_title.text = "event_create_reserved_female_title".localized
+        ui_switch.onTintColor = .appOrange
+    }
+
+    func populateCell(isReserved: Bool, delegate: EventReservedFemaleCellDelegate) {
+        self.delegate = delegate
+        ui_switch.isOn = isReserved
+    }
+
+    @IBAction func action_switch(_ sender: UISwitch) {
+        delegate?.updateReservedFemale(isReserved: sender.isOn)
+    }
+}

--- a/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.xib
+++ b/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.xib
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="EventReservedFemaleCell" rowHeight="56" id="KGk-i7-Jjw" customClass="EventReservedFemaleCell" customModule="Ent_Beta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cet événement est-il réservé aux femmes ?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abc-12-def">
+                        <rect key="frame" x="20" y="10" width="221" height="36"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ghi-34-jkl">
+                        <rect key="frame" x="251" y="12.666666666666664" width="51" height="31"/>
+                        <connections>
+                            <action selector="action_switch:" destination="KGk-i7-Jjw" eventType="valueChanged" id="mno-56-pqr"/>
+                        </connections>
+                    </switch>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="abc-12-def" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="123-45-abc"/>
+                    <constraint firstItem="ghi-34-jkl" firstAttribute="leading" secondItem="abc-12-def" secondAttribute="trailing" constant="10" id="456-78-def"/>
+                    <constraint firstItem="ghi-34-jkl" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="789-01-efg"/>
+                    <constraint firstAttribute="trailing" secondItem="ghi-34-jkl" secondAttribute="trailing" constant="20" id="abc-de-fgh"/>
+                    <constraint firstAttribute="bottom" secondItem="abc-12-def" secondAttribute="bottom" constant="10" id="xyz-98-765"/>
+                    <constraint firstItem="abc-12-def" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="uvw-12-345"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="ui_switch" destination="ghi-34-jkl" id="stu-90-vwx"/>
+                <outlet property="ui_title" destination="abc-12-def" id="yza-23-bcd"/>
+            </connections>
+            <point key="canvasLocation" x="129.7709923664122" y="-11.267605633802818"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
+++ b/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
@@ -261,6 +261,11 @@ extension EventCreateMainViewController: EventCreateMainDelegate {
         _ = checkValidation()
     }
     
+    func addReservedFemale(reserved: Bool) {
+        newEvent.reservedFemale = reserved
+        _ = checkValidation()
+    }
+
     //Phase 3
     func addPlaceType(isOnline:Bool) {
         newEvent.isOnline = isOnline
@@ -470,6 +475,7 @@ protocol EventCreateMainDelegate: AnyObject {
     func addDateStart(dateStart:Date?)
     func addDateEnd(dateEnd:Date?)
     func addRecurrence(recurrence:EventRecurrence)
+    func addReservedFemale(reserved: Bool)
     func setDateChanged()
     
     //Phase 3

--- a/entourage/Scenes/Events/Create/EventCreatePhase2ViewController.swift
+++ b/entourage/Scenes/Events/Create/EventCreatePhase2ViewController.swift
@@ -28,6 +28,8 @@ class EventCreatePhase2ViewController: UIViewController {
         ui_tableview.rowHeight = UITableView.automaticDimension
         ui_tableview.estimatedRowHeight = 50
         
+        ui_tableview.register(UINib(nibName: "EventReservedFemaleCell", bundle: nil), forCellReuseIdentifier: "EventReservedFemaleCell")
+
         if pageDelegate?.isEdit() ?? false {
             currentEvent = pageDelegate?.getCurrentEvent()
             hasCurrentRecurrency = pageDelegate?.hasCurrentRecurrency() ?? false
@@ -46,7 +48,7 @@ class EventCreatePhase2ViewController: UIViewController {
 //MARK: - UITableView datasource / Delegate -
 extension EventCreatePhase2ViewController:UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return hasCurrentRecurrency ? 1 : 2
+        return hasCurrentRecurrency ? 2 : 3
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -60,12 +62,24 @@ extension EventCreatePhase2ViewController:UITableViewDataSource, UITableViewDele
             
             return cell
         }
+        else if indexPath.row == 1 && !hasCurrentRecurrency {
+            let cell = tableView.dequeueReusableCell(withIdentifier: "cellSelector", for: indexPath) as! EventRecurrenceCell
+            let recur = currentEvent != nil ? currentEvent!.recurrence : recurrenceSelected
+
+            cell.populateCell(recurrence:recur, delegate: self)
+            return cell
+        }
         
-        let cell = tableView.dequeueReusableCell(withIdentifier: "cellSelector", for: indexPath) as! EventRecurrenceCell
-        let recur = currentEvent != nil ? currentEvent!.recurrence : recurrenceSelected
-        
-        cell.populateCell(recurrence:recur, delegate: self)
+        let cell = tableView.dequeueReusableCell(withIdentifier: "EventReservedFemaleCell", for: indexPath) as! EventReservedFemaleCell
+        let isReserved = currentEvent?.reservedFemale ?? false
+        cell.populateCell(isReserved: isReserved, delegate: self)
         return cell
+    }
+}
+
+extension EventCreatePhase2ViewController: EventReservedFemaleCellDelegate {
+    func updateReservedFemale(isReserved: Bool) {
+        pageDelegate?.addReservedFemale(reserved: isReserved)
     }
 }
 

--- a/entourage/Tools/Extensions/Extensions_UIColor.swift
+++ b/entourage/Tools/Extensions/Extensions_UIColor.swift
@@ -126,6 +126,10 @@ extension UIColor {
         return UIColor(named: "grey_text_deleted") ?? .red
     }
     
+    static var appViolet: UIColor {
+        return UIColor(red: 125/255, green: 0, blue: 246/255, alpha: 1)
+    }
+
     static var rougeErreur: UIColor {
         return UIColor(named: "rouge_erreur") ?? .red
     }


### PR DESCRIPTION
Implemented the "Reserved for Women" feature for events.
- Added `reservedFemale` boolean to `Event` and `EventEditing` models.
- Added `appViolet` color to `ApplicationTheme`.
- Added a switch in the Event Creation Flow (Phase 2).
- Added `ic_entoutou_logo_woman` (handled logic to display side-by-side with ambassador logo) in `EventListCell`.
- Added a purple banner "Cet événement est réservé aux femmes" in `EventDetailTopFullCell`.
- Updated localization files.

---
*PR created automatically by Jules for task [9223403799861897412](https://jules.google.com/task/9223403799861897412) started by @clemPerrousset*