### PR TITLE
Update Home V2 with Solidarity Tools and new layout

### DIFF
--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1955,3 +1955,10 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "event_create_reserved_female_title" = "Cet événement est-il réservé aux femmes ?";
 "event_create_reserved_female_info" = "L'événement sera uniquement visible par les utilisatrices de l'application.";
 "event_detail_reserved_female_label" = "Cet événement est réservé aux femmes";
+"home_v2_small_talk_card_title" = "Rejoindre une discussion solidaire";
+"home_v2_small_talk_card_subtitle" = "On vous met en relation avec un petit groupe qui partage vos centres d'intérêt, partout en France";
+"home_v2_small_talk_card_button" = "Discuter";
+"home_v2_solidarity_tools_title" = "Tes outils solidaires";
+"home_v2_tool_card_map" = "Carte des lieux solidaires";
+"home_v2_tool_card_pedago" = "Contenus pour apprendre et agir";
+"home_v2_tool_card_ethics" = "Charte éthique Entourage";

--- a/entourage/Scenes/HomeV2/HomeV2ViewController.swift
+++ b/entourage/Scenes/HomeV2/HomeV2ViewController.swift
@@ -33,6 +33,7 @@ enum HomeV2DTO {
     case cellHZ
     case cellInitialPedago(pedagos: [PedagogicResource])
     case cellSmallTalk(userRequests:[UserSmallTalkRequest])
+    case cellSolidarityTools
 }
 
 class HomeV2ViewController: UIViewController {
@@ -100,6 +101,7 @@ class HomeV2ViewController: UIViewController {
         ui_table_view.register(UINib(nibName: HomeInitialPedagogicHorizontalCell.identifier, bundle: nil), forCellReuseIdentifier: HomeInitialPedagogicHorizontalCell.identifier)
         ui_table_view.register(UINib(nibName: HomeHZCell.identifier, bundle: nil), forCellReuseIdentifier: HomeHZCell.identifier)
         ui_table_view.register(UINib(nibName: HomeSmallTalkCell.identifier, bundle: nil), forCellReuseIdentifier: HomeSmallTalkCell.identifier)
+        ui_table_view.register(UINib(nibName: HomeSolidarityToolsCell.identifier, bundle: nil), forCellReuseIdentifier: HomeSolidarityToolsCell.identifier)
 
         self.checkAndCreateCookieIfNotExists()
         //self.checkNotificationSettings()
@@ -414,6 +416,9 @@ class HomeV2ViewController: UIViewController {
         //add condition
         tableDTO.append(.cellTitle(title: "home_v2_title_small_talk".localized, subtitle: ""))
         tableDTO.append(.cellSmallTalk(userRequests: self.userSmallTalkRequests))
+
+        tableDTO.append(.cellSolidarityTools)
+
         if (allDemands.count > 0) {
             if isContributionPreference {
                 tableDTO.append(.cellTitle(title: "home_v2_title_action_contrib".localized, subtitle: "home_v2_subtitle_action_contrib".localized))
@@ -439,16 +444,12 @@ class HomeV2ViewController: UIViewController {
             for pedago in allPedagos {
                 tableDTO.append(.cellPedago(pedago: pedago))
             }
-            tableDTO.append(.cellSeeAll(seeAllType: .seeAllPedago))
         }
 //        if allGroups.count > 0 {
 //            tableDTO.append(.cellTitle(title: "home_v2_title_group".localized, subtitle: "home_v2_subtitle_group".localized))
 //            tableDTO.append(.cellGroup(groups: allGroups))
 //            tableDTO.append(.cellSeeAll(seeAllType: .seeAllGroup))
 //        }
-        
-        tableDTO.append(.cellTitle(title: "home_v2_title_map".localized, subtitle: "home_v2_subtitle_map".localized))
-        tableDTO.append(.cellMap)
         
         var _offlineEvents = [Event]()
         for event in allEvents {
@@ -599,6 +600,12 @@ extension HomeV2ViewController: UITableViewDelegate, UITableViewDataSource {
                 cell.data = dto
                 return cell
             }
+        case .cellSolidarityTools:
+            if let cell = tableView.dequeueReusableCell(withIdentifier: HomeSolidarityToolsCell.identifier) as? HomeSolidarityToolsCell {
+                cell.selectionStyle = .none
+                cell.delegate = self
+                return cell
+            }
         }
         return UITableViewCell()
     }
@@ -668,6 +675,8 @@ extension HomeV2ViewController: UITableViewDelegate, UITableViewDataSource {
             return
         case .cellSmallTalk(let userRequests): break
             return
+        case .cellSolidarityTools:
+            return
         }
     }
     
@@ -697,6 +706,8 @@ extension HomeV2ViewController: UITableViewDelegate, UITableViewDataSource {
             return 115
         case .cellSmallTalk(let userRequests):
             return 200
+        case .cellSolidarityTools:
+            return UITableView.automaticDimension
         }
     }
 }
@@ -805,7 +816,7 @@ extension HomeV2ViewController {
                 }
                 for pedagoRead in pedagoReads {
                     self.allPedagos.append(pedagoRead)
-                    if self.allPedagos.count > 1 {
+                    if self.allPedagos.count >= 3 {
                         break
                     }
                 }
@@ -900,6 +911,25 @@ extension HomeV2ViewController {
                     currentVc.present(vc, animated: true)
                 }
             }
+        }
+    }
+}
+
+// MARK: - HomeSolidarityToolsCellDelegate
+extension HomeV2ViewController: HomeSolidarityToolsCellDelegate {
+    func onMapTapped() {
+        AnalyticsLoggerManager.logEvent(name: Action__Home__Map)
+        self.showAllPois()
+    }
+
+    func onPedagoTapped() {
+        AnalyticsLoggerManager.logEvent(name: Action__Home__Pedago)
+        DeepLinkManager.showRessourceListUniversalLink()
+    }
+
+    func onEthicsTapped() {
+        if let url = URL(string: "https://www.entourage.social/charte-ethique-grand-public") {
+            WebLinkManager.openUrl(url: url, openInApp: true, presenterViewController: self)
         }
     }
 }

