### PR TITLE
Update Home V2 Moderator Card

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -1697,3 +1697,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_title_small_talk" = "انضم إلى مناقشة تضامنية";
 "small_talk_subtitle_match" = "نربطك بمجموعة صغيرة من الأشخاص الذين يشاركونك اهتماماتك، في أي مكان في فرنسا.";
 "Tomorrow" = "غدا";
+"home_v2_moderator_title_format" = "%@، جهة اتصالك المميزة";
+"home_v2_moderator_subtitle" = "أنا جزء من فريق Entourage وأنا هنا لمرافقتك. لا تتردد إذا كان لديك أي أسئلة! 🤗";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -1758,3 +1758,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_title_small_talk" = "An einer solidarischen Diskussion teilnehmen";
 "small_talk_subtitle_match" = "Wir verbinden Sie mit einer kleinen Gruppe von Menschen, die Ihre Interessen teilen, überall in Frankreich.";
 "Tomorrow" = "Morgen";
+"home_v2_moderator_title_format" = "%@, Ihr privilegierter Kontakt";
+"home_v2_moderator_subtitle" = "Ich gehöre zum Entourage-Team und bin hier, um Sie zu unterstützen. Zögern Sie nicht, wenn Sie Fragen haben! 🤗";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -1964,3 +1964,5 @@
 "event_create_reserved_female_title" = "Is this event reserved for women?";
 "event_create_reserved_female_info" = "The event will only be visible to female users of the application.";
 "event_detail_reserved_female_label" = "This event is reserved for women";
+"home_v2_moderator_title_format" = "%@, your privileged contact";
+"home_v2_moderator_subtitle" = "I am part of the Entourage team and I am here to support you. Do not hesitate if you have any questions! 🤗";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -3181,3 +3181,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_title_small_talk" = "Únete a una discusión solidaria";
 "small_talk_subtitle_match" = "Te conectamos con un pequeño grupo de personas que comparten tus intereses, en cualquier lugar de Francia.";
 "Tomorrow" = "Mañana";
+"home_v2_moderator_title_format" = "%@, tu contacto privilegiado";
+"home_v2_moderator_subtitle" = "Formo parte del equipo de Entourage y estoy aquí para acompañarte. ¡No dudes en preguntar si tienes alguna duda! 🤗";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1962,3 +1962,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_tool_card_map" = "Carte des lieux solidaires";
 "home_v2_tool_card_pedago" = "Contenus pour apprendre et agir";
 "home_v2_tool_card_ethics" = "Charte éthique Entourage";
+"home_v2_moderator_title_format" = "%@, ton contact privilégié";
+"home_v2_moderator_subtitle" = "Je fais parti·e de l'équipe Entourage et je suis là pour t'accompagner. N'hésite pas si tu as des questions ! 🤗";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -1772,3 +1772,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_title_small_talk" = "Dołącz do dyskusji solidarnościowej";
 "small_talk_subtitle_match" = "Łączymy Cię z małą grupą osób o podobnych zainteresowaniach, w całej Francji.";
 "Tomorrow" = "Jutro";
+"home_v2_moderator_title_format" = "%@, twój uprzywilejowany kontakt";
+"home_v2_moderator_subtitle" = "Jestem częścią zespołu Entourage i jestem tutaj, aby ci towarzyszyć. Nie wahaj się, jeśli masz pytania! 🤗";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -1661,3 +1661,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_title_small_talk" = "Alătură-te unei discuții solidare";
 "small_talk_subtitle_match" = "Te conectăm cu un grup mic de oameni care îți împărtășesc interesele, oriunde în Franța.";
 "Tomorrow" = "Mâine";
+"home_v2_moderator_title_format" = "%@, contactul tău privilegiat";
+"home_v2_moderator_subtitle" = "Fac parte din echipa Entourage și sunt aici să te însoțesc. Nu ezita dacă ai întrebări! 🤗";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -1738,3 +1738,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_title_small_talk" = "Приєднуйтесь до солідарної дискусії";
 "small_talk_subtitle_match" = "Ми з'єднуємо вас з невеликою групою людей, які поділяють ваші інтереси, по всій Франції.";
 "Tomorrow" = "Завтра";
