### PR TITLE
Fix 'Reserved for Women' UI and Event Creation Flow

### DIFF
--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
@@ -89,10 +89,10 @@ class EventDetailTopFullCell: UITableViewCell {
         ui_img_member_2.layer.cornerRadius = ui_img_member_2.frame.height / 2
         ui_img_member_3.layer.cornerRadius = ui_img_member_3.frame.height / 2
         
-        ui_view_reserved_female.layer.cornerRadius = 16
+        ui_view_reserved_female.layer.cornerRadius = 12
         ui_view_reserved_female.backgroundColor = UIColor.appViolet
         ui_lbl_reserved_female?.text = "event_detail_reserved_female_label".localized
-        ui_lbl_reserved_female.setFontTitle(size: 13)
+        ui_lbl_reserved_female.setFontTitle(size: 11)
 
         ui_view_place_limit.isHidden = true
         
@@ -221,7 +221,7 @@ class EventDetailTopFullCell: UITableViewCell {
         
         if let reservedFemale = event.metadata?.reservedFemale, reservedFemale {
             ui_view_reserved_female.isHidden = false
-            ui_constraint_height_reserved_female.constant = 32
+            ui_constraint_height_reserved_female.constant = 24
         } else {
             ui_view_reserved_female.isHidden = true
             ui_constraint_height_reserved_female.constant = 0

--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
@@ -38,8 +38,8 @@
                         <rect key="frame" x="20" y="62" width="366" height="0"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cet événement est réservé aux femmes" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="def-female-label">
-                                <rect key="frame" x="10" y="4" width="346" height="18"/>
-                                <fontDescription key="fontDescription" name="Quicksand-Bold" family="Quicksand" pointSize="15"/>
+                                <rect key="frame" x="12" y="4" width="342" height="18"/>
+                                <fontDescription key="fontDescription" name="Quicksand-Bold" family="Quicksand" pointSize="11"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -47,13 +47,13 @@
                         <color key="backgroundColor" red="0.49019607843137253" green="0.0" blue="0.96470588235294119" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="0" id="hij-height-constraint"/>
-                            <constraint firstItem="def-female-label" firstAttribute="leading" secondItem="abc-female-banner" secondAttribute="leading" constant="10" id="klm-leading"/>
-                            <constraint firstAttribute="trailing" secondItem="def-female-label" secondAttribute="trailing" constant="10" id="nop-trailing"/>
+                            <constraint firstItem="def-female-label" firstAttribute="leading" secondItem="abc-female-banner" secondAttribute="leading" constant="12" id="klm-leading"/>
+                            <constraint firstAttribute="trailing" secondItem="def-female-label" secondAttribute="trailing" constant="12" id="nop-trailing"/>
                             <constraint firstItem="def-female-label" firstAttribute="centerY" secondItem="abc-female-banner" secondAttribute="centerY" id="qrs-center-y"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                <integer key="value" value="16"/>
+                                <integer key="value" value="12"/>
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </view>
@@ -488,7 +488,7 @@
                     <constraint firstItem="1xV-ay-YP1" firstAttribute="trailing" secondItem="1V4-oV-Dh3" secondAttribute="trailing" id="Ujl-4M-eMB"/>
                             <constraint firstItem="abc-female-banner" firstAttribute="top" secondItem="klB-o1-C0m" secondAttribute="bottom" constant="5" id="tuv-banner-top"/>
                             <constraint firstItem="abc-female-banner" firstAttribute="leading" secondItem="klB-o1-C0m" secondAttribute="leading" id="wxy-banner-leading"/>
-                            <constraint firstItem="abc-female-banner" firstAttribute="trailing" secondItem="klB-o1-C0m" secondAttribute="trailing" id="xyz-banner-trailing"/>
+                            <constraint firstItem="abc-female-banner" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="klB-o1-C0m" secondAttribute="trailing" id="xyz-banner-trailing"/>
                             <constraint firstItem="Nfw-W1-dO7" firstAttribute="top" secondItem="abc-female-banner" secondAttribute="bottom" constant="10" id="VQC-kR-A9p"/>
                     <constraint firstAttribute="bottom" secondItem="1xV-ay-YP1" secondAttribute="bottom" constant="20" id="Vpw-kr-Z8k"/>
                     <constraint firstItem="lgR-Y6-WWf" firstAttribute="leading" secondItem="klB-o1-C0m" secondAttribute="leading" id="Y0c-Lv-hqK"/>

--- a/entourage/Scenes/Events/Create/EventCreatePhase2ViewController.swift
+++ b/entourage/Scenes/Events/Create/EventCreatePhase2ViewController.swift
@@ -27,8 +27,6 @@ class EventCreatePhase2ViewController: UIViewController {
         ui_tableview.delegate = self
         ui_tableview.rowHeight = UITableView.automaticDimension
         ui_tableview.estimatedRowHeight = 50
-        
-        ui_tableview.register(UINib(nibName: "EventReservedFemaleCell", bundle: nil), forCellReuseIdentifier: "EventReservedFemaleCell")
 
         if pageDelegate?.isEdit() ?? false {
             currentEvent = pageDelegate?.getCurrentEvent()
@@ -48,7 +46,7 @@ class EventCreatePhase2ViewController: UIViewController {
 //MARK: - UITableView datasource / Delegate -
 extension EventCreatePhase2ViewController:UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return hasCurrentRecurrency ? 2 : 3
+        return hasCurrentRecurrency ? 1 : 2
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -62,34 +60,12 @@ extension EventCreatePhase2ViewController:UITableViewDataSource, UITableViewDele
             
             return cell
         }
-        else if indexPath.row == 1 {
-            if !hasCurrentRecurrency {
-                let cell = tableView.dequeueReusableCell(withIdentifier: "cellSelector", for: indexPath) as! EventRecurrenceCell
-                let recur = currentEvent != nil ? currentEvent!.recurrence : recurrenceSelected
-
-                cell.populateCell(recurrence:recur, delegate: self)
-                return cell
-            } else {
-                let cell = tableView.dequeueReusableCell(withIdentifier: "EventReservedFemaleCell", for: indexPath) as! EventReservedFemaleCell
-                let isReserved = currentEvent?.metadata?.reservedFemale ?? false
-                cell.populateCell(isReserved: isReserved, delegate: self)
-                return cell
-            }
-        }
         
-        let cell = tableView.dequeueReusableCell(withIdentifier: "EventReservedFemaleCell", for: indexPath) as! EventReservedFemaleCell
-        let isReserved = currentEvent?.metadata?.reservedFemale ?? false
-        cell.populateCell(isReserved: isReserved, delegate: self)
-        return cell
-    }
-}
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cellSelector", for: indexPath) as! EventRecurrenceCell
+        let recur = currentEvent != nil ? currentEvent!.recurrence : recurrenceSelected
 
-extension EventCreatePhase2ViewController: EventReservedFemaleCellDelegate {
-    func updateReservedFemale(isReserved: Bool) {
-        pageDelegate?.addReservedFemale(reserved: isReserved)
-        //Force resize cell
-        ui_tableview.beginUpdates()
-        ui_tableview.endUpdates()
+        cell.populateCell(recurrence:recur, delegate: self)
+        return cell
     }
 }
 

--- a/entourage/Scenes/Events/Create/EventCreatePhase3ViewController.swift
+++ b/entourage/Scenes/Events/Create/EventCreatePhase3ViewController.swift
@@ -35,6 +35,8 @@ class EventCreatePhase3ViewController: UIViewController {
         ui_tableview.rowHeight = UITableView.automaticDimension
         ui_tableview.estimatedRowHeight = 50
 
+        ui_tableview.register(UINib(nibName: "EventReservedFemaleCell", bundle: nil), forCellReuseIdentifier: "EventReservedFemaleCell")
+
         if pageDelegate?.isEdit() ?? false {
             currentEvent = pageDelegate?.getCurrentEvent()
         }
@@ -43,7 +45,7 @@ class EventCreatePhase3ViewController: UIViewController {
 //MARK: - UITableView datasource / Delegate -
 extension EventCreatePhase3ViewController:UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 2
+        return 3
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -73,14 +75,29 @@ extension EventCreatePhase3ViewController:UITableViewDataSource, UITableViewDele
             
             return cell
         }
+        else if indexPath.row == 1 {
+            let cell = tableView.dequeueReusableCell(withIdentifier: "cellLimit", for: indexPath) as! EventPlaceLimitCell
+
+            let _hasplaceLimit = currentEvent?.metadata?.hasPlaceLimit != nil ? currentEvent!.metadata!.hasPlaceLimit! : hasplaceLimit
+            let _nbplaceLimit = currentEvent?.metadata?.place_limit != nil ? currentEvent!.metadata!.place_limit! : nbPlaceLimit
+
+            cell.populateCell(delegate: self,hasPlaceLimit: _hasplaceLimit, limitNb: _nbplaceLimit)
+            return cell
+        }
         
-        let cell = tableView.dequeueReusableCell(withIdentifier: "cellLimit", for: indexPath) as! EventPlaceLimitCell
-        
-        let _hasplaceLimit = currentEvent?.metadata?.hasPlaceLimit != nil ? currentEvent!.metadata!.hasPlaceLimit! : hasplaceLimit
-        let _nbplaceLimit = currentEvent?.metadata?.place_limit != nil ? currentEvent!.metadata!.place_limit! : nbPlaceLimit
-        
-        cell.populateCell(delegate: self,hasPlaceLimit: _hasplaceLimit, limitNb: _nbplaceLimit)
+        let cell = tableView.dequeueReusableCell(withIdentifier: "EventReservedFemaleCell", for: indexPath) as! EventReservedFemaleCell
+        let isReserved = currentEvent?.metadata?.reservedFemale ?? false
+        cell.populateCell(isReserved: isReserved, delegate: self)
         return cell
+    }
+}
+
+extension EventCreatePhase3ViewController: EventReservedFemaleCellDelegate {
+    func updateReservedFemale(isReserved: Bool) {
+        pageDelegate?.addReservedFemale(reserved: isReserved)
+        //Force resize cell
+        ui_tableview.beginUpdates()
+        ui_tableview.endUpdates()
     }
 }
 


### PR DESCRIPTION
This resolves the issue where the 'Reserved for women' mention on the Event detail view was too large and took up all the space in width. It shrinks it to a nice pill-shaped badge. Furthermore, it moves the switch and its title 'réservé pour femme' from the `EventCreatePhase2` screen to the `EventCreatePhase3` screen, directly underneath the 'event place limit' options.

---
*PR created automatically by Jules for task [11123344546512809709](https://jules.google.com/task/11123344546512809709) started by @clemPerrousset*