### PR TITLE
Fix: Add birthdate to User CodingKeys

### DIFF
--- a/entourage/Models/User.swift
+++ b/entourage/Models/User.swift
@@ -123,6 +123,7 @@ struct User: Codable {
         case unreadCount = "unread_count"
         case radiusDistance = "travel_distance"
         case isBirthday = "birthday_today"
+        case birthdate
         case creationDateString = "created_at"
         case confirmedAt = "confirmed_at"
     }


### PR DESCRIPTION
Added `case birthdate` to `CodingKeys` in `User.swift` to fix issue where birthdate was not being saved/loaded from API and UserDefaults.

---
*PR created automatically by Jules for task [4590682406373566213](https://jules.google.com/task/4590682406373566213) started by @clemPerrousset*