### PR TITLE
Add fluid entrance animations to Home V2 horizontal lists

### DIFF
--- a/entourage/Scenes/HomeV2/homev2cells/HomeActionHorizontalCollectionCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeActionHorizontalCollectionCell.swift
@@ -90,4 +90,8 @@ extension HomeActionHorizontalCollectionCell: UICollectionViewDelegate, UICollec
             delegate?.goToMyActionHomeCell(action: action)
         }
     }
+
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        AnimationUtils.animateCell(cell, index: indexPath.row)
+    }
 }

--- a/entourage/Scenes/HomeV2/homev2cells/HomeEventHorizontalCollectionCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeEventHorizontalCollectionCell.swift
@@ -79,4 +79,8 @@ extension HomeEventHorizontalCollectionCell:UICollectionViewDelegate, UICollecti
             delegate?.goToMyEventHomeCell(event: event)
         }
     }
+
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        AnimationUtils.animateCell(cell, index: indexPath.row)
+    }
 }

--- a/entourage/Scenes/HomeV2/homev2cells/HomeGroupHorizontalCollectionCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeGroupHorizontalCollectionCell.swift
@@ -77,4 +77,8 @@ extension HomeGroupHorizontalCollectionCell:UICollectionViewDelegate, UICollecti
             delegate?.goToMyGroup(group: group)
         }
     }
+
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        AnimationUtils.animateCell(cell, index: indexPath.row)
+    }
 }

--- a/entourage/Scenes/HomeV2/homev2cells/HomeInitialPedagogicHorizontalCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeInitialPedagogicHorizontalCell.swift
@@ -78,4 +78,8 @@ extension HomeInitialPedagogicHorizontalCell:UICollectionViewDelegate, UICollect
             delegate?.goToPedago(pedago: pedago)
         }
     }
+
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        AnimationUtils.animateCell(cell, index: indexPath.row)
+    }
 }

--- a/entourage/Scenes/HomeV2/homev2cells/HomeSmallTalkCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeSmallTalkCell.swift
@@ -148,4 +148,8 @@ extension HomeSmallTalkCell: UICollectionViewDelegateFlowLayout {
             print("nothing to do")
         }
     }
+
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        AnimationUtils.animateCell(cell, index: indexPath.row)
+    }
 }

--- a/entourage/Tools/AnimationUtils.swift
+++ b/entourage/Tools/AnimationUtils.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+class AnimationUtils {
+    static func animateCell(_ cell: UICollectionViewCell, index: Int) {
+        cell.alpha = 0
+        cell.transform = CGAffineTransform(translationX: 20, y: 0)
+
+        // Use a modulo to create a wave effect without accumulating too much delay for long lists
+        // This ensures the first few items cascade, and scrolling reveals items with a slight pop/slide
+        let delay = 0.05 * Double(index % 4)
+
+        UIView.animate(withDuration: 0.3, delay: delay, options: [.curveEaseOut, .allowUserInteraction], animations: {
+            cell.alpha = 1
+            cell.transform = .identity
+        }, completion: nil)
+    }
+}


### PR DESCRIPTION
This PR adds a standard, fluid entrance animation to the horizontal list items (Actions, Events, Groups, Pedagogic Resources, Small Talk) on the Home V2 screen.

**Changes:**
- **New Utility:** Created `entourage/Tools/AnimationUtils.swift` with a reusable `animateCell(_:index:)` function. This function applies a subtle translation and fade-in effect with a calculated delay (`index % 4 * 0.05s`) to create a pleasing "wave" or "cascade" effect without accumulating excessive delays for long lists.
- **Integration:** Updated the `willDisplay` delegate method in the following cells to trigger the animation:
    - `HomeActionHorizontalCollectionCell`
    - `HomeEventHorizontalCollectionCell`
    - `HomeGroupHorizontalCollectionCell`
    - `HomeInitialPedagogicHorizontalCell`
    - `HomeSmallTalkCell`

**Behavior:**
- Items animate in one by one when the view loads.
- Items also animate in as the user scrolls horizontally to reveal them, as requested.
- The animation is non-blocking (`.allowUserInteraction`).

---
*PR created automatically by Jules for task [16930594807036143411](https://jules.google.com/task/16930594807036143411) started by @clemPerrousset*