### PR TITLE
Fix EventReservedFemaleCell layout issue

### DIFF
--- a/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.xib
+++ b/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.xib
@@ -24,13 +24,13 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="top-container">
                                 <rect key="frame" x="0.0" y="0.0" width="280" height="36"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cet événement est-il réservé aux femmes ?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abc-12-def">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Cet événement est-il réservé aux femmes ?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="abc-12-def">
                                         <rect key="frame" x="0.0" y="0.0" width="221" height="36"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ghi-34-jkl">
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ghi-34-jkl">
                                         <rect key="frame" x="231" y="2.6666666666666661" width="51" height="31"/>
                                         <connections>
                                             <action selector="action_switch:" destination="KGk-i7-Jjw" eventType="valueChanged" id="mno-56-pqr"/>


### PR DESCRIPTION
Fixes a bug reported where "Cet événement est-il réservé aux femmes ?" pushes the UI switch out of bounds on smaller screens or when text becomes too long. The `horizontalCompressionResistancePriority` of the switch was increased to 1000 and the label decreased to 749, ensuring the switch maintains its minimum required width.

---
*PR created automatically by Jules for task [9986104997470758283](https://jules.google.com/task/9986104997470758283) started by @clemPerrousset*