### PR TITLE
fix: correct "no results" placeholder visibility in members lists

### DIFF
--- a/entourage/Scenes/Conversations/ConversationListMembersViewController.swift
+++ b/entourage/Scenes/Conversations/ConversationListMembersViewController.swift
@@ -124,6 +124,10 @@ class ConversationListMembersViewController: BasePopViewController {
                 self.ui_tableview.tableFooterView = (self.nextPage != nil)
                     ? self.makeLoadingFooter()
                     : UIView()
+
+                if !self.isSearch {
+                    self.ui_view_no_result.isHidden = !self.users.isEmpty
+                }
             }
         }
 
@@ -170,7 +174,9 @@ class ConversationListMembersViewController: BasePopViewController {
         usersSearch = users.filter {
             $0.username?.lowercased().contains(text.lowercased()) ?? false
         }
-        ui_view_no_result.isHidden = !usersSearch.isEmpty
+        if isSearch {
+            ui_view_no_result.isHidden = !usersSearch.isEmpty
+        }
         ui_tableview.reloadData()
     }
 }
@@ -273,7 +279,7 @@ extension ConversationListMembersViewController: NeighborhoodHomeSearchDelegate 
             isSearch = false
             usersSearch.removeAll()
             isAlreadyClearRows = false
-            ui_view_no_result.isHidden = true
+            ui_view_no_result.isHidden = !users.isEmpty
             ui_tableview.reloadData()
         }
     }
@@ -282,7 +288,7 @@ extension ConversationListMembersViewController: NeighborhoodHomeSearchDelegate 
         // gère le moment où l'utilisateur appuie sur la loupe sans texte
         isSearch = true
         isAlreadyClearRows.toggle()
-        ui_view_no_result.isHidden = true
+        ui_view_no_result.isHidden = !usersSearch.isEmpty
         ui_tableview.reloadData()
     }
 }

--- a/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
@@ -174,6 +174,9 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
                     self.rebuildTableDataFromUsers()
                     self.currentPage = nextPage ?? self.currentPage
                     self.hasMorePages = nextPage != nil
+                    if !self.isSearch {
+                        self.ui_view_no_result.isHidden = !self.users.isEmpty
+                    }
                 } else if let error = error {
                     print("Erreur lors de la récupération des utilisateurs: \(error)")
                 }
@@ -203,7 +206,9 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
                     self.rebuildTableDataFromUsers()
                     self.currentPage = nextPage ?? self.currentPage
                     self.hasMorePages = nextPage != nil
-                    self.ui_view_no_result.isHidden = !users.isEmpty
+                    if !self.isSearch {
+                        self.ui_view_no_result.isHidden = !self.users.isEmpty
+                    }
                 }
             }
         }
@@ -221,10 +226,14 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
         usersSearch.append(contentsOf: searchedUsers)
 
         tableData = [.searchCell]
-        if usersSearch.isEmpty {
-            ui_view_no_result.isHidden = false
+        if isSearch {
+            if usersSearch.isEmpty {
+                ui_view_no_result.isHidden = false
+            } else {
+                ui_view_no_result.isHidden = true
+                tableData += searchedUsers.map { .userCell(user: $0, reactionType: nil) }
+            }
         } else {
-            ui_view_no_result.isHidden = true
             tableData += searchedUsers.map { .userCell(user: $0, reactionType: nil) }
         }
         ui_tableview.reloadData()
@@ -245,6 +254,9 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
                     self.tableData = [.searchCell]
                     for (idx, user) in self.users.enumerated() {
                         self.tableData.append(.userCell(user: user, reactionType: self.reactionTypeList[safe: idx]))
+                    }
+                    if !self.isSearch {
+                        self.ui_view_no_result.isHidden = !self.users.isEmpty
                     }
                     self.ui_tableview.reloadData()
                 } else if let error = error {
@@ -387,7 +399,7 @@ extension NeighBorhoodEventListUsersViewController: NeighborhoodHomeSearchDelega
             self.usersSearch.removeAll()
             self.isAlreadyClearRows = false
             self.isSearch = false
-            ui_view_no_result.isHidden = true
+            ui_view_no_result.isHidden = !users.isEmpty
             self.ui_tableview.reloadData()
         }
     }
@@ -400,7 +412,7 @@ extension NeighBorhoodEventListUsersViewController: NeighborhoodHomeSearchDelega
         } else {
             isAlreadyClearRows = false
         }
-        ui_view_no_result.isHidden = true
+        ui_view_no_result.isHidden = !usersSearch.isEmpty
     }
 }
 


### PR DESCRIPTION
This commit fixes an issue where the "no results" (`ui_view_no_result`) placeholder in the member lists (for discussions and events) would mistakenly display when first loading the view or returning from a search.

The logic was updated to use a condition that separates search mode vs standard list mode, checking if `users` or `usersSearch` is actually empty before showing the placeholder.

---
*PR created automatically by Jules for task [7512349998815870311](https://jules.google.com/task/7512349998815870311) started by @clemPerrousset*