### PR TITLE
Fix reserved for women placement and "My events" logo

### DIFF
--- a/entourage/Scenes/Events/Create/Cells/EventPlaceLimitCell.swift
+++ b/entourage/Scenes/Events/Create/Cells/EventPlaceLimitCell.swift
@@ -22,9 +22,23 @@ class EventPlaceLimitCell: UITableViewCell {
     
     weak var delegate:EventCreateLocationCellDelegate? = nil
     
+    var bottomConstraint: NSLayoutConstraint?
+    var topConstraint: NSLayoutConstraint?
+
     override func awakeFromNib() {
         super.awakeFromNib()
         
+        if let superview = ui_view_limit.superview {
+            for constraint in superview.constraints {
+                if constraint.firstAttribute == .bottom && constraint.secondItem as? UIView == ui_view_limit {
+                    bottomConstraint = constraint
+                }
+                if constraint.firstItem as? UIView == ui_view_limit && constraint.firstAttribute == .top {
+                    topConstraint = constraint
+                }
+            }
+        }
+
         let stringAttr = Utils.formatString(messageTxt: "event_create_phase3_title_limit".localized, messageTxtHighlight: "event_create_mandatory".localized, fontColorType: ApplicationTheme.getFontH2Noir(size: 15), fontColorTypeHighlight: ApplicationTheme.getFontLegend(size: 13))
         let stringAttrLimit = Utils.formatString(messageTxt: "event_create_phase3_title_nb_places".localized, messageTxtHighlight: "event_create_mandatory".localized, fontColorType: ApplicationTheme.getFontH2Noir(size: 15), fontColorTypeHighlight: ApplicationTheme.getFontLegend(size: 13))
         
@@ -101,9 +115,13 @@ class EventPlaceLimitCell: UITableViewCell {
         if selectedItem == 1 {
             ui_limit_tf.text = ""
             ui_view_limit.isHidden = false
+            bottomConstraint?.constant = 32
+            topConstraint?.constant = 32
         }
         else {
             ui_view_limit.isHidden = true
+            bottomConstraint?.constant = 0
+            topConstraint?.constant = 0
         }
     }
     

--- a/entourage/Scenes/Events/Create/EventCreatePhase3ViewController.swift
+++ b/entourage/Scenes/Events/Create/EventCreatePhase3ViewController.swift
@@ -164,5 +164,8 @@ extension EventCreatePhase3ViewController:PlaceViewControllerDelegate, EventCrea
         self.nbPlaceLimit = limitNb
         Logger.print("***** add Limit : \(hasPlaceLimit) - \(limitNb)")
         pageDelegate?.addPlaceLimit(hasLimit: hasPlaceLimit,nbPlaces: limitNb)
+
+        ui_tableview.beginUpdates()
+        ui_tableview.endUpdates()
     }
 }

--- a/entourage/Scenes/HomeV2/homev2cells/HomeCellEvent.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeCellEvent.swift
@@ -49,18 +49,29 @@ class HomeCellEvent:UICollectionViewCell{
         else {
             ui_image_event.image = UIImage.init(named: "ic_placeholder_event")
         }
+        var isAmbassador = false
         if let _author = event.author {
             if let _roles = _author.communityRoles{
                 if _roles.contains("Équipe Entourage") || _roles.contains("Animateur Entourage") {
-                    self.ic_entoutou.isHidden = false
-                }else {
-                    self.ic_entoutou.isHidden = true
+                    isAmbassador = true
                 }
-            }else{
-                self.ic_entoutou.isHidden = true
             }
         }
         
+        let isReservedFemale = event.metadata?.reservedFemale ?? false
+
+        if isReservedFemale {
+            self.ic_entoutou.isHidden = false
+            self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_woman")
+        }
+        else if isAmbassador {
+            self.ic_entoutou.isHidden = false
+            self.ic_entoutou.image = UIImage(named: "ic_entoutou_logo_little")
+        }
+        else {
+            self.ic_entoutou.isHidden = true
+        }
+
         ui_label_date.text = event.startDateFormatted
         let addressComponents = event.addressName?.split(separator: ",")
         if let lastComponent = addressComponents?.last {


### PR DESCRIPTION
- Fixes the issue where "Reserved for women" appeared too far down in step 3 of event creation due to uncollapsed constraints from the place limit cell.
- Ensures the "Mes événements" horizontal list uses the correct purple logo for events reserved for women, matching the logic in the "Tous les événements" list.

---
*PR created automatically by Jules for task [301441202274746495](https://jules.google.com/task/301441202274746495) started by @clemPerrousset*