--- a/entourage/Scenes/HomeV2/homev2cells/HomeCellPedago.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeCellPedago.swift
@@ -25,11 +25,32 @@ class HomeCellPedago:UITableViewCell{
     }
     
     override func awakeFromNib() {
+        super.awakeFromNib()
         self.contentView.backgroundColor = UIColor(named: "white_orange_home")
         containerView.layer.cornerRadius = 15
         containerView.layer.borderWidth = 1
         containerView.layer.borderColor = UIColor.appBeige.cgColor
         containerView.clipsToBounds = true
+
+        repositionDurationLabel()
+    }
+
+    private func repositionDurationLabel() {
+        guard let tagContainer = ui_label_pedago.superview else { return }
+
+        // Remove existing constraints on ui_label_duration
+        // It's a direct child of containerView, so constraints are held by containerView
+        let constraintsToRemove = containerView.constraints.filter { constraint in
+            return (constraint.firstItem as? UIView == ui_label_duration && (constraint.firstAttribute == .bottom || constraint.firstAttribute == .leading)) ||
+                   (constraint.secondItem as? UIView == ui_label_duration && (constraint.secondAttribute == .bottom || constraint.secondAttribute == .leading))
+        }
+        containerView.removeConstraints(constraintsToRemove)
+
+        ui_label_duration.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            ui_label_duration.leadingAnchor.constraint(equalTo: tagContainer.trailingAnchor, constant: 10),
+            ui_label_duration.centerYAnchor.constraint(equalTo: tagContainer.centerYAnchor)
+        ])
     }
     
     func configure(pedago:PedagogicResource){
@@ -52,15 +73,22 @@ class HomeCellPedago:UITableViewCell{
         case .None:
             ui_label_title.text = "Autre"
         }
-        if let _duration = pedago.duration{
-            if _duration > 0 {
-                ui_label_duration.text = String(format: "home_v2_pedag_item_lenght_title".localized, _duration)
-            }else{
-                ui_label_duration.isHidden = true
-            }
-        }else{
-            ui_label_duration.isHidden = true
 
+        if let _duration = pedago.duration, _duration > 0 {
+            ui_label_duration.isHidden = false
+            let durationText = String(format: "home_v2_pedag_item_lenght_title".localized, _duration)
+
+            // Add clock icon using NSTextAttachment
+            let attachment = NSTextAttachment()
+            if let image = UIImage(systemName: "clock")?.withTintColor(.black, renderingMode: .alwaysOriginal) {
+                attachment.image = image
+                attachment.bounds = CGRect(x: 0, y: -2, width: 12, height: 12)
+            }
+            let completeText = NSMutableAttributedString(attachment: attachment)
+            completeText.append(NSAttributedString(string: " " + durationText))
+            ui_label_duration.attributedText = completeText
+        } else {
+            ui_label_duration.isHidden = true
         }
     }
 }

