### PR TITLE
Update moderator card text to formal French

### DIFF
--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1962,5 +1962,5 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_tool_card_map" = "Carte des lieux solidaires";
 "home_v2_tool_card_pedago" = "Contenus pour apprendre et agir";
 "home_v2_tool_card_ethics" = "Charte éthique Entourage";
-"home_v2_moderator_title_format" = "%@, ton contact privilégié";
-"home_v2_moderator_subtitle" = "Je fais parti·e de l'équipe Entourage et je suis là pour t'accompagner. N'hésite pas si tu as des questions ! 🤗";
+"home_v2_moderator_title_format" = "%@, votre contact privilégié";
+"home_v2_moderator_subtitle" = "Je fais parti·e de l'équipe Entourage et je suis là pour vous accompagner. N'hésitez pas si vous avez des questions ! 🤗";


### PR DESCRIPTION
Updated the French localization strings for the moderator card on the Home V2 screen to use the formal "vous" (vouvoiement) instead of the informal "tu". This aligns the tone with professional expectations while maintaining the welcoming nature of the message.

---
*PR created automatically by Jules for task [5942818797190432471](https://jules.google.com/task/5942818797190432471) started by @clemPerrousset*