### PR TITLE
Implement Reserved Female Event UI logic

### DIFF
--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -1960,3 +1960,7 @@
 "birthday_title" = "It's your birthday!";
 "birthday_subtitle" = "The entire Entourage team wishes you a happy birthday!";
 "birthday_button" = "Thank you!";
+
+"event_create_reserved_female_title" = "Is this event reserved for women?";
+"event_create_reserved_female_info" = "The event will only be visible to female users of the application.";
+"event_detail_reserved_female_label" = "This event is reserved for women";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1953,4 +1953,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "birthday_button" = "Revenir à la page d'accueil";
 
 "event_create_reserved_female_title" = "Cet événement est-il réservé aux femmes ?";
+"event_create_reserved_female_info" = "L'événement sera uniquement visible par les utilisatrices de l'application.";
 "event_detail_reserved_female_label" = "Cet événement est réservé aux femmes";

--- a/entourage/Scenes/Events/Cells/EventListCell.swift
+++ b/entourage/Scenes/Events/Cells/EventListCell.swift
@@ -74,33 +74,28 @@ class EventListCell: UITableViewCell {
             }
         }
         
-        self.ic_entoutou.isHidden = !isAmbassador
+        let isReservedFemale = event.reservedFemale ?? false
 
-        if let reservedFemale = event.reservedFemale, reservedFemale {
-            self.ic_entoutou_woman.isHidden = false
-
-            if !isAmbassador {
-                 self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_little")
-                 self.ic_entoutou_woman.image = UIImage(named: "ic_entoutou_logo_woman")
-
-                 if !isAmbassador {
-                     self.ic_entoutou.isHidden = true
-
-                     self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_woman")
-                     self.ic_entoutou.isHidden = false
-                     self.ic_entoutou_woman.isHidden = true
-                 } else {
-                     self.ic_entoutou.isHidden = false
-                     self.ic_entoutou_woman.isHidden = false
-                 }
-            } else {
-                self.ic_entoutou_woman.isHidden = false
-                self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_little")
-            }
-        } else {
-            self.ic_entoutou_woman.isHidden = true
-            self.ic_entoutou.isHidden = !isAmbassador
+        if isAmbassador && isReservedFemale {
+            self.ic_entoutou.isHidden = false
             self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_little")
+
+            self.ic_entoutou_woman.isHidden = false
+            self.ic_entoutou_woman.image = UIImage(named: "ic_entoutou_logo_woman")
+        }
+        else if isAmbassador {
+            self.ic_entoutou.isHidden = false
+            self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_little")
+            self.ic_entoutou_woman.isHidden = true
+        }
+        else if isReservedFemale {
+            self.ic_entoutou.isHidden = false
+            self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_woman")
+            self.ic_entoutou_woman.isHidden = true
+        }
+        else {
+            self.ic_entoutou.isHidden = true
+            self.ic_entoutou_woman.isHidden = true
         }
 
         if event.isMember ?? false {

--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
@@ -48,6 +48,7 @@ class EventDetailTopFullCell: UITableViewCell {
     
     @IBOutlet weak var ui_view_reserved_female: UIView!
     @IBOutlet weak var ui_constraint_height_reserved_female: NSLayoutConstraint!
+    @IBOutlet weak var ui_lbl_reserved_female: UILabel!
 
     weak var delegate: EventDetailTopCellDelegate? = nil
     
@@ -90,6 +91,7 @@ class EventDetailTopFullCell: UITableViewCell {
         
         ui_view_reserved_female.layer.cornerRadius = 16
         ui_view_reserved_female.backgroundColor = UIColor.appViolet
+        ui_lbl_reserved_female?.text = "event_detail_reserved_female_label".localized
 
         ui_view_place_limit.isHidden = true
         

--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
@@ -508,6 +508,7 @@
                 <outlet property="adress_view_top_constraint" destination="yX0-kE-283" id="tad-Gm-gRd"/>
                 <outlet property="ui_btn_agenda" destination="G9W-bu-4QC" id="BSR-SG-7Es"/>
                 <outlet property="ui_view_reserved_female" destination="abc-female-banner" id="out-view-reserved"/>
+                <outlet property="ui_lbl_reserved_female" destination="def-female-label" id="out-lbl-reserved"/>
                 <outlet property="ui_constraint_height_reserved_female" destination="hij-height-constraint" id="out-constraint-height"/>
                 <outlet property="ui_btn_i_participate" destination="IR4-sb-IgC" id="2Bw-Ef-4tt"/>
                 <outlet property="ui_btn_participate" destination="1xV-ay-YP1" id="H26-cy-lt3"/>

--- a/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.swift
+++ b/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.swift
@@ -14,6 +14,8 @@ class EventReservedFemaleCell: UITableViewCell {
 
     @IBOutlet weak var ui_title: UILabel!
     @IBOutlet weak var ui_switch: UISwitch!
+    @IBOutlet weak var ui_view_info: UIView!
+    @IBOutlet weak var ui_lbl_info: UILabel!
 
     weak var delegate: EventReservedFemaleCellDelegate?
 
@@ -21,15 +23,24 @@ class EventReservedFemaleCell: UITableViewCell {
         super.awakeFromNib()
         ui_title.setupFontAndColor(style: ApplicationTheme.getFontCourantBoldNoir())
         ui_title.text = "event_create_reserved_female_title".localized
+
+        ui_lbl_info.setupFontAndColor(style: ApplicationTheme.getFontCourantRegularNoir())
+        ui_lbl_info.text = "event_create_reserved_female_info".localized
+
+        ui_view_info.layer.cornerRadius = 16
+        ui_view_info.backgroundColor = .appOrangeLight.withAlphaComponent(0.2) // Adjust color as needed to match screenshot
+
         ui_switch.onTintColor = .appOrange
     }
 
     func populateCell(isReserved: Bool, delegate: EventReservedFemaleCellDelegate) {
         self.delegate = delegate
         ui_switch.isOn = isReserved
+        ui_view_info.isHidden = !isReserved
     }
 
     @IBAction func action_switch(_ sender: UISwitch) {
+        ui_view_info.isHidden = !sender.isOn
         delegate?.updateReservedFemale(isReserved: sender.isOn)
     }
 }

--- a/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.xib
+++ b/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.xib
@@ -4,47 +4,107 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="EventReservedFemaleCell" rowHeight="56" id="KGk-i7-Jjw" customClass="EventReservedFemaleCell" customModule="Ent_Beta" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="EventReservedFemaleCell" rowHeight="120" id="KGk-i7-Jjw" customClass="EventReservedFemaleCell" customModule="Ent_Beta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="120"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="120"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cet événement est-il réservé aux femmes ?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abc-12-def">
-                        <rect key="frame" x="20" y="10" width="221" height="36"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ghi-34-jkl">
-                        <rect key="frame" x="251" y="12.666666666666664" width="51" height="31"/>
-                        <connections>
-                            <action selector="action_switch:" destination="KGk-i7-Jjw" eventType="valueChanged" id="mno-56-pqr"/>
-                        </connections>
-                    </switch>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="root-stack">
+                        <rect key="frame" x="20" y="10" width="280" height="100"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="top-container">
+                                <rect key="frame" x="0.0" y="0.0" width="280" height="36"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cet événement est-il réservé aux femmes ?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abc-12-def">
+                                        <rect key="frame" x="0.0" y="0.0" width="221" height="36"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ghi-34-jkl">
+                                        <rect key="frame" x="231" y="2.6666666666666661" width="51" height="31"/>
+                                        <connections>
+                                            <action selector="action_switch:" destination="KGk-i7-Jjw" eventType="valueChanged" id="mno-56-pqr"/>
+                                        </connections>
+                                    </switch>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="ghi-34-jkl" firstAttribute="leading" secondItem="abc-12-def" secondAttribute="trailing" constant="10" id="123-switch-leading"/>
+                                    <constraint firstItem="abc-12-def" firstAttribute="top" secondItem="top-container" secondAttribute="top" id="456-label-top"/>
+                                    <constraint firstAttribute="bottom" secondItem="abc-12-def" secondAttribute="bottom" id="789-label-bottom"/>
+                                    <constraint firstItem="abc-12-def" firstAttribute="leading" secondItem="top-container" secondAttribute="leading" id="abc-label-leading"/>
+                                    <constraint firstItem="ghi-34-jkl" firstAttribute="centerY" secondItem="top-container" secondAttribute="centerY" id="def-switch-center"/>
+                                    <constraint firstAttribute="trailing" secondItem="ghi-34-jkl" secondAttribute="trailing" id="ghi-switch-trailing"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="36" id="jkl-height"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xyz-12-uvw">
+                                <rect key="frame" x="0.0" y="46" width="280" height="54"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="info.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="jkl-34-rst">
+                                        <rect key="frame" x="12" y="12" width="20" height="20"/>
+                                        <color key="tintColor" name="orange_app"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="20" id="opq-56-xyz"/>
+                                            <constraint firstAttribute="height" constant="20" id="rst-78-uvw"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="L'événement sera uniquement visible par les utilisatrices de l'application." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vwx-90-yza">
+                                        <rect key="frame" x="40" y="12" width="228" height="30"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <color key="textColor" name="gris_112"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" name="Beige"/>
+                                <constraints>
+                                    <constraint firstItem="jkl-34-rst" firstAttribute="leading" secondItem="xyz-12-uvw" secondAttribute="leading" constant="12" id="abc-def-123"/>
+                                    <constraint firstItem="jkl-34-rst" firstAttribute="top" secondItem="xyz-12-uvw" secondAttribute="top" constant="12" id="def-ghi-456"/>
+                                    <constraint firstItem="vwx-90-yza" firstAttribute="leading" secondItem="jkl-34-rst" secondAttribute="trailing" constant="8" id="ghi-jkl-789"/>
+                                    <constraint firstAttribute="trailing" secondItem="vwx-90-yza" secondAttribute="trailing" constant="12" id="jkl-mno-012"/>
+                                    <constraint firstItem="vwx-90-yza" firstAttribute="top" secondItem="xyz-12-uvw" secondAttribute="top" constant="12" id="mno-pqr-345"/>
+                                    <constraint firstAttribute="bottom" secondItem="vwx-90-yza" secondAttribute="bottom" constant="12" id="pqr-stu-678"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                    </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="abc-12-def" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="123-45-abc"/>
-                    <constraint firstItem="ghi-34-jkl" firstAttribute="leading" secondItem="abc-12-def" secondAttribute="trailing" constant="10" id="456-78-def"/>
-                    <constraint firstItem="ghi-34-jkl" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="789-01-efg"/>
-                    <constraint firstAttribute="trailing" secondItem="ghi-34-jkl" secondAttribute="trailing" constant="20" id="abc-de-fgh"/>
-                    <constraint firstAttribute="bottom" secondItem="abc-12-def" secondAttribute="bottom" constant="10" id="xyz-98-765"/>
-                    <constraint firstItem="abc-12-def" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="uvw-12-345"/>
+                    <constraint firstItem="root-stack" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="stack-leading"/>
+                    <constraint firstAttribute="trailing" secondItem="root-stack" secondAttribute="trailing" constant="20" id="stack-trailing"/>
+                    <constraint firstItem="root-stack" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="stack-top"/>
+                    <constraint firstAttribute="bottom" secondItem="root-stack" secondAttribute="bottom" constant="10" id="stack-bottom"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="ui_lbl_info" destination="vwx-90-yza" id="stu-90-vwx-lbl"/>
                 <outlet property="ui_switch" destination="ghi-34-jkl" id="stu-90-vwx"/>
                 <outlet property="ui_title" destination="abc-12-def" id="yza-23-bcd"/>
+                <outlet property="ui_view_info" destination="xyz-12-uvw" id="vwx-90-yza-view"/>
             </connections>
-            <point key="canvasLocation" x="129.7709923664122" y="-11.267605633802818"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <namedColor name="Beige">
+            <color red="1" green="0.91764705882352937" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="gris_112">
+            <color red="0.4392156862745098" green="0.4392156862745098" blue="0.4392156862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="orange_app">
+            <color red="0.96078431372549022" green="0.37254901960784315" blue="0.14117647058823529" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <image name="info.circle" catalog="system" width="128" height="121"/>
+    </resources>
 </document>


### PR DESCRIPTION
Implemented the missing UI logic for "Event Reserved for Women". This includes:
1.  Restoring `EventReservedFemaleCell` with a `UIStackView` based layout so the orange info box appears/disappears correctly without leaving whitespace.
2.  Updating `EventListCell` logic to support displaying both the Ambassador logo and the Woman Reserved logo simultaneously, or reusing the primary logo slot if only one is present, respecting the "same size and position" requirement.
3.  Updating `EventDetailTopFullCell` to programmatically set the text of the purple banner using the localized string `event_detail_reserved_female_label`, ensuring multi-language support.
4.  Adding the necessary localization keys (`event_create_reserved_female_info`, `event_create_reserved_female_title`, `event_detail_reserved_female_label`) to French and English files.

---
*PR created automatically by Jules for task [10636206780304507891](https://jules.google.com/task/10636206780304507891) started by @clemPerrousset*