### PR TITLE
Refactor reserved_female event field to metadata and adjust UI

### DIFF
--- a/entourage/Models/Event.swift
+++ b/entourage/Models/Event.swift
@@ -48,7 +48,6 @@ struct Event:Codable {
     private var statusChangedAt:String? = nil
     private var createdAt:String? = nil
     private var updatedAt:String? = nil
-    var reservedFemale:Bool? = false
     
     func getChangedStatusDate() -> Date? {
         return statusChangedAt == nil ? nil : Utils.getDateFromWSDateString(statusChangedAt)
@@ -228,7 +227,6 @@ struct Event:Codable {
         case titleTranslations = "title_translations"
         case descriptionTranslations = "description_translations"
         case signable
-        case reservedFemale = "reserved_female"
     }
     
     func dictionaryForWS() -> [String:Any] {
@@ -346,12 +344,12 @@ struct Event:Codable {
         if let place = metadata?.place_limit , place > 0 {
             metadatas["place_limit"] = place
         }
+        
+        if let reservedFemale = metadata?.reservedFemale {
+            metadatas["reserved_female"] = reservedFemale
+        }
 
         dict["metadata"] = metadatas
-        
-        if let reservedFemale = reservedFemale {
-            dict["reserved_female"] = reservedFemale
-        }
 
         return dict
     }
@@ -404,6 +402,7 @@ struct EventMetadata:Codable {
     var place_limit:Int? = 0
     var portrait_url:String? = nil
     var landscape_url:String? = nil
+    var reservedFemale:Bool? = false
     
     var hasPlaceLimit:Bool? {
         get {
@@ -424,6 +423,7 @@ struct EventMetadata:Codable {
         case place_limit
         case portrait_url
         case landscape_url
+        case reservedFemale = "reserved_female"
     }
 }
 
@@ -531,7 +531,6 @@ struct EventEditing {
     var neighborhoods:[EventNeighborhood]? = nil
     
     var recurrence:EventRecurrence? = nil
-    var reservedFemale:Bool? = nil
     
     private var _startDate:Date? = nil
     var startDate:Date? {
@@ -622,10 +621,6 @@ struct EventEditing {
                 dict["recurrency"] = 31
             }
         }
-        
-        if let reservedFemale = reservedFemale {
-            dict["reserved_female"] = reservedFemale
-        }
 
         var metadatas = [String:Any]()
         if let newStartDate = metadata?.starts_at {
@@ -647,6 +642,10 @@ struct EventEditing {
         if let place = metadata?.place_limit  {
             metadatas["place_limit"] = place
         }
+
+        if let reservedFemale = metadata?.reservedFemale {
+            metadatas["reserved_female"] = reservedFemale
+        }
        
         if metadatas.count > 0 {
             dict["metadata"] = metadatas
@@ -667,6 +666,7 @@ struct EventMetadataEditing {
     var place_name:String? = nil
     var google_place_id:String? = nil
     var place_limit:Int? = 0
+    var reservedFemale:Bool? = nil
     var hasPlaceLimit:Bool? {
         get {
             if place_limit == nil {

--- a/entourage/Scenes/Events/Cells/EventListCell.swift
+++ b/entourage/Scenes/Events/Cells/EventListCell.swift
@@ -74,23 +74,16 @@ class EventListCell: UITableViewCell {
             }
         }
         
-        let isReservedFemale = event.reservedFemale ?? false
+        let isReservedFemale = event.metadata?.reservedFemale ?? false
 
-        if isAmbassador && isReservedFemale {
+        if isReservedFemale {
             self.ic_entoutou.isHidden = false
-            self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_little")
-
-            self.ic_entoutou_woman.isHidden = false
-            self.ic_entoutou_woman.image = UIImage(named: "ic_entoutou_logo_woman")
+            self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_woman")
+            self.ic_entoutou_woman.isHidden = true
         }
         else if isAmbassador {
             self.ic_entoutou.isHidden = false
             self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_little")
-            self.ic_entoutou_woman.isHidden = true
-        }
-        else if isReservedFemale {
-            self.ic_entoutou.isHidden = false
-            self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_woman")
             self.ic_entoutou_woman.isHidden = true
         }
         else {

--- a/entourage/Scenes/Events/Cells/Feed/EventDetailFullCell.swift
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailFullCell.swift
@@ -291,6 +291,7 @@ class EventDetailFullCell: UITableViewCell {
             ui_view_organised_by.isHidden = true
             ui_view_association.isHidden = true
         }
+
         if isEntourageEvent {
             ui_label_association.text = String(format: "event_top_cell_asso".localized, "Entourage")
             ui_view_association.isHidden = false

--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
@@ -218,7 +218,7 @@ class EventDetailTopFullCell: UITableViewCell {
             })
         }
         
-        if let reservedFemale = event.reservedFemale, reservedFemale {
+        if let reservedFemale = event.metadata?.reservedFemale, reservedFemale {
             ui_view_reserved_female.isHidden = false
             ui_constraint_height_reserved_female.constant = 32
         } else {

--- a/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.swift
+++ b/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.swift
@@ -14,8 +14,6 @@ class EventReservedFemaleCell: UITableViewCell {
 
     @IBOutlet weak var ui_title: UILabel!
     @IBOutlet weak var ui_switch: UISwitch!
-    @IBOutlet weak var ui_view_info: UIView!
-    @IBOutlet weak var ui_lbl_info: UILabel!
 
     weak var delegate: EventReservedFemaleCellDelegate?
 
@@ -24,23 +22,15 @@ class EventReservedFemaleCell: UITableViewCell {
         ui_title.setupFontAndColor(style: ApplicationTheme.getFontCourantBoldNoir())
         ui_title.text = "event_create_reserved_female_title".localized
 
-        ui_lbl_info.setupFontAndColor(style: ApplicationTheme.getFontCourantRegularNoir())
-        ui_lbl_info.text = "event_create_reserved_female_info".localized
-
-        ui_view_info.layer.cornerRadius = 16
-        ui_view_info.backgroundColor = .appOrangeLight.withAlphaComponent(0.2) // Adjust color as needed to match screenshot
-
         ui_switch.onTintColor = .appOrange
     }
 
     func populateCell(isReserved: Bool, delegate: EventReservedFemaleCellDelegate) {
         self.delegate = delegate
         ui_switch.isOn = isReserved
-        ui_view_info.isHidden = !isReserved
     }
 
     @IBAction func action_switch(_ sender: UISwitch) {
-        ui_view_info.isHidden = !sender.isOn
         delegate?.updateReservedFemale(isReserved: sender.isOn)
     }
 }

--- a/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.xib
+++ b/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.xib
@@ -48,34 +48,6 @@
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="36" id="jkl-height"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xyz-12-uvw">
-                                <rect key="frame" x="0.0" y="46" width="280" height="54"/>
-                                <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="info.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="jkl-34-rst">
-                                        <rect key="frame" x="12" y="12" width="20" height="20"/>
-                                        <color key="tintColor" name="orange_app"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="20" id="opq-56-xyz"/>
-                                            <constraint firstAttribute="height" constant="20" id="rst-78-uvw"/>
-                                        </constraints>
-                                    </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="L'événement sera uniquement visible par les utilisatrices de l'application." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vwx-90-yza">
-                                        <rect key="frame" x="40" y="12" width="228" height="30"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                        <color key="textColor" name="gris_112"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                                <color key="backgroundColor" name="Beige"/>
-                                <constraints>
-                                    <constraint firstItem="jkl-34-rst" firstAttribute="leading" secondItem="xyz-12-uvw" secondAttribute="leading" constant="12" id="abc-def-123"/>
-                                    <constraint firstItem="jkl-34-rst" firstAttribute="top" secondItem="xyz-12-uvw" secondAttribute="top" constant="12" id="def-ghi-456"/>
-                                    <constraint firstItem="vwx-90-yza" firstAttribute="leading" secondItem="jkl-34-rst" secondAttribute="trailing" constant="8" id="ghi-jkl-789"/>
-                                    <constraint firstAttribute="trailing" secondItem="vwx-90-yza" secondAttribute="trailing" constant="12" id="jkl-mno-012"/>
-                                    <constraint firstItem="vwx-90-yza" firstAttribute="top" secondItem="xyz-12-uvw" secondAttribute="top" constant="12" id="mno-pqr-345"/>
-                                    <constraint firstAttribute="bottom" secondItem="vwx-90-yza" secondAttribute="bottom" constant="12" id="pqr-stu-678"/>
-                                </constraints>
-                            </view>
                         </subviews>
                     </stackView>
                 </subviews>
@@ -88,23 +60,9 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="ui_lbl_info" destination="vwx-90-yza" id="stu-90-vwx-lbl"/>
                 <outlet property="ui_switch" destination="ghi-34-jkl" id="stu-90-vwx"/>
                 <outlet property="ui_title" destination="abc-12-def" id="yza-23-bcd"/>
-                <outlet property="ui_view_info" destination="xyz-12-uvw" id="vwx-90-yza-view"/>
             </connections>
         </tableViewCell>
     </objects>
-    <resources>
-        <namedColor name="Beige">
-            <color red="1" green="0.91764705882352937" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="gris_112">
-            <color red="0.4392156862745098" green="0.4392156862745098" blue="0.4392156862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="orange_app">
-            <color red="0.96078431372549022" green="0.37254901960784315" blue="0.14117647058823529" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <image name="info.circle" catalog="system" width="128" height="121"/>
-    </resources>
 </document>

--- a/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
+++ b/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
@@ -262,7 +262,10 @@ extension EventCreateMainViewController: EventCreateMainDelegate {
     }
     
     func addReservedFemale(reserved: Bool) {
-        newEvent.reservedFemale = reserved
+        if newEvent.metadata == nil {
+            newEvent.metadata = EventMetadataEditing()
+        }
+        newEvent.metadata?.reservedFemale = reserved
         _ = checkValidation()
     }
 

--- a/entourage/Scenes/Events/Create/EventCreatePhase2ViewController.swift
+++ b/entourage/Scenes/Events/Create/EventCreatePhase2ViewController.swift
@@ -62,16 +62,23 @@ extension EventCreatePhase2ViewController:UITableViewDataSource, UITableViewDele
             
             return cell
         }
-        else if indexPath.row == 1 && !hasCurrentRecurrency {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "cellSelector", for: indexPath) as! EventRecurrenceCell
-            let recur = currentEvent != nil ? currentEvent!.recurrence : recurrenceSelected
+        else if indexPath.row == 1 {
+            if !hasCurrentRecurrency {
+                let cell = tableView.dequeueReusableCell(withIdentifier: "cellSelector", for: indexPath) as! EventRecurrenceCell
+                let recur = currentEvent != nil ? currentEvent!.recurrence : recurrenceSelected
 
-            cell.populateCell(recurrence:recur, delegate: self)
-            return cell
+                cell.populateCell(recurrence:recur, delegate: self)
+                return cell
+            } else {
+                let cell = tableView.dequeueReusableCell(withIdentifier: "EventReservedFemaleCell", for: indexPath) as! EventReservedFemaleCell
+                let isReserved = currentEvent?.metadata?.reservedFemale ?? false
+                cell.populateCell(isReserved: isReserved, delegate: self)
+                return cell
+            }
         }
         
         let cell = tableView.dequeueReusableCell(withIdentifier: "EventReservedFemaleCell", for: indexPath) as! EventReservedFemaleCell
-        let isReserved = currentEvent?.reservedFemale ?? false
+        let isReserved = currentEvent?.metadata?.reservedFemale ?? false
         cell.populateCell(isReserved: isReserved, delegate: self)
         return cell
     }

--- a/entourage/Scenes/Events/EventEditMainViewController.swift
+++ b/entourage/Scenes/Events/EventEditMainViewController.swift
@@ -282,6 +282,7 @@ class EventEditMainViewController: UIViewController {
         newEvent.imageId = newImageId
         
         newEvent.recurrence = newRecurrence
+        newEvent.metadata?.reservedFemale = eventEditing.metadata?.reservedFemale
         newEvent.isOnline = newIsOnline
         newEvent.onlineEventUrl = newOnlineEventUrl
         newEvent.location = newLocation
@@ -303,7 +304,11 @@ class EventEditMainViewController: UIViewController {
 //MARK: - EventCreateMainDelegate -
 extension EventEditMainViewController: EventCreateMainDelegate {
     func addReservedFemale(reserved: Bool) {
-        //
+        if eventEditing.metadata == nil {
+            eventEditing.metadata = EventMetadataEditing()
+        }
+        eventEditing.metadata?.reservedFemale = reserved
+        _ = checkValidation()
     }
     
     //Phase 1


### PR DESCRIPTION
- Move `reserved_female` to `EventMetadata`
- Update event creation UI to drop info view and position switch correctly
- Use `ic_entoutou_logo_woman` on the event cell if the event is reserved for women

---
*PR created automatically by Jules for task [6733025963125674962](https://jules.google.com/task/6733025963125674962) started by @clemPerrousset*