### PR TITLE
Fix Event Cancel Button Wording for Non-Author Admins

### DIFF
--- a/entourage/Scenes/Events/EventParamsViewController.swift
+++ b/entourage/Scenes/Events/EventParamsViewController.swift
@@ -345,7 +345,7 @@ extension EventParamsViewController: UITableViewDataSource, UITableViewDelegate 
                         isQuit: true,
                         hasCellBottom: false,
                         delegate: self,
-                        isCancelEvent: true
+                        isCancelEvent: self.isRealAuthor
                     )
                     return cell
                 }
@@ -356,7 +356,7 @@ extension EventParamsViewController: UITableViewDataSource, UITableViewDelegate 
                     isQuit: true,
                     hasCellBottom: false,
                     delegate: self,
-                    isCancelEvent: true
+                    isCancelEvent: self.isRealAuthor
                 )
                 return cell
             }


### PR DESCRIPTION
This PR fixes an issue where the "Cancel Event" button was shown to administrators who were not the original creators of the event. While admins have management rights, they cannot delete the event, only leave it. The button now correctly displays "Quitter l'événement" (Quit Event) for non-author admins, aligning the UI with the actual functionality. Only the original author will see "Annuler l'événement".

---
*PR created automatically by Jules for task [3414293264932952467](https://jules.google.com/task/3414293264932952467) started by @clemPerrousset*