### PR TITLE
Update Ethics Charter Deeplink

### DIFF
--- a/entourage/Managers/UniversalLinkManager.swift
+++ b/entourage/Managers/UniversalLinkManager.swift
@@ -44,9 +44,9 @@ struct UniversalLinkManager {
             
         // --- 2. Charte éthique ---
         case "charte-ethique-entourage":
-            // Android: Intent.ACTION_VIEW disclaimer_link_public
-            if let url = URL(string: "https://www.entourage.social/charte-ethique-grand-public") {
-                UIApplication.shared.open(url)
+            let urlString = EnvironmentConfigurationManager.sharedInstance.runsOnProduction ? "https://www.entourage.social/app/resources/eMU_InNSSJbE" : "https://preprod.entourage.social/app/resources/87203debda8b"
+            if let url = URL(string: urlString) {
+                WebLinkManager.openUrl(url: url, openInApp: true, presenterViewController: AppState.getTopViewController())
             }
             
         // --- 3. Outings (Événements) ---

--- a/entourage/Scenes/HomeV2/HomeV2ViewController.swift
+++ b/entourage/Scenes/HomeV2/HomeV2ViewController.swift
@@ -926,7 +926,8 @@ extension HomeV2ViewController: HomeSolidarityToolsCellDelegate {
     }
 
     func onEthicsTapped() {
-        if let url = URL(string: "https://www.entourage.social/charte-ethique-grand-public") {
+        let urlString = EnvironmentConfigurationManager.sharedInstance.runsOnProduction ? "https://www.entourage.social/app/resources/eMU_InNSSJbE" : "https://preprod.entourage.social/app/resources/87203debda8b"
+        if let url = URL(string: urlString) {
             WebLinkManager.openUrl(url: url, openInApp: true, presenterViewController: self)
         }
     }


### PR DESCRIPTION
Updated the `onEthicsTapped` action in `HomeV2ViewController` and the universal link mapping for `charte-ethique-entourage` in `UniversalLinkManager` to open the app resource deep links (`/app/resources/...`) rather than the external website. The specific resource ID changes depending on whether the app is running in the production or pre-production environment.

---
*PR created automatically by Jules for task [7322862886050332889](https://jules.google.com/task/7322862886050332889) started by @clemPerrousset*