### PR TITLE
Fix Home V2 solidarity tools and moderator UI

### DIFF
--- a/entourage/Managers/UniversalLinkManager.swift
+++ b/entourage/Managers/UniversalLinkManager.swift
@@ -44,9 +44,10 @@ struct UniversalLinkManager {
             
         // --- 2. Charte éthique ---
         case "charte-ethique-entourage":
-            let urlString = EnvironmentConfigurationManager.sharedInstance.runsOnProduction ? "https://www.entourage.social/app/resources/eMU_InNSSJbE" : "https://preprod.entourage.social/app/resources/87203debda8b"
+            let isProd = EnvironmentConfigurationManager.sharedInstance.runsOnProduction
+            let urlString = isProd ? "https://www.entourage.social/app/resources/eMU_InNSSJbE" : "https://preprod.entourage.social/app/resources/87203debda8b"
             if let url = URL(string: urlString) {
-                WebLinkManager.openUrl(url: url, openInApp: true, presenterViewController: AppState.getTopViewController())
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
             }
             
         // --- 3. Outings (Événements) ---

--- a/entourage/Scenes/HomeV2/HomeV2ViewController.swift
+++ b/entourage/Scenes/HomeV2/HomeV2ViewController.swift
@@ -432,12 +432,6 @@ class HomeV2ViewController: UIViewController {
             tableDTO.append(.cellSeeAll(seeAllType: .seeAllEvent))
         }
 
-        if let _moderator = userHome.moderator {
-            if let _name = _moderator.displayName {
-                tableDTO.append(.moderator(name: _name, imageUrl: _moderator.imgUrl))
-            }
-        }
-
         var _offlineEvents = [Event]()
         for event in allEvents {
             if event.isOnline == false {
@@ -448,8 +442,13 @@ class HomeV2ViewController: UIViewController {
             tableDTO.append(.cellHZ)
         }
 
+        if let _moderator = userHome.moderator {
+            if let _name = _moderator.displayName {
+                tableDTO.append(.moderator(name: _name, imageUrl: _moderator.imgUrl))
+            }
+        }
+
         //add condition
-        tableDTO.append(.cellTitle(title: "home_v2_title_small_talk".localized, subtitle: ""))
         tableDTO.append(.cellSmallTalk(userRequests: self.userSmallTalkRequests))
 
         tableDTO.append(.cellSolidarityTools)
@@ -926,9 +925,10 @@ extension HomeV2ViewController: HomeSolidarityToolsCellDelegate {
     }
 
     func onEthicsTapped() {
-        let urlString = EnvironmentConfigurationManager.sharedInstance.runsOnProduction ? "https://www.entourage.social/app/resources/eMU_InNSSJbE" : "https://preprod.entourage.social/app/resources/87203debda8b"
+        let isProd = EnvironmentConfigurationManager.sharedInstance.runsOnProduction
+        let urlString = isProd ? "https://www.entourage.social/app/resources/eMU_InNSSJbE" : "https://preprod.entourage.social/app/resources/87203debda8b"
         if let url = URL(string: urlString) {
-            WebLinkManager.openUrl(url: url, openInApp: true, presenterViewController: self)
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
     }
 }

--- a/entourage/Scenes/HomeV2/homev2cells/HomeModeratorCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeModeratorCell.swift
@@ -32,16 +32,21 @@ class HomeModeratorCell:UITableViewCell{
         // Apply shadow/card style
         containerView.backgroundColor = .white
         containerView.layer.cornerRadius = 15
-        containerView.layer.shadowColor = UIColor.black.cgColor
-        containerView.layer.shadowOpacity = 0.1
-        containerView.layer.shadowOffset = CGSize(width: 0, height: 2)
-        containerView.layer.shadowRadius = 4
+        containerView.layer.borderColor = UIColor.appBeige.cgColor
+        containerView.layer.borderWidth = 1
+        containerView.layer.shadowColor = UIColor.clear.cgColor
+        containerView.layer.shadowOpacity = 0
 
-        ui_label_title.font = UIFont(name: "Quicksand-Bold", size: 15)
+        ui_label_title.font = UIFont(name: "Quicksand-Bold", size: 14)
         ui_label_title.textColor = UIColor(named: "black_app")
 
         ui_label_description.font = UIFont(name: "Quicksand-Regular", size: 13)
         ui_label_description.textColor = UIColor(named: "black_app")
+
+        ui_image.layer.borderColor = UIColor.appOrangeLight.cgColor
+        ui_image.layer.borderWidth = 1
+        ui_image.layer.cornerRadius = 23
+        ui_image.clipsToBounds = true
     }
     
     func configure(title:String, imageUrl:String? = nil){

--- a/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.swift
@@ -49,18 +49,18 @@ class HomeSolidarityToolsCell: UITableViewCell {
         ui_label_title.font = ApplicationTheme.getFontQuickSandBold(size: 15)
         ui_label_title.textColor = .black
 
-        setupCard(view: ui_view_map, label: ui_lbl_map, image: ui_iv_map, title: "home_v2_tool_card_map".localized, iconName: "illu_map", systemIcon: "map.fill")
-        setupCard(view: ui_view_pedago, label: ui_lbl_pedago, image: ui_iv_pedago, title: "home_v2_tool_card_pedago".localized, iconName: "ic_book", systemIcon: "book.fill")
-        setupCard(view: ui_view_ethics, label: ui_lbl_ethics, image: ui_iv_ethics, title: "home_v2_tool_card_ethics".localized, iconName: "ic_handshake", systemIcon: "hand.raised.fill")
+        setupCard(view: ui_view_map, label: ui_lbl_map, image: ui_iv_map, title: "home_v2_tool_card_map".localized, iconName: "ic_card_map", systemIcon: "map.fill")
+        setupCard(view: ui_view_pedago, label: ui_lbl_pedago, image: ui_iv_pedago, title: "home_v2_tool_card_pedago".localized, iconName: "ic_card_pedago", systemIcon: "book.fill")
+        setupCard(view: ui_view_ethics, label: ui_lbl_ethics, image: ui_iv_ethics, title: "home_v2_tool_card_ethics".localized, iconName: "ic_card_charte", systemIcon: "hand.raised.fill")
     }
 
     private func setupCard(view: UIView, label: UILabel, image: UIImageView, title: String, iconName: String, systemIcon: String) {
         view.layer.cornerRadius = 14
         view.backgroundColor = .white
-        view.layer.shadowColor = UIColor.black.cgColor
-        view.layer.shadowOpacity = 0.1
-        view.layer.shadowOffset = CGSize(width: 0, height: 2)
-        view.layer.shadowRadius = 4
+        view.layer.borderColor = UIColor.appBeige.cgColor
+        view.layer.borderWidth = 1
+        view.layer.shadowColor = UIColor.clear.cgColor
+        view.layer.shadowOpacity = 0
 
         label.text = title
         label.font = ApplicationTheme.getFontNunitoBold(size: 12)
@@ -74,7 +74,11 @@ class HomeSolidarityToolsCell: UITableViewCell {
             image.image = UIImage(systemName: systemIcon)
             image.tintColor = .appOrange
         }
-        image.contentMode = .scaleAspectFit
+        image.contentMode = .center
+
+        image.backgroundColor = UIColor.appBeige
+        image.layer.cornerRadius = 25
+        image.clipsToBounds = true
     }
 
     private func setupTapGestures() {


### PR DESCRIPTION
This commit addresses several UI and functional requests on the Home V2 screen:
1. Re-routes the "Charte" tool card to explicitly use Universal Links with environment-specific URLs.
2. Updates icons and styling (beige circular background) for the Solidarity Tools cards.
3. Moves the moderator card to sit just before the Small Talk section, removing its shadow and adding proper borders to match the new mockup.
4. Removes the "Bonnes Ondes" section title.

---
*PR created automatically by Jules for task [9519247922853365525](https://jules.google.com/task/9519247922853365525) started by @clemPerrousset*