### PR TITLE
Refactor Home V2 Action cards into a horizontal carousel

### DIFF
--- a/entourage/Scenes/HomeV2/HomeV2ViewController.swift
+++ b/entourage/Scenes/HomeV2/HomeV2ViewController.swift
@@ -22,7 +22,7 @@ enum seeAllCellType {
 
 enum HomeV2DTO {
     case cellTitle(title: String, subtitle: String)
-    case cellAction(action: Action)
+    case cellAction(actions: [Action])
     case cellSeeAll(seeAllType: seeAllCellType)
     case cellEvent(events: [Event])
     case cellGroup(groups: [Neighborhood])
@@ -93,6 +93,7 @@ class HomeV2ViewController: UIViewController {
         ui_table_view.register(UINib(nibName: HomeSeeAllCell.identifier, bundle: nil), forCellReuseIdentifier: HomeSeeAllCell.identifier)
         ui_table_view.register(UINib(nibName: HomeCellMapButton.identifier, bundle: nil), forCellReuseIdentifier: HomeCellMapButton.identifier)
         ui_table_view.register(UINib(nibName: HomeCellAction.identifier, bundle: nil), forCellReuseIdentifier: HomeCellAction.identifier)
+        ui_table_view.register(UINib(nibName: HomeActionHorizontalCollectionCell.identifier, bundle: nil), forCellReuseIdentifier: HomeActionHorizontalCollectionCell.identifier)
         ui_table_view.register(UINib(nibName: HomeEventHorizontalCollectionCell.identifier, bundle: nil), forCellReuseIdentifier: HomeEventHorizontalCollectionCell.identifier)
         ui_table_view.register(UINib(nibName: HomeGroupHorizontalCollectionCell.identifier, bundle: nil), forCellReuseIdentifier: HomeGroupHorizontalCollectionCell.identifier)
         ui_table_view.register(UINib(nibName: HomeCellPedago.identifier, bundle: nil), forCellReuseIdentifier: HomeCellPedago.identifier)
@@ -417,15 +418,11 @@ class HomeV2ViewController: UIViewController {
         if (allDemands.count > 0) {
             if isContributionPreference {
                 tableDTO.append(.cellTitle(title: "home_v2_title_action_contrib".localized, subtitle: "home_v2_subtitle_action_contrib".localized))
-                for demand in allDemands {
-                    tableDTO.append(.cellAction(action: demand))
-                }
+                tableDTO.append(.cellAction(actions: allDemands))
                 tableDTO.append(.cellSeeAll(seeAllType: .seeAllDemand))
             } else {
                 tableDTO.append(.cellTitle(title: "home_v2_title_action".localized, subtitle: "home_v2_subtitle_action".localized))
-                for demand in allDemands {
-                    tableDTO.append(.cellAction(action: demand))
-                }
+                tableDTO.append(.cellAction(actions: allDemands))
                 tableDTO.append(.cellSeeAll(seeAllType: .seeAllDemand))
             }
         }
@@ -510,10 +507,11 @@ extension HomeV2ViewController: UITableViewDelegate, UITableViewDataSource {
                 cell.configure(title: title, subtitle: subtitle)
                 return cell
             }
-        case .cellAction(let action):
-            if let cell = ui_table_view.dequeueReusableCell(withIdentifier: "HomeCellAction") as? HomeCellAction {
+        case .cellAction(let actions):
+            if let cell = ui_table_view.dequeueReusableCell(withIdentifier: HomeActionHorizontalCollectionCell.identifier) as? HomeActionHorizontalCollectionCell {
                 cell.selectionStyle = .none
-                cell.configure(action: action)
+                cell.delegate = self
+                cell.configure(actions: actions)
                 return cell
             }
         case .cellSeeAll(let seeAllType):
@@ -617,13 +615,7 @@ extension HomeV2ViewController: UITableViewDelegate, UITableViewDataSource {
         case .cellTitle(_, _):
             return
         case .cellAction(let action):
-            if isContributionPreference {
-                AnalyticsLoggerManager.logEvent(name: Action_Home_Contrib_Detail)
-                self.showAction(actionId: action.id, isContrib: true, action: action)
-            } else {
-                AnalyticsLoggerManager.logEvent(name: Action_Home_Demand_Detail)
-                self.showAction(actionId: action.id, isContrib: false, action: action)
-            }
+            return
         case .cellSeeAll(let seeAllType):
             switch seeAllType {
             case .seeAllDemand:
@@ -691,7 +683,7 @@ extension HomeV2ViewController: UITableViewDelegate, UITableViewDataSource {
         case .cellTitle(_, _):
             return UITableView.automaticDimension
         case .cellAction(_):
-            return UITableView.automaticDimension
+            return 215
         case .cellSeeAll(_):
             return UITableView.automaticDimension
         case .cellEvent(_):
@@ -1520,4 +1512,15 @@ extension HomeV2ViewController {
     }
 }
 
-
+// MARK: - HomeActionHCCDelegate
+extension HomeV2ViewController: HomeActionHCCDelegate {
+    func goToMyActionHomeCell(action: Action) {
+        if isContributionPreference {
+            AnalyticsLoggerManager.logEvent(name: Action_Home_Contrib_Detail)
+            self.showAction(actionId: action.id, isContrib: true, action: action)
+        } else {
+            AnalyticsLoggerManager.logEvent(name: Action_Home_Demand_Detail)
+            self.showAction(actionId: action.id, isContrib: false, action: action)
+        }
+    }
+}

--- a/entourage/Scenes/HomeV2/homev2cells/HomeActionHorizontalCollectionCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeActionHorizontalCollectionCell.swift
@@ -1,0 +1,93 @@
+//
+//  HomeActionHorizontalCollectionCell.swift
+//  entourage
+//
+//  Created by Clement entourage on 13/10/2023.
+//
+
+import UIKit
+
+protocol HomeActionHCCDelegate: AnyObject {
+    func goToMyActionHomeCell(action: Action)
+}
+
+enum HomeActionCollectionDTO {
+    case actionCell(action: Action)
+}
+
+class HomeActionHorizontalCollectionCell: UITableViewCell {
+
+    // OUTLET
+    @IBOutlet weak var ui_collection_view: UICollectionView!
+
+    // VARIABLE
+    class var identifier: String {
+        return String(describing: self)
+    }
+
+    var tableDTO = [HomeActionCollectionDTO]()
+    weak var delegate: HomeActionHCCDelegate?
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        self.contentView.backgroundColor = UIColor(named: "white_orange_home")
+
+        ui_collection_view.delegate = self
+        ui_collection_view.dataSource = self
+        ui_collection_view.showsHorizontalScrollIndicator = false
+        ui_collection_view.backgroundColor = .clear
+
+        // Register the new collection view cell
+        ui_collection_view.register(UINib(nibName: HomeCellActionCollectionViewCell.identifier, bundle: nil), forCellWithReuseIdentifier: HomeCellActionCollectionViewCell.identifier)
+
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.minimumLineSpacing = 16 // Spacing between cards
+        ui_collection_view.setCollectionViewLayout(layout, animated: true)
+        ui_collection_view.contentInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+    }
+
+    func configure(actions: [Action]) {
+        tableDTO.removeAll()
+        for action in actions {
+            tableDTO.append(.actionCell(action: action))
+        }
+        ui_collection_view.reloadData()
+    }
+}
+
+extension HomeActionHorizontalCollectionCell: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return tableDTO.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        switch tableDTO[indexPath.row] {
+        case .actionCell(let action):
+            if let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeCellActionCollectionViewCell.identifier, for: indexPath) as? HomeCellActionCollectionViewCell {
+                cell.configure(action: action)
+                return cell
+            }
+        }
+        return UICollectionViewCell()
+    }
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        // Requirement: "Voir 1 card entière et 1/4 de la 2ème card en proportion"
+        // Screen width - left padding (16) - right padding (16) - inter item spacing (16)
+        // Let's approximate. Standard width for carousel cards often takes ~80-85% of screen width.
+        // Assuming iPhone width 375 (SE) or 390 (12/13/14).
+        // Let's try 280-300 width for a good balance or dynamic calculation.
+        // Dynamic: (UIScreen.main.bounds.width - 32) * 0.85
+        let width = (UIScreen.main.bounds.width - 32) * 0.85
+        return CGSize(width: width, height: 215) // Fixed height to match Event carousel or adjusted as needed
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        switch tableDTO[indexPath.row] {
+        case .actionCell(let action):
+            AnalyticsLoggerManager.logEvent(name: Action_Home_Demand_Detail) // Log click
+            delegate?.goToMyActionHomeCell(action: action)
+        }
+    }
+}

--- a/entourage/Scenes/HomeV2/homev2cells/HomeActionHorizontalCollectionCell.xib
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeActionHorizontalCollectionCell.xib
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="HomeActionHorizontalCollectionCell" rowHeight="207" id="2mG-jO-Huu" customClass="HomeActionHorizontalCollectionCell" customModule="Ent_Beta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="669" height="207"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2mG-jO-Huu" id="vDO-Da-VjE">
+                <rect key="frame" x="0.0" y="0.0" width="669" height="207"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="13H-LX-KCU">
+                        <rect key="frame" x="0.0" y="0.0" width="669" height="207"/>
+                        <color key="backgroundColor" name="white_orange_home"/>
+                        <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="VCW-mn-WlH">
+                            <size key="itemSize" width="128" height="128"/>
+                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                        </collectionViewFlowLayout>
+                    </collectionView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="13H-LX-KCU" firstAttribute="leading" secondItem="vDO-Da-VjE" secondAttribute="leading" id="2MF-0v-MbI"/>
+                    <constraint firstAttribute="bottom" secondItem="13H-LX-KCU" secondAttribute="bottom" id="WcL-Di-BcX"/>
+                    <constraint firstAttribute="trailing" secondItem="13H-LX-KCU" secondAttribute="trailing" id="mF2-yE-Ma2"/>
+                    <constraint firstItem="13H-LX-KCU" firstAttribute="top" secondItem="vDO-Da-VjE" secondAttribute="top" id="osd-s1-GiA"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="ui_collection_view" destination="13H-LX-KCU" id="FOq-gX-fgy"/>
+            </connections>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <namedColor name="white_orange_home">
+            <color red="1" green="0.9882352941176471" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/entourage/Scenes/HomeV2/homev2cells/HomeCellActionCollectionViewCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeCellActionCollectionViewCell.swift
@@ -1,0 +1,105 @@
+//
+//  HomeCellActionCollectionViewCell.swift
+//  entourage
+//
+//  Created by Clement entourage on 13/10/2023.
+//
+
+import UIKit
+import SDWebImage
+
+class HomeCellActionCollectionViewCell: UICollectionViewCell {
+
+    // OUTLET
+    @IBOutlet weak var containerView: UIView!
+    @IBOutlet weak var ui_image_user: UIImageView!
+    @IBOutlet weak var ui_label_username: UILabel!
+    @IBOutlet weak var ui_view_tag: UIView!
+    @IBOutlet weak var ui_label_tag: UILabel!
+    @IBOutlet weak var ui_label_title: UILabel!
+    @IBOutlet weak var ui_label_description: UILabel!
+    @IBOutlet weak var ui_image_pin: UIImageView!
+    @IBOutlet weak var ui_label_distance: UILabel!
+
+    // VARIABLE
+    class var identifier: String {
+        return String(describing: self)
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupUI()
+    }
+
+    func setupUI() {
+        containerView.layer.cornerRadius = 16
+        containerView.layer.borderWidth = 1
+        containerView.layer.borderColor = UIColor.appBeige.cgColor
+        containerView.backgroundColor = .white
+
+        ui_image_user.layer.cornerRadius = ui_image_user.frame.height / 2
+        ui_image_user.layer.borderWidth = 1
+        ui_image_user.layer.borderColor = UIColor.appOrange.cgColor
+        ui_image_user.clipsToBounds = true
+
+        ui_view_tag.layer.cornerRadius = ui_view_tag.frame.height / 2
+        ui_view_tag.backgroundColor = UIColor.appBeige
+
+        ui_label_username.font = UIFont(name: "Quicksand-Bold", size: 15)
+        ui_label_username.textColor = .black
+
+        ui_label_tag.font = UIFont(name: "NunitoSans-Regular", size: 11)
+        ui_label_tag.textColor = UIColor.appOrange
+
+        ui_label_title.font = UIFont(name: "Quicksand-Bold", size: 15)
+        ui_label_title.textColor = .black
+        ui_label_title.numberOfLines = 2
+
+        ui_label_description.font = UIFont(name: "NunitoSans-Regular", size: 13)
+        ui_label_description.textColor = UIColor.lightGray
+        ui_label_description.numberOfLines = 3
+
+        ui_label_distance.font = UIFont(name: "NunitoSans-Regular", size: 11)
+        ui_label_distance.textColor = UIColor.appOrange
+
+        ui_image_pin.tintColor = UIColor.appOrange
+    }
+
+    func configure(action: Action) {
+        // User Image
+        if let imageUrl = action.author?.avatarURL, !imageUrl.isEmpty, let mainUrl = URL(string: imageUrl) {
+            ui_image_user.sd_setImage(with: mainUrl, placeholderImage: UIImage(named: "placeholder_user"))
+        } else {
+            ui_image_user.image = UIImage(named: "placeholder_user")
+        }
+
+        // Username
+        ui_label_username.text = action.author?.displayName ?? "-"
+
+        // Tag
+        if let sectionName = action.sectionName {
+            ui_label_tag.text = TagsUtils.showTagTranslated(sectionName)
+        } else {
+            ui_label_tag.text = "-"
+        }
+
+        // Title
+        ui_label_title.text = action.title
+
+        // Description
+        if let desc = action.description, !desc.isEmpty {
+            let first = desc.prefix(1).uppercased()
+            let other = desc.dropFirst()
+            ui_label_description.text = first + other
+        } else {
+            ui_label_description.text = ""
+        }
+
+        // Distance
+        if let distance = action.distance {
+            ui_label_distance.text = Utils.displayDistance(distance: distance) + " de moi"
+        } else {
+            ui_label_distance.text = "-"
+        }
+    }
+}

--- a/entourage/Scenes/HomeV2/homev2cells/HomeCellActionCollectionViewCell.xib
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeCellActionCollectionViewCell.xib
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeCellActionCollectionViewCell" id="2mG-jO-Huu" customClass="HomeCellActionCollectionViewCell" customModule="Ent_Beta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="220" height="200"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="vDO-Da-VjE">
+                <rect key="frame" x="0.0" y="0.0" width="220" height="200"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="13H-LX-KCU">
+                        <rect key="frame" x="0.0" y="0.0" width="220" height="200"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="A8d-L1-k9f">
+                                <rect key="frame" x="16" y="16" width="50" height="50"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="50" id="K10-90-K8L"/>
+                                    <constraint firstAttribute="height" constant="50" id="M10-80-M9L"/>
+                                </constraints>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B9d-L2-l0g">
+                                <rect key="frame" x="74" y="20" width="138" height="20"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C0d-L3-m1h">
+                                <rect key="frame" x="74" y="44" width="60" height="22"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D1e-L4-n2i">
+                                        <rect key="frame" x="8" y="2" width="44" height="18"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="D1e-L4-n2i" firstAttribute="leading" secondItem="C0d-L3-m1h" secondAttribute="leading" constant="8" id="E2f-G5-H3j"/>
+                                    <constraint firstAttribute="trailing" secondItem="D1e-L4-n2i" secondAttribute="trailing" constant="8" id="F3g-H6-I4k"/>
+                                    <constraint firstAttribute="bottom" secondItem="D1e-L4-n2i" secondAttribute="bottom" constant="2" id="G4h-I7-J5k"/>
+                                    <constraint firstItem="D1e-L4-n2i" firstAttribute="top" secondItem="C0d-L3-m1h" secondAttribute="top" constant="2" id="H5i-J8-K6l"/>
+                                    <constraint firstAttribute="height" constant="22" id="I6j-K9-L0m"/>
+                                </constraints>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E2f-L5-o3p">
+                                <rect key="frame" x="16" y="78" width="196" height="20.333333333333343"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F3g-M6-p4q">
+                                <rect key="frame" x="16" y="102.33333333333333" width="196" height="20.333333333333329"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="pin_partners_trans" translatesAutoresizingMaskIntoConstraints="NO" id="G4h-N7-q5r">
+                                <rect key="frame" x="16" y="172" width="12" height="12"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="12" id="H5i-O8-R6s"/>
+                                    <constraint firstAttribute="height" constant="12" id="I6j-P9-S7t"/>
+                                </constraints>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H5i-O8-R7s">
+                                <rect key="frame" x="32" y="169.66666666666666" width="172" height="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="A8d-L1-k9f" firstAttribute="leading" secondItem="13H-LX-KCU" secondAttribute="leading" constant="16" id="L9m-S2-V0w"/>
+                            <constraint firstItem="A8d-L1-k9f" firstAttribute="top" secondItem="13H-LX-KCU" secondAttribute="top" constant="16" id="M0n-T3-W1x"/>
+                            <constraint firstItem="B9d-L2-l0g" firstAttribute="leading" secondItem="A8d-L1-k9f" secondAttribute="trailing" constant="8" id="N1o-U4-X2y"/>
+                            <constraint firstItem="B9d-L2-l0g" firstAttribute="top" secondItem="13H-LX-KCU" secondAttribute="top" constant="20" id="O2p-V5-Y3z"/>
+                            <constraint firstAttribute="trailing" secondItem="B9d-L2-l0g" secondAttribute="trailing" constant="8" id="P3q-W6-Z4a"/>
+                            <constraint firstItem="C0d-L3-m1h" firstAttribute="leading" secondItem="A8d-L1-k9f" secondAttribute="trailing" constant="8" id="Q4r-X7-a5b"/>
+                            <constraint firstItem="C0d-L3-m1h" firstAttribute="top" secondItem="B9d-L2-l0g" secondAttribute="bottom" constant="4" id="R5s-Y8-b6c"/>
+                            <constraint firstItem="E2f-L5-o3p" firstAttribute="leading" secondItem="13H-LX-KCU" secondAttribute="leading" constant="16" id="S6t-Z9-c7d"/>
+                            <constraint firstItem="E2f-L5-o3p" firstAttribute="top" secondItem="A8d-L1-k9f" secondAttribute="bottom" constant="12" id="T7u-a0-d8e"/>
+                            <constraint firstAttribute="trailing" secondItem="E2f-L5-o3p" secondAttribute="trailing" constant="8" id="U8v-b1-e9f"/>
+                            <constraint firstItem="F3g-M6-p4q" firstAttribute="leading" secondItem="13H-LX-KCU" secondAttribute="leading" constant="16" id="V9w-c2-f0g"/>
+                            <constraint firstItem="F3g-M6-p4q" firstAttribute="top" secondItem="E2f-L5-o3p" secondAttribute="bottom" constant="4" id="W0x-d3-g1h"/>
+                            <constraint firstAttribute="trailing" secondItem="F3g-M6-p4q" secondAttribute="trailing" constant="8" id="X1y-e4-h2i"/>
+                            <constraint firstItem="G4h-N7-q5r" firstAttribute="leading" secondItem="13H-LX-KCU" secondAttribute="leading" constant="16" id="Y2z-f5-i3j"/>
+                            <constraint firstAttribute="bottom" secondItem="G4h-N7-q5r" secondAttribute="bottom" constant="16" id="Z3a-g6-j4k"/>
+                            <constraint firstItem="H5i-O8-R7s" firstAttribute="leading" secondItem="G4h-N7-q5r" secondAttribute="trailing" constant="4" id="a4b-h7-k5l"/>
+                            <constraint firstItem="H5i-O8-R7s" firstAttribute="centerY" secondItem="G4h-N7-q5r" secondAttribute="centerY" id="b5c-i8-l6m"/>
+                            <constraint firstAttribute="trailing" secondItem="H5i-O8-R7s" secondAttribute="trailing" constant="16" id="c6d-j9-m7n"/>
+                            <constraint firstItem="G4h-N7-q5r" firstAttribute="top" relation="greaterThanOrEqual" secondItem="F3g-M6-p4q" secondAttribute="bottom" constant="8" id="k8l-m9-n8p"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="13H-LX-KCU" firstAttribute="leading" secondItem="vDO-Da-VjE" secondAttribute="leading" id="f9g-m2-p0q"/>
+                    <constraint firstAttribute="bottom" secondItem="13H-LX-KCU" secondAttribute="bottom" id="g0h-n3-q1r"/>
+                    <constraint firstAttribute="trailing" secondItem="13H-LX-KCU" secondAttribute="trailing" id="h1i-o4-r2s"/>
+                    <constraint firstItem="13H-LX-KCU" firstAttribute="top" secondItem="vDO-Da-VjE" secondAttribute="top" id="i2j-p5-s3t"/>
+                </constraints>
+            </collectionViewCellContentView>
+            <connections>
+                <outlet property="containerView" destination="13H-LX-KCU" id="j3k-q6-t4u"/>
+                <outlet property="ui_image_pin" destination="G4h-N7-q5r" id="l5m-s8-v6w"/>
+                <outlet property="ui_image_user" destination="A8d-L1-k9f" id="m6n-t9-w7x"/>
+                <outlet property="ui_label_description" destination="F3g-M6-p4q" id="n7o-u0-x8y"/>
+                <outlet property="ui_label_distance" destination="H5i-O8-R7s" id="o8p-v1-y9z"/>
+                <outlet property="ui_label_tag" destination="D1e-L4-n2i" id="p9q-w2-z0a"/>
+                <outlet property="ui_label_title" destination="E2f-L5-o3p" id="q0r-x3-A1b"/>
+                <outlet property="ui_label_username" destination="B9d-L2-l0g" id="r1s-y4-B2c"/>
+                <outlet property="ui_view_tag" destination="C0d-L3-m1h" id="s2t-z5-C3d"/>
+            </connections>
+            <point key="canvasLocation" x="140" y="20"/>
+        </collectionViewCell>
+    </objects>
+    <resources>
+        <image name="pin_partners_trans" width="12" height="12"/>
+        <namedColor name="white_orange_home">
+            <color red="1" green="0.9882352941176471" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>


### PR DESCRIPTION
This change updates the "Entraide" (Actions) section on the Home screen to use a horizontal carousel layout instead of a vertical list. The new design features cards with a specific layout including a circular author avatar, bold username, category tag, truncated description, and location information. The carousel is sized to show one full card and a portion of the next card.

**Key Changes:**
- **`HomeCellActionCollectionViewCell`:** A new UICollectionViewCell representing a single action card.
- **`HomeActionHorizontalCollectionCell`:** A new UITableViewCell hosting the horizontal `UICollectionView`.
- **`HomeV2ViewController`:** Updated `tableDTO` to aggregate actions into a single `.cellAction(actions: [Action])` item and registered the new cells.
- **`HomeV2DTO`:** Changed `.cellAction(action: Action)` to `.cellAction(actions: [Action])`.
- **Retain Cycle Fix:** Ensured `HomeActionHCCDelegate` is `weak` and class-bound.

---
*PR created automatically by Jules for task [2303858631285529579](https://jules.google.com/task/2303858631285529579) started by @clemPerrousset*