### PR TITLE
feat: Update pedago tags with dynamic colors

### DIFF
--- a/entourage/Scenes/HomeV2/homev2cells/HomeCellPedago.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeCellPedago.swift
@@ -14,6 +14,7 @@ class HomeCellPedago:UITableViewCell{
     //OUTLET
     @IBOutlet weak var containerView: UIView!
     @IBOutlet weak var ui_image: UIImageView!
+    @IBOutlet weak var ui_view_tag_container: UIView!
     @IBOutlet weak var ui_label_pedago: UILabel!
     @IBOutlet weak var ui_label_title: UILabel!
     
@@ -36,7 +37,7 @@ class HomeCellPedago:UITableViewCell{
     }
 
     private func repositionDurationLabel() {
-        guard let tagContainer = ui_label_pedago.superview else { return }
+        guard let tagContainer = ui_view_tag_container else { return }
 
         // Remove existing constraints on ui_label_duration
         // It's a direct child of containerView, so constraints are held by containerView
@@ -61,17 +62,28 @@ class HomeCellPedago:UITableViewCell{
         else {
             ui_image.image = UIImage(named: "placeholder_action")
         }
-        switch pedago.tag{
+
+        switch pedago.tag {
         case .All:
             ui_label_pedago.text = "home_v2_pedago_item_tag_all".localized
+            ui_label_pedago.textColor = UIColor.orange_light
+            ui_view_tag_container.backgroundColor = UIColor.appBeigeLighter
         case .Understand:
             ui_label_pedago.text = "home_v2_pedago_item_tag_understand".localized
+            ui_label_pedago.textColor = UIColor.appTagUnderstand
+            ui_view_tag_container.backgroundColor = UIColor.appTagUnderstandBackground
         case .Act:
             ui_label_pedago.text = "home_v2_pedago_item_tag_act".localized
+            ui_label_pedago.textColor = UIColor.appTagAct
+            ui_view_tag_container.backgroundColor = UIColor.appTagActBackground
         case .Inspire:
             ui_label_pedago.text = "home_v2_pedago_item_tag_inspire".localized
+            ui_label_pedago.textColor = UIColor.appTagInspire
+            ui_view_tag_container.backgroundColor = UIColor.appTagInspireBackground
         case .None:
             ui_label_title.text = "Autre"
+            ui_label_pedago.textColor = UIColor.orange_light
+            ui_view_tag_container.backgroundColor = UIColor.appBeigeLighter
         }
 
         if let _duration = pedago.duration, _duration > 0 {

--- a/entourage/Scenes/HomeV2/homev2cells/HomeCellPedago.xib
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeCellPedago.xib
@@ -111,6 +111,7 @@ Label</string>
                 <outlet property="ui_label_duration" destination="EUc-UL-CfJ" id="pWY-xi-RMx"/>
                 <outlet property="ui_label_pedago" destination="WBt-j9-VNQ" id="oRq-qX-zRk"/>
                 <outlet property="ui_label_title" destination="paw-8t-e1g" id="OHF-Bc-Iku"/>
+                <outlet property="ui_view_tag_container" destination="pnT-2M-wbY" id="ABC-12-XYZ"/>
             </connections>
             <point key="canvasLocation" x="150" y="-22"/>
         </tableViewCell>

--- a/entourage/Tools/Extensions/Extensions_UIColor.swift
+++ b/entourage/Tools/Extensions/Extensions_UIColor.swift
@@ -139,6 +139,15 @@ extension UIColor {
     static var appGreyOff: UIColor {
         return UIColor(named: "grey_off") ?? .red
     }
+
+    //MARK: - Tag colors -
+    static var appTagInspire: UIColor { return UIColor(hexString: "#D4A000") }
+    static var appTagInspireBackground: UIColor { return UIColor(hexString: "#FFF8DE") }
+    static var appTagAct: UIColor { return UIColor(hexString: "#4DA865") }
+    static var appTagActBackground: UIColor { return UIColor(hexString: "#E5F6E8") }
+    static var appTagUnderstand: UIColor { return UIColor(hexString: "#3F6AD7") }
+    static var appTagUnderstandBackground: UIColor { return UIColor(hexString: "#E3EBFF") }
+
     convenience init(hexString: String) {
         let scanner = Scanner(string: hexString.trimmingCharacters(in: CharacterSet.alphanumerics.inverted))
         var hexNumber: UInt64 = 0


### PR DESCRIPTION
This change updates the pedagogy tags on the Home V2 screen to use specific colors based on their category (Inspire, Act, Understand), matching the new design requirements. It introduces new color extensions and refactors the cell to apply these styles dynamically.

---
*PR created automatically by Jules for task [8964618000716936196](https://jules.google.com/task/8964618000716936196) started by @clemPerrousset*