+"home_v2_moderator_title_format" = "%@, твій привілейований контакт";
+"home_v2_moderator_subtitle" = "Я є частиною команди Entourage і тут, щоб супроводжувати тебе. Не соромся, якщо у тебе є питання! 🤗";

--- a/entourage/Scenes/HomeV2/HomeV2ViewController.swift
+++ b/entourage/Scenes/HomeV2/HomeV2ViewController.swift
@@ -435,6 +435,12 @@ class HomeV2ViewController: UIViewController {
             tableDTO.append(.cellSeeAll(seeAllType: .seeAllEvent))
         }
 
+        if let _moderator = userHome.moderator {
+            if let _name = _moderator.displayName {
+                tableDTO.append(.moderator(name: _name, imageUrl: _moderator.imgUrl))
+            }
+        }
+
         var _offlineEvents = [Event]()
         for event in allEvents {
             if event.isOnline == false {
@@ -462,12 +468,6 @@ class HomeV2ViewController: UIViewController {
 //            tableDTO.append(.cellSeeAll(seeAllType: .seeAllGroup))
 //        }
         
-        tableDTO.append(.cellTitle(title: "home_v2_title_help".localized, subtitle: "home_v2_subtitle_help".localized))
-        if let _moderator = userHome.moderator {
-            if let _name = _moderator.displayName {
-                tableDTO.append(.moderator(name: _name, imageUrl: _moderator.imgUrl))
-            }
-        }
         self.ui_table_view.reloadData()
         self.handleEnhancedOnboardingReturn()
         SVProgressHUD.dismiss()
@@ -667,7 +667,11 @@ extension HomeV2ViewController: UITableViewDelegate, UITableViewDataSource {
             if let _moderator = self.userHome.moderator {
                 AnalyticsLoggerManager.logEvent(name: Action__Home__Moderator)
                 if let _id = _moderator.id {
-                    showUserProfile(id: _id)
+                    MessagingService.createOrGetConversation(userId: String(_id)) { conversation, error in
+                        if let conversation = conversation {
+                            DeepLinkManager.showConversation(conversationId: conversation.uid)
+                        }
+                    }
                 }
             }
         case .cellHZ:

--- a/entourage/Scenes/HomeV2/homev2cells/HomeModeratorCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeModeratorCell.swift
@@ -15,6 +15,7 @@ class HomeModeratorCell:UITableViewCell{
     @IBOutlet weak var containerView: UIView!
     
     @IBOutlet weak var ui_label_title: UILabel!
+    @IBOutlet weak var ui_label_description: UILabel!
     @IBOutlet weak var ui_image: UIImageView!
     //VARIABLE
     class var identifier: String {
@@ -22,23 +23,32 @@ class HomeModeratorCell:UITableViewCell{
     }
     
     override func awakeFromNib() {
+        super.awakeFromNib()
         self.contentView.backgroundColor = UIColor(named: "white_orange_home")
-        let gradientLayer = CAGradientLayer()
-        gradientLayer.frame = containerView.bounds
 
-        // Convertir les valeurs hexadécimales en UIColor
-        let color1 = UIColor(hexString: "#F55F24")
-        let color2 = UIColor(hexString: "#FF9C5D")
+        // Remove old gradient layer
+        containerView.layer.sublayers?.filter { $0 is CAGradientLayer }.forEach { $0.removeFromSuperlayer() }
 
-        gradientLayer.colors = [color1.cgColor, color2.cgColor]
-        gradientLayer.startPoint = CGPoint(x: 0, y: 0)
-        gradientLayer.endPoint = CGPoint(x: 1, y: 1)
-        containerView.layer.insertSublayer(gradientLayer, at: 0)
+        // Apply shadow/card style
+        containerView.backgroundColor = .white
+        containerView.layer.cornerRadius = 15
+        containerView.layer.shadowColor = UIColor.black.cgColor
+        containerView.layer.shadowOpacity = 0.1
+        containerView.layer.shadowOffset = CGSize(width: 0, height: 2)
+        containerView.layer.shadowRadius = 4
 
+        ui_label_title.font = UIFont(name: "Quicksand-Bold", size: 15)
+        ui_label_title.textColor = UIColor(named: "black_app")
+
+        ui_label_description.font = UIFont(name: "Quicksand-Regular", size: 13)
+        ui_label_description.textColor = UIColor(named: "black_app")
     }
     
     func configure(title:String, imageUrl:String? = nil){
-        self.ui_label_title.text = "home_v2_help_title_three".localized + " " + title
+        let titleFormat = "home_v2_moderator_title_format".localized
+        self.ui_label_title.text = String(format: titleFormat, title)
+        self.ui_label_description.text = "home_v2_moderator_subtitle".localized
+
         if let _urlImageString = imageUrl{
             if let mainUrl = URL(string: _urlImageString) {
                 self.updateImage(mainUrl: mainUrl)

--- a/entourage/Scenes/HomeV2/homev2cells/HomeModeratorCell.xib
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeModeratorCell.xib
@@ -11,56 +11,61 @@
         <array key="Quicksand-Bold.ttf">
             <string>Quicksand-Bold</string>
         </array>
+        <array key="Quicksand-Regular.ttf">
+            <string>Quicksand-Regular</string>
+        </array>
     </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="HomeModeratorCell" rowHeight="197" id="geW-xp-TH0" customClass="HomeModeratorCell" customModule="Ent_Beta" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="567" height="114"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="HomeModeratorCell" rowHeight="130" id="geW-xp-TH0" customClass="HomeModeratorCell" customModule="Ent_Beta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="567" height="130"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="geW-xp-TH0" id="StR-XD-kBu">
-                <rect key="frame" x="0.0" y="0.0" width="567" height="114"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="geW-xp-TH0" id="StR-XD-kBu">
+                <rect key="frame" x="0.0" y="0.0" width="567" height="130"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zPb-0Z-MjV">
-                        <rect key="frame" x="16" y="10" width="535" height="65"/>
+                        <rect key="frame" x="20" y="10" width="527" height="110"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qcV-DB-YFJ">
-                                <rect key="frame" x="16" y="20.666666666666671" width="24" height="24"/>
+                                <rect key="frame" x="16" y="32" width="46" height="46"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="24" id="bGS-0f-7ay"/>
-                                    <constraint firstAttribute="width" constant="24" id="cH2-W3-AMK"/>
+                                    <constraint firstAttribute="height" constant="46" id="bGS-0f-7ay"/>
+                                    <constraint firstAttribute="width" constant="46" id="cH2-W3-AMK"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="cradius">
-                                        <real key="value" value="12"/>
+                                        <real key="value" value="23"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eAW-wQ-Gw9">
-                                <rect key="frame" x="50" y="23.666666666666664" width="435" height="17.666666666666664"/>
-                                <fontDescription key="fontDescription" name="Quicksand-Bold" family="Quicksand" pointSize="14"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_white_arrow_right_home_v2" translatesAutoresizingMaskIntoConstraints="NO" id="F5J-6D-OBA">
-                                <rect key="frame" x="500" y="25" width="10" height="15"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="10" id="gxe-vq-rDC"/>
-                                    <constraint firstAttribute="height" constant="15" id="qo3-Lh-tru"/>
-                                </constraints>
-                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="stackView">
+                                <rect key="frame" x="78" y="16" width="433" height="78"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eAW-wQ-Gw9">
+                                        <rect key="frame" x="0.0" y="0.0" width="433" height="17.666666666666668"/>
+                                        <fontDescription key="fontDescription" name="Quicksand-Bold" family="Quicksand" pointSize="15"/>
+                                        <color key="textColor" name="black_app"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Message" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="msg-Label-ID">
+                                        <rect key="frame" x="0.0" y="21.666666666666664" width="433" height="56.333333333333336"/>
+                                        <fontDescription key="fontDescription" name="Quicksand-Regular" family="Quicksand" pointSize="13"/>
+                                        <color key="textColor" name="black_app"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
                         </subviews>
-                        <color key="backgroundColor" name="orange_app"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="65" id="7fR-0i-lnz"/>
-                            <constraint firstItem="F5J-6D-OBA" firstAttribute="centerY" secondItem="zPb-0Z-MjV" secondAttribute="centerY" id="GaW-xm-ykz"/>
-                            <constraint firstItem="eAW-wQ-Gw9" firstAttribute="centerY" secondItem="qcV-DB-YFJ" secondAttribute="centerY" id="Nrv-Ru-5ej"/>
-                            <constraint firstAttribute="trailing" secondItem="F5J-6D-OBA" secondAttribute="trailing" constant="25" id="O6f-Xh-ri9"/>
                             <constraint firstItem="qcV-DB-YFJ" firstAttribute="centerY" secondItem="zPb-0Z-MjV" secondAttribute="centerY" id="ikh-Hs-bbZ"/>
-                            <constraint firstAttribute="trailing" secondItem="eAW-wQ-Gw9" secondAttribute="trailing" constant="50" id="nNi-f1-WAU"/>
-                            <constraint firstItem="eAW-wQ-Gw9" firstAttribute="leading" secondItem="qcV-DB-YFJ" secondAttribute="trailing" constant="10" id="nkO-fw-CvB"/>
+                            <constraint firstItem="stackView" firstAttribute="leading" secondItem="qcV-DB-YFJ" secondAttribute="trailing" constant="16" id="nkO-fw-CvB"/>
                             <constraint firstItem="qcV-DB-YFJ" firstAttribute="leading" secondItem="zPb-0Z-MjV" secondAttribute="leading" constant="16" id="suz-ac-P9W"/>
+                            <constraint firstAttribute="trailing" secondItem="stackView" secondAttribute="trailing" constant="16" id="stack-trailing"/>
+                            <constraint firstItem="stackView" firstAttribute="top" secondItem="zPb-0Z-MjV" secondAttribute="top" constant="16" id="stack-top"/>
+                            <constraint firstAttribute="bottom" secondItem="stackView" secondAttribute="bottom" constant="16" id="stack-bottom"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="number" keyPath="cradius">
@@ -71,24 +76,24 @@
                 </subviews>
                 <color key="backgroundColor" name="white_orange_home"/>
                 <constraints>
-                    <constraint firstItem="zPb-0Z-MjV" firstAttribute="leading" secondItem="StR-XD-kBu" secondAttribute="leading" constant="16" id="1b8-98-lef"/>
+                    <constraint firstItem="zPb-0Z-MjV" firstAttribute="leading" secondItem="StR-XD-kBu" secondAttribute="leading" constant="20" id="1b8-98-lef"/>
                     <constraint firstItem="zPb-0Z-MjV" firstAttribute="top" secondItem="StR-XD-kBu" secondAttribute="top" constant="10" id="O2p-Il-Lmx"/>
-                    <constraint firstAttribute="trailing" secondItem="zPb-0Z-MjV" secondAttribute="trailing" constant="16" id="OYa-6m-Vrx"/>
-                    <constraint firstAttribute="bottom" secondItem="zPb-0Z-MjV" secondAttribute="bottom" constant="28" id="oyA-ME-QtK"/>
+                    <constraint firstAttribute="trailing" secondItem="zPb-0Z-MjV" secondAttribute="trailing" constant="20" id="OYa-6m-Vrx"/>
+                    <constraint firstAttribute="bottom" secondItem="zPb-0Z-MjV" secondAttribute="bottom" constant="10" id="oyA-ME-QtK"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
                 <outlet property="containerView" destination="zPb-0Z-MjV" id="xit-Tx-Jno"/>
                 <outlet property="ui_image" destination="qcV-DB-YFJ" id="iwA-s3-eGB"/>
                 <outlet property="ui_label_title" destination="eAW-wQ-Gw9" id="yRq-6P-qja"/>
+                <outlet property="ui_label_description" destination="msg-Label-ID" id="desc-outlet-id"/>
             </connections>
             <point key="canvasLocation" x="223.66412213740458" y="40.845070422535215"/>
         </tableViewCell>
     </objects>
     <resources>
-        <image name="ic_white_arrow_right_home_v2" width="11" height="16"/>
-        <namedColor name="orange_app">
-            <color red="0.96078431372549022" green="0.37254901960784315" blue="0.14117647058823529" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <namedColor name="black_app">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="white_orange_home">
             <color red="1" green="0.9882352941176471" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
This change updates the moderator card on the Home V2 screen. The card's wording has been changed to "Prénom du modé, ton contact privilégié" and a new welcoming message. The card is now positioned directly below the events section. Tapping the card now redirects the user to a conversation with the moderator instead of their profile. The UI has also been updated to a cleaner white card design.

---
*PR created automatically by Jules for task [1576830520922248428](https://jules.google.com/task/1576830520922248428) started by @clemPerrousset*