--- a/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.swift
@@ -1,0 +1,105 @@
+//
+//  HomeSolidarityToolsCell.swift
+//  entourage
+//
+//  Created by Clement entourage on 25/02/2026.
+//
+
+import UIKit
+
+protocol HomeSolidarityToolsCellDelegate: AnyObject {
+    func onMapTapped()
+    func onPedagoTapped()
+    func onEthicsTapped()
+}
+
+class HomeSolidarityToolsCell: UITableViewCell {
+
+    // MARK: - Outlets
+    @IBOutlet weak var ui_label_title: UILabel!
+    @IBOutlet weak var ui_stack_view: UIStackView!
+
+    @IBOutlet weak var ui_view_map: UIView!
+    @IBOutlet weak var ui_view_pedago: UIView!
+    @IBOutlet weak var ui_view_ethics: UIView!
+
+    @IBOutlet weak var ui_iv_map: UIImageView!
+    @IBOutlet weak var ui_iv_pedago: UIImageView!
+    @IBOutlet weak var ui_iv_ethics: UIImageView!
+
+    @IBOutlet weak var ui_lbl_map: UILabel!
+    @IBOutlet weak var ui_lbl_pedago: UILabel!
+    @IBOutlet weak var ui_lbl_ethics: UILabel!
+
+    // MARK: - Properties
+    weak var delegate: HomeSolidarityToolsCellDelegate?
+
+    class var identifier: String {
+        return String(describing: self)
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupUI()
+        setupTapGestures()
+    }
+
+    private func setupUI() {
+        ui_label_title.text = "home_v2_solidarity_tools_title".localized
+        ui_label_title.font = ApplicationTheme.getFontQuickSandBold(size: 15)
+        ui_label_title.textColor = .black
+
+        setupCard(view: ui_view_map, label: ui_lbl_map, image: ui_iv_map, title: "home_v2_tool_card_map".localized, iconName: "illu_map", systemIcon: "map.fill")
+        setupCard(view: ui_view_pedago, label: ui_lbl_pedago, image: ui_iv_pedago, title: "home_v2_tool_card_pedago".localized, iconName: "ic_book", systemIcon: "book.fill")
+        setupCard(view: ui_view_ethics, label: ui_lbl_ethics, image: ui_iv_ethics, title: "home_v2_tool_card_ethics".localized, iconName: "ic_handshake", systemIcon: "hand.raised.fill")
+    }
+
+    private func setupCard(view: UIView, label: UILabel, image: UIImageView, title: String, iconName: String, systemIcon: String) {
+        view.layer.cornerRadius = 14
+        view.backgroundColor = .white
+        view.layer.shadowColor = UIColor.black.cgColor
+        view.layer.shadowOpacity = 0.1
+        view.layer.shadowOffset = CGSize(width: 0, height: 2)
+        view.layer.shadowRadius = 4
+
+        label.text = title
+        label.font = ApplicationTheme.getFontNunitoBold(size: 12)
+        label.textColor = .black
+        label.numberOfLines = 0
+        label.textAlignment = .center
+
+        if let img = UIImage(named: iconName) {
+            image.image = img
+        } else {
+            image.image = UIImage(systemName: systemIcon)
+            image.tintColor = .appOrange
+        }
+        image.contentMode = .scaleAspectFit
+    }
+
+    private func setupTapGestures() {
+        let mapTap = UITapGestureRecognizer(target: self, action: #selector(handleMapTap))
+        ui_view_map.addGestureRecognizer(mapTap)
+        ui_view_map.isUserInteractionEnabled = true
+
+        let pedagoTap = UITapGestureRecognizer(target: self, action: #selector(handlePedagoTap))
+        ui_view_pedago.addGestureRecognizer(pedagoTap)
+        ui_view_pedago.isUserInteractionEnabled = true
+
+        let ethicsTap = UITapGestureRecognizer(target: self, action: #selector(handleEthicsTap))
+        ui_view_ethics.addGestureRecognizer(ethicsTap)
+        ui_view_ethics.isUserInteractionEnabled = true
+    }
+
+    @objc private func handleMapTap() {
+        delegate?.onMapTapped()
+    }
+
+    @objc private func handlePedagoTap() {
+        delegate?.onPedagoTapped()
+    }
+
+    @objc private func handleEthicsTap() {
+        delegate?.onEthicsTapped()
+    }
+}

--- a/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.xib
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.xib
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="HomeSolidarityToolsCell" rowHeight="160" id="KGk-i7-Jjw" customClass="HomeSolidarityToolsCell" customModule="entourage" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="160"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="160"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tes outils solidaires" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-Title">
+                        <rect key="frame" x="20" y="10" width="335" height="20"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="20" id="hTitle"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="stack-Tools">
+                        <rect key="frame" x="20" y="40" width="335" height="110"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="view-Map">
+                                <rect key="frame" x="0.0" y="0.0" width="105" height="110"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="img-Map">
+                                        <rect key="frame" x="27.666666666666671" y="15" width="50" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="50" id="wMap"/>
+                                            <constraint firstAttribute="height" constant="50" id="hMap"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Carte" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-Map">
+                                        <rect key="frame" x="5" y="70" width="95" height="35"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="img-Map" firstAttribute="centerX" secondItem="view-Map" secondAttribute="centerX" id="cenMap"/>
+                                    <constraint firstItem="img-Map" firstAttribute="top" secondItem="view-Map" secondAttribute="top" constant="15" id="topMap"/>
+                                    <constraint firstAttribute="trailing" secondItem="lbl-Map" secondAttribute="trailing" constant="5" id="trMap"/>
+                                    <constraint firstItem="lbl-Map" firstAttribute="leading" secondItem="view-Map" secondAttribute="leading" constant="5" id="ldMap"/>
+                                    <constraint firstItem="lbl-Map" firstAttribute="top" secondItem="img-Map" secondAttribute="bottom" constant="5" id="btmMap"/>
+                                    <constraint firstAttribute="bottom" secondItem="lbl-Map" secondAttribute="bottom" constant="5" id="btm2Map"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="view-Pedago">
+                                <rect key="frame" x="115" y="0.0" width="105" height="110"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="img-Pedago">
+                                        <rect key="frame" x="27.666666666666657" y="15" width="50" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="50" id="wPed"/>
+                                            <constraint firstAttribute="height" constant="50" id="hPed"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Contenus" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-Pedago">
+                                        <rect key="frame" x="5" y="70" width="95" height="35"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="img-Pedago" firstAttribute="centerX" secondItem="view-Pedago" secondAttribute="centerX" id="cenPed"/>
+                                    <constraint firstItem="img-Pedago" firstAttribute="top" secondItem="view-Pedago" secondAttribute="top" constant="15" id="topPed"/>
+                                    <constraint firstAttribute="trailing" secondItem="lbl-Pedago" secondAttribute="trailing" constant="5" id="trPed"/>
+                                    <constraint firstItem="lbl-Pedago" firstAttribute="leading" secondItem="view-Pedago" secondAttribute="leading" constant="5" id="ldPed"/>
+                                    <constraint firstItem="lbl-Pedago" firstAttribute="top" secondItem="img-Pedago" secondAttribute="bottom" constant="5" id="btmPed"/>
+                                    <constraint firstAttribute="bottom" secondItem="lbl-Pedago" secondAttribute="bottom" constant="5" id="btm2Ped"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="view-Ethics">
+                                <rect key="frame" x="230" y="0.0" width="105" height="110"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="img-Ethics">
+                                        <rect key="frame" x="27.666666666666686" y="15" width="50" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="50" id="wEth"/>
+                                            <constraint firstAttribute="height" constant="50" id="hEth"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Charte" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-Ethics">
+                                        <rect key="frame" x="5" y="70" width="95" height="35"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="img-Ethics" firstAttribute="centerX" secondItem="view-Ethics" secondAttribute="centerX" id="cenEth"/>
+                                    <constraint firstItem="img-Ethics" firstAttribute="top" secondItem="view-Ethics" secondAttribute="top" constant="15" id="topEth"/>
+                                    <constraint firstAttribute="trailing" secondItem="lbl-Ethics" secondAttribute="trailing" constant="5" id="trEth"/>
+                                    <constraint firstItem="lbl-Ethics" firstAttribute="leading" secondItem="view-Ethics" secondAttribute="leading" constant="5" id="ldEth"/>
+                                    <constraint firstItem="lbl-Ethics" firstAttribute="top" secondItem="img-Ethics" secondAttribute="bottom" constant="5" id="btmEth"/>
+                                    <constraint firstAttribute="bottom" secondItem="lbl-Ethics" secondAttribute="bottom" constant="5" id="btm2Eth"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="lbl-Title" secondAttribute="trailing" constant="20" id="trTitle"/>
+                    <constraint firstItem="lbl-Title" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="ldTitle"/>
+                    <constraint firstItem="lbl-Title" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="topTitle"/>
+                    <constraint firstItem="stack-Tools" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="ldStack"/>
+                    <constraint firstAttribute="trailing" secondItem="stack-Tools" secondAttribute="trailing" constant="20" id="trStack"/>
+                    <constraint firstItem="stack-Tools" firstAttribute="top" secondItem="lbl-Title" secondAttribute="bottom" constant="10" id="topStack"/>
+                    <constraint firstAttribute="bottom" secondItem="stack-Tools" secondAttribute="bottom" constant="10" id="btmStack"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="ui_iv_ethics" destination="img-Ethics" id="out-EthImg"/>
+                <outlet property="ui_iv_map" destination="img-Map" id="out-MapImg"/>
+                <outlet property="ui_iv_pedago" destination="img-Pedago" id="out-PedImg"/>
+                <outlet property="ui_label_title" destination="lbl-Title" id="out-Title"/>
+                <outlet property="ui_lbl_ethics" destination="lbl-Ethics" id="out-EthLbl"/>
+                <outlet property="ui_lbl_map" destination="lbl-Map" id="out-MapLbl"/>
+                <outlet property="ui_lbl_pedago" destination="lbl-Pedago" id="out-PedLbl"/>
+                <outlet property="ui_stack_view" destination="stack-Tools" id="out-Stack"/>
+                <outlet property="ui_view_ethics" destination="view-Ethics" id="out-EthView"/>
+                <outlet property="ui_view_map" destination="view-Map" id="out-MapView"/>
+                <outlet property="ui_view_pedago" destination="view-Pedago" id="out-PedView"/>
+            </connections>
+            <point key="canvasLocation" x="139.69465648854961" y="20.422535211267608"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellCreateSmallTalk.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellCreateSmallTalk.swift
@@ -18,12 +18,31 @@ class CellCreateSmallTalk:UICollectionViewCell{
     //VARIABLE
     
     override func awakeFromNib() {
-        ui_label_title.text = "small_talk_subtitle_match".localized
-        ui_label_title.setFontBody(size: 15)
-        configureOrangeButton(ui_btn, withTitle: "home_button_start".localized)
+        super.awakeFromNib()
+        setupUI()
         ui_btn.addTarget(self, action: #selector(onBtnClick), for: .touchUpInside)
     }
     
+    func setupUI() {
+        let titleText = "home_v2_small_talk_card_title".localized
+        let subtitleText = "home_v2_small_talk_card_subtitle".localized
+
+        let attributedString = NSMutableAttributedString(string: titleText + "\n", attributes: [
+            .font: ApplicationTheme.getFontQuickSandBold(size: 15),
+            .foregroundColor: UIColor.black
+        ])
+
+        attributedString.append(NSAttributedString(string: subtitleText, attributes: [
+            .font: ApplicationTheme.getFontNunitoRegular(size: 13),
+            .foregroundColor: UIColor.black
+        ]))
+
+        ui_label_title.attributedText = attributedString
+        ui_label_title.numberOfLines = 0
+
+        configureOrangeButton(ui_btn, withTitle: "home_v2_small_talk_card_button".localized)
+    }
+
     func configureOrangeButton(_ button: UIButton, withTitle title: String) {
         button.setTitle(title, for: .normal)
         button.backgroundColor = UIColor.appOrange


### PR DESCRIPTION
This PR updates the Home V2 screen based on the new design requirements.
It introduces a "Solidarity Tools" section with three horizontal cards (Map, Pedagogic Resources, Ethics Charter) replacing the previous buttons.
The Small Talk creation card is updated with new wording.
The Pedagogic Content list now displays 3 items with an updated horizontal layout (Image Left, Content Right).
Localized strings for French have been added.

---
*PR created automatically by Jules for task [11606689846029624731](https://jules.google.com/task/11606689846029624731) started by @clemPerrousset*