### PR TITLE
fix: Update onboarding, settings CTAs, and association strings

### DIFF
--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1911,7 +1911,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "onboard_asso_title" = "Sélectionnez votre association";
 "onboard_asso_subtitle" = "Nom de votre association";
 "onboard_asso_dropdown_hint" = "Sélectionner dans la liste";
-"onboard_asso_info" = "Votre association ne figure pas dans la liste.\nCréez-en une nouvelle";
+"onboard_asso_info" = "Votre association ne figure pas dans la liste ? Ajoutez-la pour continuer.";
 "onboard_asso_other_label" = "Nom de votre association";
 "onboard_asso_other_placeholder" = "Ex. : Utopia 56 ou Femmes solidaires";
 "onboard_asso_other_required" = "Merci d’indiquer le nom de votre association.";

--- a/entourage/Scenes/Onboarding/OnboardingPhase1ViewController.swift
+++ b/entourage/Scenes/Onboarding/OnboardingPhase1ViewController.swift
@@ -177,7 +177,7 @@ final class OnboardingPhase1VM: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
 
-    // Helpers ordre forcé (Femme → Homme → Autre → reste)
+    // Helpers ordre forcé (Femme → Homme → Non renseigné → reste)
     private func normalized(_ s: String) -> String {
         s.folding(options: .diacriticInsensitive, locale: .current)
          .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -187,7 +187,7 @@ final class OnboardingPhase1VM: ObservableObject {
         let n = normalized(label)
         if n.contains("femme") { return 0 }
         if n.contains("homme") { return 1 }
-        if n.contains("autre") || n.contains("non binaire") || n.contains("non-binaire") || n.contains("autres") { return 2 }
+        if n.contains("non renseigne") || n.contains("non renseigné") || n.contains("autre") || n.contains("non binaire") || n.contains("non-binaire") || n.contains("autres") { return 2 }
         return 3
     }
 
@@ -301,10 +301,10 @@ final class OnboardingPhase1VM: ObservableObject {
                     self.gendersMap = meta.user?.genders ?? [:]
                     self.discoverySourcesMap = meta.user?.discoverySources ?? [:]
 
-                    // Genders: ordre forcé Femme > Homme > Autre, puis le reste
+                    // Genders: ordre forcé Femme > Homme > Non renseigné, puis le reste
                     let labelsG = Array(self.gendersMap.values)
                     if labelsG.isEmpty {
-                        self.genderOptions = ["Femme", "Homme", "Autre"]
+                        self.genderOptions = ["Femme", "Homme", "Non renseigné"]
                     } else {
                         self.genderOptions = labelsG.sorted { a, b in
                             let pa = self.genderPriority(a)
@@ -334,7 +334,7 @@ final class OnboardingPhase1VM: ObservableObject {
                 case .failure:
                     self.gendersMap = [:]
                     self.discoverySourcesMap = [:]
-                    self.genderOptions = ["Femme", "Homme", "Autre"]
+                    self.genderOptions = ["Femme", "Homme", "Non renseigné"]
                     self.howWeMetOptions = []
                 }
                 self.recomputeCanProceed()

--- a/entourage/Scenes/enhancedOnboarding/EnhancedViewController.swift
+++ b/entourage/Scenes/enhancedOnboarding/EnhancedViewController.swift
@@ -113,12 +113,12 @@ class EnhancedViewController: UIViewController, UIImagePickerControllerDelegate,
         buttonView.translatesAutoresizingMaskIntoConstraints = false
         self.stickyButtonView = buttonView
         
-        let height: CGFloat = 130
+        let height: CGFloat = 85
         
         NSLayoutConstraint.activate([
             buttonView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             buttonView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-            buttonView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            buttonView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
             buttonView.heightAnchor.constraint(equalToConstant: height)
         ])
         
@@ -243,7 +243,7 @@ class EnhancedViewController: UIViewController, UIImagePickerControllerDelegate,
         case .associationPresentation:
             AnalyticsLoggerManager.logEvent(name: "onboarding_association_view")
             tableDTO.append(.backArrow)
-            tableDTO.append(.title(title: "Présentez votre association", subtitle: "Ajoutez votre logo et une courte description."))
+            tableDTO.append(.title(title: "Présentez votre association à la communauté", subtitle: "Ajoutez votre logo et une courte description pour que les membres de la communauté sachent qui vous êtes et ce que vous faites."))
             
             // Chargement des données si nécessaire
             if associationDescription == nil && associationLogoImage == nil, let pid = currentPartnerId {
@@ -258,6 +258,24 @@ class EnhancedViewController: UIViewController, UIImagePickerControllerDelegate,
         if hasChangedMod {
             hasChangedMod = false
             ui_tableview.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
+        }
+
+        updateStickyFooter()
+    }
+
+    private func updateStickyFooter() {
+        guard let buttonView = self.stickyButtonView else { return }
+
+        if EnhancedOnboardingConfiguration.shared.isInterestsFromSetting {
+            return // Already handled in configureForMainFilter (only validate)
+        }
+
+        let isLastStep = isAssociationGoal ? (self.mode == .associationPresentation) : (self.mode == .choiceDisponibility)
+
+        if isLastStep {
+            buttonView.ui_btn_next.setTitle("action_create_close_button".localized, for: .normal)
+        } else {
+            buttonView.ui_btn_next.setTitle("enhanced_onboarding_button_title_next".localized, for: .normal)
         }
     }
 

--- a/entourage/Scenes/enhancedOnboarding/cells/AssociationPresentationCell.swift
+++ b/entourage/Scenes/enhancedOnboarding/cells/AssociationPresentationCell.swift
@@ -67,7 +67,7 @@ class AssociationPresentationCell: UITableViewCell, UITextViewDelegate {
     private let descriptionLabel: UILabel = {
         let label = UILabel()
         label.text = NSLocalizedString("description_association_label", value: "Description de votre association", comment: "")
-        label.font = UIFont.boldSystemFont(ofSize: 16)
+        label.font = ApplicationTheme.getFontQuickSandBold(size: 16)
         label.textColor = .black
         label.translatesAutoresizingMaskIntoConstraints = false
         return label

--- a/entourage/Scenes/enhancedOnboarding/cells/EnahancedOnboardingButtonCell.swift
+++ b/entourage/Scenes/enhancedOnboarding/cells/EnahancedOnboardingButtonCell.swift
@@ -27,13 +27,14 @@ class EnahancedOnboardingButtonCell:UITableViewCell{
         let config = EnhancedOnboardingConfiguration.shared
         if config.isInterestsFromSetting{
             configureOrangeButton(ui_btn_next, withTitle: "button_title_for_setting_onboarding".localized)
+            ui_btn_configure_later.isHidden = true
+        } else {
+            ui_btn_configure_later.isHidden = false
         }
     }
     
     func configure(){
         ui_btn_configure_later.addTarget(self, action: #selector(onConfigureLaterClick), for: .touchUpInside)
-        self.ui_btn_next.setTitle("validate".localized, for: .normal)
-        self.ui_btn_configure_later.setTitle("cancel".localized, for: .normal)
         ui_btn_next.addTarget(self, action: #selector(onBtnNextClick), for: .touchUpInside)
     }
     
@@ -41,6 +42,7 @@ class EnahancedOnboardingButtonCell:UITableViewCell{
         self.configure()
         self.ui_btn_next.setTitle("validate".localized, for: .normal)
         self.ui_btn_configure_later.setTitle("cancel".localized, for: .normal)
+        self.ui_btn_configure_later.isHidden = true
     }
     
     @objc func onConfigureLaterClick(){


### PR DESCRIPTION
This pull request addresses multiple feedback items on the registration, onboarding, and settings screens.

**Key Changes:**
1.  **Gender Option:** Renamed "Autre" to "Non renseigné" in `OnboardingPhase1ViewController` while maintaining sorting and backend logic.
2.  **Association Registration:** Replaced the "create new association" hint with "Votre association ne figure pas dans la liste ? Ajoutez-la pour continuer."
3.  **Onboarding Asso:** Replaced the title and subtitle of the presentation screen for associations and applied the correct `ApplicationTheme.getFontQuickSandBold` font to the description field.
4.  **CTAs & Sticky Footer Refactor:** 
    - Reduced the spacing beneath the CTAs by anchoring the footer to the `safeAreaLayoutGuide.bottomAnchor` and setting its height to `85` (down from `130`).
    - Added `updateStickyFooter()` logic in `EnhancedViewController` to toggle "Suivant" vs "Terminer" on the final step.
    - Simplified the settings view by completely hiding the "Cancel" button, leaving only "Enregistrer".

---
*PR created automatically by Jules for task [15010144261583229936](https://jules.google.com/task/15010144261583229936) started by @clemPerrousset*