### PR TITLE
Fix reserved female switch interaction and bubble layout

### DIFF
--- a/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.swift
+++ b/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.swift
@@ -31,12 +31,21 @@ class EventReservedFemaleCell: UITableViewCell {
         ui_view_info.backgroundColor = .appOrangeLight.withAlphaComponent(0.2) // Adjust color as needed to match screenshot
 
         ui_switch.onTintColor = .appOrange
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(toggleSwitch))
+        ui_title.superview?.addGestureRecognizer(tap)
+        ui_title.superview?.isUserInteractionEnabled = true
     }
 
     func populateCell(isReserved: Bool, delegate: EventReservedFemaleCellDelegate) {
         self.delegate = delegate
         ui_switch.isOn = isReserved
         ui_view_info.isHidden = !isReserved
+    }
+
+    @objc func toggleSwitch() {
+        ui_switch.setOn(!ui_switch.isOn, animated: true)
+        action_switch(ui_switch)
     }
 
     @IBAction func action_switch(_ sender: UISwitch) {

--- a/entourage/Scenes/Events/Create/EventCreatePhase2ViewController.swift
+++ b/entourage/Scenes/Events/Create/EventCreatePhase2ViewController.swift
@@ -80,6 +80,9 @@ extension EventCreatePhase2ViewController:UITableViewDataSource, UITableViewDele
 extension EventCreatePhase2ViewController: EventReservedFemaleCellDelegate {
     func updateReservedFemale(isReserved: Bool) {
         pageDelegate?.addReservedFemale(reserved: isReserved)
+        //Force resize cell
+        ui_tableview.beginUpdates()
+        ui_tableview.endUpdates()
     }
 }
 


### PR DESCRIPTION
This PR addresses UI and interaction issues with the "Reserved Female" field in the event creation flow.

**Changes:**
1.  **Switch Interaction:** Added a `UITapGestureRecognizer` to the `EventReservedFemaleCell` container view (`ui_title.superview`). This makes the entire row area tappable to toggle the switch, solving the issue where the switch was difficult to click.
2.  **Layout Update:** Modified `EventCreatePhase2ViewController.swift` to call `ui_tableview.beginUpdates()` and `ui_tableview.endUpdates()` within the `updateReservedFemale` delegate method. This ensures that when the switch is toggled and the info bubble appears/disappears, the table view row height animates correctly.
3.  **Verification:** Confirmed that the API uses the `reserved_female` key as requested.

**Files Modified:**
*   `entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.swift`
*   `entourage/Scenes/Events/Create/EventCreatePhase2ViewController.swift`

---
*PR created automatically by Jules for task [6840998682884466863](https://jules.google.com/task/6840998682884466863) started by @clemPerrousset*