### PR TITLE
Refactor event detail actions and update UI with new discussion box

### DIFF
--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
@@ -385,6 +385,10 @@ class EventDetailTopFullCell: UITableViewCell {
     @IBAction func action_show_place(_ sender: Any) {
         delegate?.showPlace()
     }
+
+    @IBAction func action_go_to_discussion(_ sender: Any) {
+        delegate?.showDiscussion()
+    }
 }
 
 // MARK: - MKMapViewDelegate
@@ -433,6 +437,7 @@ protocol EventDetailTopCellDelegate: AnyObject {
     func showMembers()
     func joinLeave()
     func showDetailFull()
+    func showDiscussion()
     func showPlace()
     func showWebUrl(url: URL)
     func showUser()

--- a/entourage/Scenes/Events/EventDetailFeedViewController.swift
+++ b/entourage/Scenes/Events/EventDetailFeedViewController.swift
@@ -759,6 +759,30 @@ extension EventDetailFeedViewController: EventDetailTopCellDelegate {
         }
     }
     
+    func showDiscussion() {
+        SVProgressHUD.show()
+        MessagingService.getDetailConversation(conversationId: self.event?.uuid_v2 ?? "") { conversation, error in
+            SVProgressHUD.dismiss()
+            if let convId = conversation?.uid {
+                let sb = UIStoryboard.init(name: StoryboardName.messages, bundle: nil)
+                if let vc = sb.instantiateViewController(withIdentifier: "detailMessagesVC") as? ConversationDetailMessagesViewController {
+                    vc.setupFromOtherVC(conversationId: convId, title: self.event?.title, isOneToOne: false, conversation: conversation)
+
+                    if let presentedVC = self.presentedViewController {
+                        if presentedVC is ConversationDetailMessagesViewController { return }
+                        presentedVC.dismiss(animated: true) {
+                            self.present(vc, animated: true, completion: nil)
+                        }
+                    } else {
+                        self.present(vc, animated: true, completion: nil)
+                    }
+                }
+            } else {
+                SVProgressHUD.showError(withStatus: "Une erreur est survenue")
+            }
+        }
+    }
+
     func showPlace() {
         // Si l’événement est annulé => on ne fait rien
         if event?.isCanceled() ?? false {


### PR DESCRIPTION
Refactor event detail actions and update UI with new discussion box

- Moved the 'Share' functionality to a top-right navigation header button (`action_share_from_top:`).
- Mapped the 'Add to Agenda' feature directly to the start date/time label taps (with underlines for affordance) using gesture recognizers in `EventDetailTopFullCell`.
- Added a new 'Discussion' box below the map view that replaces the old share/agenda block. This box calls `showDiscussion()` to fetch and open the event conversation correctly via `MessagingService`.
- Modified the bottom button's functionality to now execute 'Leave event' / 'Cancel event' (with an alert confirmation) based on user's author status.
- Added and properly translated the localization keys (`event_discussion_box_title`, `event_discussion_box_button`, `event_detail_button_quitter`, `event_detail_button_annuler`) across all 9 supported languages.

---
*PR created automatically by Jules for task [11466206964230039171](https://jules.google.com/task/11466206964230039171) started by @clemPerrousset*