### PR TITLE
feat: reorganize event detail view according to mockup

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -1699,3 +1699,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "Tomorrow" = "غدا";
 "home_v2_moderator_title_format" = "%@، جهة اتصالك المميزة";
 "home_v2_moderator_subtitle" = "أنا جزء من فريق Entourage وأنا هنا لمرافقتك. لا تتردد إذا كان لديك أي أسئلة! 🤗";
+"event_discussion_card_title" = "You can ask questions and discuss with the organizer and event participants.";
+"leave_event" = "Leave event";
+"cancel_event" = "Cancel event";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -1760,3 +1760,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "Tomorrow" = "Morgen";
 "home_v2_moderator_title_format" = "%@, Ihr privilegierter Kontakt";
 "home_v2_moderator_subtitle" = "Ich gehöre zum Entourage-Team und bin hier, um Sie zu unterstützen. Zögern Sie nicht, wenn Sie Fragen haben! 🤗";
+"event_discussion_card_title" = "You can ask questions and discuss with the organizer and event participants.";
+"leave_event" = "Leave event";
+"cancel_event" = "Cancel event";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -1966,3 +1966,6 @@
 "event_detail_reserved_female_label" = "This event is reserved for women";
 "home_v2_moderator_title_format" = "%@, your privileged contact";
 "home_v2_moderator_subtitle" = "I am part of the Entourage team and I am here to support you. Do not hesitate if you have any questions! 🤗";
+"event_discussion_card_title" = "You can ask questions and discuss with the organizer and event participants.";
+"leave_event" = "Leave event";
+"cancel_event" = "Cancel event";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -3183,3 +3183,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "Tomorrow" = "Mañana";
 "home_v2_moderator_title_format" = "%@, tu contacto privilegiado";
 "home_v2_moderator_subtitle" = "Formo parte del equipo de Entourage y estoy aquí para acompañarte. ¡No dudes en preguntar si tienes alguna duda! 🤗";
+"event_discussion_card_title" = "You can ask questions and discuss with the organizer and event participants.";
+"leave_event" = "Leave event";
+"cancel_event" = "Cancel event";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1964,3 +1964,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_tool_card_ethics" = "Charte éthique Entourage";
 "home_v2_moderator_title_format" = "%@, votre contact privilégié";
 "home_v2_moderator_subtitle" = "Je fais parti·e de l'équipe Entourage et je suis là pour vous accompagner. N'hésitez pas si vous avez des questions ! 🤗";
+"event_discussion_card_title" = "Vous pouvez poser vos questions et échanger avec l'organisateur et les participants de l'événement";
+"leave_event" = "Quitter l'événement";
+"cancel_event" = "Annuler l'événement";

--- a/entourage/Assets/hr.lproj/Localizable.strings
+++ b/entourage/Assets/hr.lproj/Localizable.strings
@@ -1437,3 +1437,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_title_small_talk" = "Pridružite se solidarnoj raspravi";
 "small_talk_subtitle_match" = "Povezujemo vas s malom grupom ljudi koji dijele vaše interese, bilo gdje u Francuskoj.";
 "Tomorrow" = "Sutra";
+"event_discussion_card_title" = "You can ask questions and discuss with the organizer and event participants.";
+"leave_event" = "Leave event";
+"cancel_event" = "Cancel event";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -1774,3 +1774,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "Tomorrow" = "Jutro";
 "home_v2_moderator_title_format" = "%@, twój uprzywilejowany kontakt";
 "home_v2_moderator_subtitle" = "Jestem częścią zespołu Entourage i jestem tutaj, aby ci towarzyszyć. Nie wahaj się, jeśli masz pytania! 🤗";
+"event_discussion_card_title" = "You can ask questions and discuss with the organizer and event participants.";
+"leave_event" = "Leave event";
+"cancel_event" = "Cancel event";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -1663,3 +1663,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "Tomorrow" = "Mâine";
 "home_v2_moderator_title_format" = "%@, contactul tău privilegiat";
 "home_v2_moderator_subtitle" = "Fac parte din echipa Entourage și sunt aici să te însoțesc. Nu ezita dacă ai întrebări! 🤗";
+"event_discussion_card_title" = "You can ask questions and discuss with the organizer and event participants.";
+"leave_event" = "Leave event";
+"cancel_event" = "Cancel event";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -1740,3 +1740,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "Tomorrow" = "Завтра";
 "home_v2_moderator_title_format" = "%@, твій привілейований контакт";
 "home_v2_moderator_subtitle" = "Я є частиною команди Entourage і тут, щоб супроводжувати тебе. Не соромся, якщо у тебе є питання! 🤗";
