### PR TITLE
Update event cancellation wording to 'annuler'

### DIFF
--- a/entourage/Scenes/Events/EventDetailFeedViewController.swift
+++ b/entourage/Scenes/Events/EventDetailFeedViewController.swift
@@ -287,7 +287,7 @@ class EventDetailFeedViewController: UIViewController {
             
             if event == nil {
                 let alertController = UIAlertController(title: "Attention",
-                                                        message: "Cet événement a été supprimé",
+                                                        message: "Cet événement a été annulé",
                                                         preferredStyle: .alert)
                 let closeAction = UIAlertAction(title: "Fermer", style: .default, handler: nil)
                 alertController.addAction(closeAction)


### PR DESCRIPTION
- Replaced the hardcoded popup text `"Cet événement a été supprimé"` with `"Cet événement a été annulé"` in `EventDetailFeedViewController.swift` when an event is missing from the backend (or canceled).
- Validated that `params_cancel_event_pop_bt_delete` correctly uses "Annuler" for event popups where it's called.

---
*PR created automatically by Jules for task [7686834171309223005](https://jules.google.com/task/7686834171309223005) started by @clemPerrousset*