+"event_discussion_card_title" = "You can ask questions and discuss with the organizer and event participants.";
+"leave_event" = "Leave event";
+"cancel_event" = "Cancel event";

--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
@@ -36,12 +36,12 @@ class EventDetailTopFullCell: UITableViewCell {
     @IBOutlet weak var ui_view_organised_by: UIView!
     @IBOutlet weak var ui_view_association: UIView!
     @IBOutlet weak var ui_label_association: UILabel!
-    @IBOutlet weak var ui_btn_share: UIButton!
-    @IBOutlet weak var ui_btn_participate: UIButton!
     @IBOutlet weak var ui_button_go_to_discussion: UIButton!
     @IBOutlet weak var ui_height_map_view: NSLayoutConstraint!
     
-    @IBOutlet weak var ui_btn_agenda: UIButton!
+    @IBOutlet weak var ui_lbl_discussion_title: UILabel!
+    @IBOutlet weak var ui_view_discussion_card: UIView!
+
     // **Nouvelle IBOutlet** pour la carte
     @IBOutlet weak var ui_mapview: MKMapView!
     @IBOutlet weak var ui_btn_i_participate: UIButton!
@@ -96,14 +96,13 @@ class EventDetailTopFullCell: UITableViewCell {
 
         ui_view_place_limit.isHidden = true
         
-        ui_btn_share.addTarget(self, action: #selector(onShareBtnClick), for: .touchUpInside)
-        configureWhiteButton(self.ui_btn_share, withTitle: "neighborhood_add_post_send_button".localized)
-        configureWhiteButton(self.ui_btn_participate, withTitle: "event_detail_button_participe_ON".localized)
-        configureWhiteButton(self.ui_btn_agenda, withTitle: "event_button_add_calendar".localized)
         configureOrangeButton(self.ui_button_go_to_discussion, withTitle: "event_conversation".localized)
         
-        self.ui_btn_agenda.addTarget(self, action: #selector(onAgendaClick), for: .touchUpInside)
-        self.ui_btn_participate.addTarget(self, action: #selector(onParticipateClick), for: .touchUpInside)
+        ui_lbl_discussion_title.setupFontAndColor(style: ApplicationTheme.getFontCourantRegularNoir())
+        ui_lbl_discussion_title.text = "event_discussion_card_title".localized
+
+        ui_view_discussion_card.backgroundColor = .appBeigeClair
+        ui_view_discussion_card.layer.cornerRadius = 15
         
         // **Initialisation de la carte**
         ui_mapview.delegate = self
@@ -121,7 +120,7 @@ class EventDetailTopFullCell: UITableViewCell {
     @objc func onParticipateClick() {
         delegate?.joinLeave()
     }
-    @objc func onAgendaClick() {
+    @IBAction func onAgendaClick() {
         delegate?.showAgenda()
     }
     
@@ -162,10 +161,10 @@ class EventDetailTopFullCell: UITableViewCell {
         self.delegate = delegate
         if event?.isMember ?? false {
             self.ui_btn_i_participate.isHidden = false
-            self.ui_btn_agenda.isHidden = false
+            self.ui_view_discussion_card.isHidden = false
         }else{
             self.ui_btn_i_participate.isHidden = true
-            self.ui_btn_agenda.isHidden = true
+            self.ui_view_discussion_card.isHidden = true
         }
         
         ui_img_member_1.isHidden = true

--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
@@ -145,6 +145,12 @@
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n8b-KZ-OHc">
                                                 <rect key="frame" x="0.0" y="0.0" width="366" height="20"/>
                                                 <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="agenda_btn_click">
+                                                        <rect key="frame" x="0.0" y="0.0" width="122" height="20"/>
+                                                        <connections>
+                                                            <action selector="onAgendaClick" destination="lzF-C2-Z1g" eventType="touchUpInside" id="agenda_click_action"/>
+                                                        </connections>
+                                                    </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_event_date" translatesAutoresizingMaskIntoConstraints="NO" id="uWV-jG-Iea">
                                                         <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
                                                         <constraints>
@@ -186,6 +192,10 @@
                                                     </view>
                                                 </subviews>
                                                 <constraints>
+                                                    <constraint firstItem="agenda_btn_click" firstAttribute="top" secondItem="n8b-KZ-OHc" secondAttribute="top" id="agenda_btn_top"/>
+                                                    <constraint firstItem="agenda_btn_click" firstAttribute="leading" secondItem="n8b-KZ-OHc" secondAttribute="leading" id="agenda_btn_lead"/>
+                                                    <constraint firstAttribute="bottom" secondItem="agenda_btn_click" secondAttribute="bottom" id="agenda_btn_bot"/>
+                                                    <constraint firstItem="agenda_btn_click" firstAttribute="trailing" secondItem="nNO-3W-e8V" secondAttribute="trailing" constant="10" id="agenda_btn_trail"/>
                                                     <constraint firstItem="uWV-jG-Iea" firstAttribute="leading" secondItem="n8b-KZ-OHc" secondAttribute="leading" id="0z5-d5-WJX"/>
                                                     <constraint firstItem="8TA-y7-TCS" firstAttribute="centerY" secondItem="nNO-3W-e8V" secondAttribute="centerY" id="1E1-To-2x8"/>
                                                     <constraint firstItem="uWV-jG-Iea" firstAttribute="top" secondItem="n8b-KZ-OHc" secondAttribute="top" id="8AB-t1-w3F"/>
@@ -396,48 +406,6 @@
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </view>
-                    <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lgR-Y6-WWf">
-                        <rect key="frame" x="20" y="259" width="120" height="44"/>
-                        <color key="backgroundColor" name="orange_medium"/>
-                        <constraints>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="2Dh-bO-hHl"/>
-                            <constraint firstAttribute="height" constant="44" id="LXI-91-DvG"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" name="NunitoSans-Bold" family="Nunito Sans" pointSize="13"/>
-                        <color key="tintColor" name="orange_app"/>
-                        <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="10" maxY="0.0"/>
-                        <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="10" maxY="0.0"/>
-                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                        <state key="normal" title="Partager" image="ic_share_light">
-                            <color key="titleColor" name="orange_app"/>
-                        </state>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="number" keyPath="cradius">
-                                <real key="value" value="22"/>
-                            </userDefinedRuntimeAttribute>
-                        </userDefinedRuntimeAttributes>
-                    </button>
-                    <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G9W-bu-4QC">
-                        <rect key="frame" x="160" y="259" width="180" height="44"/>
-                        <color key="backgroundColor" name="orange_medium"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="44" id="3JA-om-kVl"/>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="180" id="Fx4-cK-8lv"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" name="NunitoSans-Bold" family="Nunito Sans" pointSize="13"/>
-                        <color key="tintColor" name="orange_app"/>
-                        <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="10" maxY="0.0"/>
-                        <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="10" maxY="0.0"/>
-                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                        <state key="normal" title="Ajouter à l'agenda" image="ic_calendar_light">
-                            <color key="titleColor" name="orange_app"/>
-                        </state>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="number" keyPath="cradius">
-                                <real key="value" value="22"/>
-                            </userDefinedRuntimeAttribute>
-                        </userDefinedRuntimeAttributes>
-                    </button>
                     <mapView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" mapType="standard" zoomEnabled="NO" scrollEnabled="NO" rotateEnabled="NO" pitchEnabled="NO" showsCompass="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1V4-oV-Dh3">
                         <rect key="frame" x="20" y="585" width="366" height="180"/>
                         <gestureRecognizers/>
@@ -445,60 +413,85 @@
                             <constraint firstAttribute="height" constant="180" id="RMI-gf-7rR"/>
                         </constraints>
                     </mapView>
-                    <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1xV-ay-YP1">
-                        <rect key="frame" x="20" y="785" width="366" height="0.0"/>
-                        <color key="backgroundColor" name="orange_medium"/>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="discussion_card_view">
+                        <rect key="frame" x="20" y="785" width="366" height="150"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Vous pouvez poser vos questions et échanger avec l'organisateur et les participants de l'événement" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="discussion_card_lbl">
+                                <rect key="frame" x="80" y="20" width="266" height="50"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_bubble_orange" translatesAutoresizingMaskIntoConstraints="NO" id="discussion_card_img">
+                                <rect key="frame" x="20" y="25" width="40" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="40" id="disc_img_w"/>
+                                    <constraint firstAttribute="height" constant="40" id="disc_img_h"/>
+                                </constraints>
+                            </imageView>
+                            <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="discussion_card_btn">
+                                <rect key="frame" x="40" y="86" width="286" height="44"/>
+                                <color key="backgroundColor" name="orange_app"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="disc_btn_h"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="NunitoSans-Bold" family="Nunito Sans" pointSize="15"/>
+                                <color key="tintColor" name="orange_app"/>
+                                <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="10" maxY="0.0"/>
+                                <state key="normal" title="Discussion de l'événement">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="22"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="action_go_to_discussion:" destination="lzF-C2-Z1g" eventType="touchUpInside" id="disc_btn_action"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="PyF-3s-UYK"/>
-                            <constraint firstAttribute="height" id="de9-KG-C33"/>
+                            <constraint firstItem="discussion_card_lbl" firstAttribute="top" secondItem="discussion_card_view" secondAttribute="top" constant="20" id="disc_lbl_top"/>
+                            <constraint firstItem="discussion_card_lbl" firstAttribute="leading" secondItem="discussion_card_img" secondAttribute="trailing" constant="20" id="disc_lbl_lead"/>
+                            <constraint firstAttribute="trailing" secondItem="discussion_card_lbl" secondAttribute="trailing" constant="20" id="disc_lbl_trail"/>
+                            <constraint firstItem="discussion_card_img" firstAttribute="leading" secondItem="discussion_card_view" secondAttribute="leading" constant="20" id="disc_img_lead"/>
+                            <constraint firstItem="discussion_card_img" firstAttribute="top" secondItem="discussion_card_view" secondAttribute="top" constant="25" id="disc_img_top"/>
+                            <constraint firstItem="discussion_card_btn" firstAttribute="top" secondItem="discussion_card_lbl" secondAttribute="bottom" constant="16" id="disc_btn_top"/>
+                            <constraint firstItem="discussion_card_btn" firstAttribute="leading" secondItem="discussion_card_view" secondAttribute="leading" constant="40" id="disc_btn_lead"/>
+                            <constraint firstAttribute="trailing" secondItem="discussion_card_btn" secondAttribute="trailing" constant="40" id="disc_btn_trail"/>
+                            <constraint firstAttribute="bottom" secondItem="discussion_card_btn" secondAttribute="bottom" constant="20" id="disc_btn_bot"/>
                         </constraints>
-                        <fontDescription key="fontDescription" name="NunitoSans-Bold" family="Nunito Sans" pointSize="15"/>
-                        <color key="tintColor" name="orange_app"/>
-                        <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="10" maxY="0.0"/>
-                        <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="10" maxY="0.0"/>
-                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                        <state key="normal" title="Partager" image="ic_share">
-                            <color key="titleColor" name="orange_app"/>
-                        </state>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="number" keyPath="cradius">
-                                <real key="value" value="20"/>
-                            </userDefinedRuntimeAttribute>
-                        </userDefinedRuntimeAttributes>
-                    </button>
+                    </view>
                 </subviews>
                 <color key="backgroundColor" name="BeigeClair"/>
                 <constraints>
                     <constraint firstItem="1V4-oV-Dh3" firstAttribute="leading" secondItem="fuU-Rj-r2w" secondAttribute="leading" id="0qB-9a-Mfi"/>
-                    <constraint firstItem="G9W-bu-4QC" firstAttribute="leading" secondItem="lgR-Y6-WWf" secondAttribute="trailing" constant="20" id="4oR-cO-90w"/>
                     <constraint firstAttribute="trailing" secondItem="Nfw-W1-dO7" secondAttribute="trailing" constant="10" id="5jS-dB-laQ"/>
-                    <constraint firstItem="G9W-bu-4QC" firstAttribute="centerY" secondItem="lgR-Y6-WWf" secondAttribute="centerY" id="A8G-fg-LMj"/>
                     <constraint firstItem="fuU-Rj-r2w" firstAttribute="top" secondItem="CsR-kO-usD" secondAttribute="bottom" constant="24" id="At5-0v-xFn"/>
-                    <constraint firstItem="1xV-ay-YP1" firstAttribute="top" secondItem="1V4-oV-Dh3" secondAttribute="bottom" constant="20" id="FLo-2B-sZ1"/>
+                    <constraint firstItem="discussion_card_view" firstAttribute="top" secondItem="1V4-oV-Dh3" secondAttribute="bottom" constant="20" id="FLo-2B-sZ1"/>
                     <constraint firstItem="fuU-Rj-r2w" firstAttribute="leading" secondItem="CsR-kO-usD" secondAttribute="leading" id="FRM-kF-rtM"/>
                     <constraint firstItem="GxR-dy-Owz" firstAttribute="top" secondItem="Nfw-W1-dO7" secondAttribute="bottom" id="Ggf-Ol-fWh"/>
                     <constraint firstItem="Nfw-W1-dO7" firstAttribute="leading" secondItem="klB-o1-C0m" secondAttribute="leading" id="H0K-5a-a4q"/>
                     <constraint firstAttribute="trailing" secondItem="GxR-dy-Owz" secondAttribute="trailing" constant="20" id="H5r-RL-hLC"/>
                     <constraint firstItem="CsR-kO-usD" firstAttribute="top" secondItem="UXs-ZL-Ra7" secondAttribute="bottom" constant="4" id="I8J-Cg-s0T"/>
                     <constraint firstItem="GxR-dy-Owz" firstAttribute="leading" secondItem="3q6-vS-dBw" secondAttribute="leading" constant="20" id="MEB-HA-ivE"/>
-                    <constraint firstItem="lgR-Y6-WWf" firstAttribute="top" secondItem="IcL-ha-FmW" secondAttribute="bottom" constant="16" id="MxB-HS-Hf2"/>
                     <constraint firstItem="klB-o1-C0m" firstAttribute="leading" secondItem="3q6-vS-dBw" secondAttribute="leading" constant="20" id="R9N-C9-cmG"/>
                     <constraint firstAttribute="trailing" secondItem="fuU-Rj-r2w" secondAttribute="trailing" constant="20" id="RgV-tb-QmG"/>
                     <constraint firstItem="UXs-ZL-Ra7" firstAttribute="leading" secondItem="klB-o1-C0m" secondAttribute="leading" id="UYw-0d-rgq"/>
-                    <constraint firstItem="1xV-ay-YP1" firstAttribute="trailing" secondItem="1V4-oV-Dh3" secondAttribute="trailing" id="Ujl-4M-eMB"/>
-                            <constraint firstItem="abc-female-banner" firstAttribute="top" secondItem="klB-o1-C0m" secondAttribute="bottom" constant="5" id="tuv-banner-top"/>
-                            <constraint firstItem="abc-female-banner" firstAttribute="leading" secondItem="klB-o1-C0m" secondAttribute="leading" id="wxy-banner-leading"/>
-                            <constraint firstItem="abc-female-banner" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="klB-o1-C0m" secondAttribute="trailing" id="xyz-banner-trailing"/>
-                            <constraint firstItem="Nfw-W1-dO7" firstAttribute="top" secondItem="abc-female-banner" secondAttribute="bottom" constant="10" id="VQC-kR-A9p"/>
-                    <constraint firstAttribute="bottom" secondItem="1xV-ay-YP1" secondAttribute="bottom" constant="20" id="Vpw-kr-Z8k"/>
-                    <constraint firstItem="lgR-Y6-WWf" firstAttribute="leading" secondItem="klB-o1-C0m" secondAttribute="leading" id="Y0c-Lv-hqK"/>
+                    <constraint firstItem="discussion_card_view" firstAttribute="trailing" secondItem="1V4-oV-Dh3" secondAttribute="trailing" id="Ujl-4M-eMB"/>
+                    <constraint firstItem="abc-female-banner" firstAttribute="top" secondItem="klB-o1-C0m" secondAttribute="bottom" constant="5" id="tuv-banner-top"/>
+                    <constraint firstItem="abc-female-banner" firstAttribute="leading" secondItem="klB-o1-C0m" secondAttribute="leading" id="wxy-banner-leading"/>
+                    <constraint firstItem="abc-female-banner" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="klB-o1-C0m" secondAttribute="trailing" id="xyz-banner-trailing"/>
+                    <constraint firstItem="Nfw-W1-dO7" firstAttribute="top" secondItem="abc-female-banner" secondAttribute="bottom" constant="10" id="VQC-kR-A9p"/>
+                    <constraint firstAttribute="bottom" secondItem="discussion_card_view" secondAttribute="bottom" constant="20" id="Vpw-kr-Z8k"/>
                     <constraint firstItem="CsR-kO-usD" firstAttribute="leading" secondItem="UXs-ZL-Ra7" secondAttribute="leading" id="aoe-s2-pzF"/>
                     <constraint firstAttribute="trailing" secondItem="klB-o1-C0m" secondAttribute="trailing" constant="20" id="hwX-yn-nXS"/>
                     <constraint firstItem="1V4-oV-Dh3" firstAttribute="trailing" secondItem="fuU-Rj-r2w" secondAttribute="trailing" id="img-dY-dzj"/>
-                    <constraint firstItem="UXs-ZL-Ra7" firstAttribute="top" secondItem="lgR-Y6-WWf" secondAttribute="bottom" constant="20" id="j3o-v2-zLf"/>
                     <constraint firstItem="1V4-oV-Dh3" firstAttribute="top" secondItem="fuU-Rj-r2w" secondAttribute="bottom" constant="20" id="kIP-Dp-8gQ"/>
                     <constraint firstAttribute="trailing" secondItem="CsR-kO-usD" secondAttribute="trailing" constant="28" id="n7J-Wl-s1L"/>
-                    <constraint firstItem="1xV-ay-YP1" firstAttribute="leading" secondItem="1V4-oV-Dh3" secondAttribute="leading" id="qy7-A3-TNT"/>
+                    <constraint firstItem="discussion_card_view" firstAttribute="leading" secondItem="1V4-oV-Dh3" secondAttribute="leading" id="qy7-A3-TNT"/>
                     <constraint firstItem="klB-o1-C0m" firstAttribute="top" secondItem="3q6-vS-dBw" secondAttribute="top" constant="28" id="yC2-ZV-76o"/>
                     <constraint firstAttribute="trailing" secondItem="UXs-ZL-Ra7" secondAttribute="trailing" constant="28" id="yGN-4g-yQG"/>
                 </constraints>
@@ -506,14 +499,13 @@
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <connections>
                 <outlet property="adress_view_top_constraint" destination="yX0-kE-283" id="tad-Gm-gRd"/>
-                <outlet property="ui_btn_agenda" destination="G9W-bu-4QC" id="BSR-SG-7Es"/>
                 <outlet property="ui_view_reserved_female" destination="abc-female-banner" id="out-view-reserved"/>
                 <outlet property="ui_lbl_reserved_female" destination="def-female-label" id="out-lbl-reserved"/>
                 <outlet property="ui_constraint_height_reserved_female" destination="hij-height-constraint" id="out-constraint-height"/>
                 <outlet property="ui_btn_i_participate" destination="IR4-sb-IgC" id="2Bw-Ef-4tt"/>
-                <outlet property="ui_btn_participate" destination="1xV-ay-YP1" id="H26-cy-lt3"/>
-                <outlet property="ui_btn_share" destination="lgR-Y6-WWf" id="Lqp-Ta-LcQ"/>
-                <outlet property="ui_button_go_to_discussion" destination="1xV-ay-YP1" id="Q8G-5Z-zcy"/>
+                <outlet property="ui_button_go_to_discussion" destination="discussion_card_btn" id="Q8G-5Z-zcy"/>
+                <outlet property="ui_lbl_discussion_title" destination="discussion_card_lbl" id="disc_card_lbl"/>
+                <outlet property="ui_view_discussion_card" destination="discussion_card_view" id="disc_card_view"/>
                 <outlet property="ui_constraint_listview_top_margin" destination="At5-0v-xFn" id="CGo-JX-gSb"/>
                 <outlet property="ui_height_map_view" destination="RMI-gf-7rR" id="iKr-JI-BjL"/>
                 <outlet property="ui_img_member_1" destination="2x2-3v-72B" id="SOR-qC-Iu0"/>

--- a/entourage/Scenes/Events/EventDetailFeedViewController.swift
+++ b/entourage/Scenes/Events/EventDetailFeedViewController.swift
@@ -26,7 +26,7 @@ class EventDetailFeedViewController: UIViewController {
     
     @IBOutlet weak var ui_view_button_back: UIView!
     @IBOutlet weak var ui_view_button_settings: UIView!
-    
+    @IBOutlet weak var ui_view_button_share: UIView!
     
     @IBOutlet weak var ui_view_full_image: UIView!
     @IBOutlet weak var ui_scrollview: UIScrollView!
@@ -88,6 +88,7 @@ class EventDetailFeedViewController: UIViewController {
         
         addShadowAndRadius(customView: ui_view_button_settings)
         addShadowAndRadius(customView: ui_view_button_back)
+        addShadowAndRadius(customView: ui_view_button_share)
         
         ui_top_view.backgroundColor = .clear
         ui_top_view.populateCustom(title: nil,
@@ -120,6 +121,10 @@ class EventDetailFeedViewController: UIViewController {
         AnalyticsLoggerManager.logEvent(name: Event_detail_main)
         configureOrangeButton(self.ui_btn_participate_and_see_conv, withTitle: "event_conversation".localized)
         ui_btn_participate_and_see_conv.addTarget(self, action: #selector(button_join_leave_see), for: .touchUpInside)
+    }
+
+    @IBAction func action_share(_ sender: Any) {
+        self.share()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -299,11 +304,14 @@ class EventDetailFeedViewController: UIViewController {
             AppSignableManager.shared.updateFromEvent(event: event!)
             self.eventId = event?.uid ?? 0
             if event?.isMember ?? false {
-                self.configureOrangeButton(self.ui_btn_participate_and_see_conv, withTitle: "event_conversation".localized)
+                if let currentUserId = UserDefaults.currentUser?.sid, event?.author?.uid == currentUserId {
+                    self.configureOrangeButton(self.ui_btn_participate_and_see_conv, withTitle: "cancel_event".localized)
+                } else {
+                    self.configureOrangeButton(self.ui_btn_participate_and_see_conv, withTitle: "leave_event".localized)
+                }
                 self.ui_btn_participate_and_see_conv.isHidden = false
             }else{
-                self.configureOrangeButton(self.ui_btn_participate_and_see_conv, withTitle: "go_to_event_conversation".localized)
-                self.ui_btn_participate_and_see_conv.isHidden = false
+                self.ui_btn_participate_and_see_conv.isHidden = true
             }
             // Si l’événement est annulé => on affiche le bandeau
             if event?.isCanceled() ?? false {
@@ -439,7 +447,26 @@ class EventDetailFeedViewController: UIViewController {
     
     @objc func button_join_leave_see(){
         AnalyticsLoggerManager.logEvent(name: Event_detail_action_participate)
-        joinLeaveEvent()
+
+        guard let currentUserId = UserDefaults.currentUser?.sid else { return }
+
+        if event?.author?.uid == currentUserId {
+            let customAlert = MJAlertController()
+            let buttonCancel = MJAlertButtonType(title: "params_cancel_event_pop_bt_cancel".localized, titleStyle: ApplicationTheme.getFontCourantBoldBlanc(), bgColor: .appOrangeLight, cornerRadius: -1)
+            let buttonValidate = MJAlertButtonType(title: "params_cancel_event_pop_bt_delete".localized, titleStyle: ApplicationTheme.getFontCourantBoldBlanc(), bgColor: .appOrange, cornerRadius: -1)
+            customAlert.configureAlert(alertTitle: "params_cancel_event_pop_title".localized, message: "params_cancel_event_pop_message".localized, buttonrightType: buttonValidate, buttonLeftType: buttonCancel, titleStyle: ApplicationTheme.getFontCourantBoldOrange(), messageStyle: ApplicationTheme.getFontCourantRegularNoir(), mainviewBGColor: .white, mainviewRadius: 35, isButtonCloseHidden: true)
+            customAlert.alertTagName = .Suppress
+            customAlert.delegate = self
+            customAlert.show()
+        } else {
+            let customAlert = MJAlertController()
+            let buttonCancel = MJAlertButtonType(title: "params_leave_event_pop_bt_cancel".localized, titleStyle: ApplicationTheme.getFontCourantBoldBlanc(), bgColor: .appOrangeLight, cornerRadius: -1)
+            let buttonValidate = MJAlertButtonType(title: "params_leave_event_pop_bt_quit".localized, titleStyle: ApplicationTheme.getFontCourantBoldBlanc(), bgColor: .appOrange, cornerRadius: -1)
+            customAlert.configureAlert(alertTitle: "params_leave_event_pop_title".localized, message: "params_leave_event_pop_message".localized, buttonrightType: buttonValidate, buttonLeftType: buttonCancel, titleStyle: ApplicationTheme.getFontCourantBoldOrange(), messageStyle: ApplicationTheme.getFontCourantRegularNoir(), mainviewBGColor: .white, mainviewRadius: 35, isButtonCloseHidden: true)
+            customAlert.alertTagName = .None
+            customAlert.delegate = self
+            customAlert.show()
+        }
     }
     
     @IBAction func action_join(_ sender: Any) {
@@ -633,6 +660,7 @@ extension EventDetailFeedViewController: UITableViewDataSource, UITableViewDeleg
             let heightImage = min(max(yImage - diffImage, self.minImageHeight), self.maxImageHeight)
             
             self.ui_view_button_settings.alpha = heightImage / self.maxImageHeight
+            self.ui_view_button_share.alpha = heightImage / self.maxImageHeight
             self.ui_view_button_back.alpha = heightImage / self.maxImageHeight
             self.ui_iv_event2.alpha = heightImage / self.maxImageHeight
             self.ui_view_top_bg.alpha = 1 - (heightImage / self.maxImageHeight)
@@ -667,6 +695,17 @@ extension EventDetailFeedViewController: MJAlertControllerDelegate {
             self.sendLeaveGroup()
         }
         
+        // Tag .Suppress => annuler l'événement
+        if alertTag == .Suppress {
+            SVProgressHUD.show()
+            EventService.cancelEvent(eventId: eventId) { error in
+                SVProgressHUD.dismiss()
+                if error == nil {
+                    self.goBack()
+                }
+            }
+        }
+
         // Paramètres pour autoriser l’accès au calendrier
         if alertTag == .AcceptSettings {
             if let url = URL(string: UIApplication.openSettingsURLString) {

--- a/entourage/Storyboards/Event.storyboard
+++ b/entourage/Storyboards/Event.storyboard
@@ -586,11 +586,19 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s64-Vk-nq7">
-                                <rect key="frame" x="342" y="110" width="40" height="40"/>
+                                <rect key="frame" x="350" y="110" width="40" height="40"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="geH-qY-i1u"/>
                                     <constraint firstAttribute="width" constant="40" id="hrB-4O-lep"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="share_view_bg">
+                                <rect key="frame" x="298" y="110" width="40" height="40"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="share_h"/>
+                                    <constraint firstAttribute="width" constant="40" id="share_w"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="keO-la-aOU" customClass="MJNavBackView" customModule="Ent_Beta" customModuleProvider="target">
@@ -602,7 +610,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tG7-Gh-1Qg">
-                                <rect key="frame" x="342" y="110" width="40" height="40"/>
+                                <rect key="frame" x="350" y="110" width="40" height="40"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="Ncr-OO-VCc"/>
@@ -613,6 +621,19 @@
                                 <state key="normal" image="ic_setting_mini"/>
                                 <connections>
                                     <action selector="action_show_params:" destination="1Sc-VH-DcS" eventType="touchUpInside" id="2mn-Sb-9N8"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="share_btn_top">
+                                <rect key="frame" x="298" y="110" width="40" height="40"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="share_btn_h"/>
+                                    <constraint firstAttribute="width" constant="40" id="share_btn_w"/>
+                                </constraints>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" image="ic_share"/>
+                                <connections>
+                                    <action selector="action_share:" destination="1Sc-VH-DcS" eventType="touchUpInside" id="action_share_id"/>
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0g5-JR-O6f">
@@ -717,7 +738,11 @@
                         <viewLayoutGuide key="safeArea" id="h8q-3a-IrB"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
-                            <constraint firstItem="tG7-Gh-1Qg" firstAttribute="trailing" secondItem="keO-la-aOU" secondAttribute="trailing" constant="-32" id="7aL-Dj-2Gi"/>
+                            <constraint firstItem="tG7-Gh-1Qg" firstAttribute="trailing" secondItem="keO-la-aOU" secondAttribute="trailing" constant="-24" id="7aL-Dj-2Gi"/>
+                            <constraint firstItem="tG7-Gh-1Qg" firstAttribute="leading" secondItem="share_btn_top" secondAttribute="trailing" constant="12" id="share_btn_trailing"/>
+                            <constraint firstItem="share_btn_top" firstAttribute="centerY" secondItem="tG7-Gh-1Qg" secondAttribute="centerY" id="share_btn_cy"/>
+                            <constraint firstItem="share_view_bg" firstAttribute="centerY" secondItem="tG7-Gh-1Qg" secondAttribute="centerY" id="share_bg_cy"/>
+                            <constraint firstItem="share_view_bg" firstAttribute="centerX" secondItem="share_btn_top" secondAttribute="centerX" id="share_bg_cx"/>
                             <constraint firstItem="WNs-CT-aUo" firstAttribute="trailing" secondItem="h8q-3a-IrB" secondAttribute="trailing" id="7ls-5s-mwR"/>
                             <constraint firstAttribute="trailing" secondItem="96a-eR-4eP" secondAttribute="trailing" id="AKM-9r-Tm6"/>
                             <constraint firstItem="0En-it-5CA" firstAttribute="top" secondItem="2TO-pb-TzV" secondAttribute="top" id="B6F-ni-lEg"/>
@@ -769,6 +794,7 @@
                         <outlet property="ui_top_view" destination="keO-la-aOU" id="DvQ-Fl-zDo"/>
                         <outlet property="ui_view_button_back" destination="b8a-81-v78" id="BBI-5w-v4X"/>
                         <outlet property="ui_view_button_settings" destination="s64-Vk-nq7" id="16m-Dx-c8f"/>
+                        <outlet property="ui_view_button_share" destination="share_view_bg" id="share_view_id"/>
                         <outlet property="ui_view_canceled" destination="zD4-yh-EWb" id="YcB-OI-TiJ"/>
                         <outlet property="ui_view_full_image" destination="96a-eR-4eP" id="EoY-Ox-lgc"/>
                         <outlet property="ui_view_height_constraint" destination="gE9-Dv-TuC" id="gE4-lk-NXE"/>


### PR DESCRIPTION
- Added a new 'Event Discussion' block replacing the old view conversation logic
- Relocated 'Share' button to the top navigation bar and removed from cell
- 'Add to Calendar' functionality moved to the date text instead of a dedicated button
- Changed the floating 'participate/view conversation' bottom button to 'Leave Event' / 'Cancel Event' based on user rights
- Updated layout in EventDetailTopFullCell
- Added relevant localized strings across all language files

---
*PR created automatically by Jules for task [4683669146282285928](https://jules.google.com/task/4683669146282285928) started by @clemPerrousset*