### PR TITLE
fix(home): update UI across multiple home cards

### DIFF
--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1446,7 +1446,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_help_title_two" = "Comment créer un événement ?";
 "home_v2_help_title_three" = "Une question ?\nContactez";
 
-"home_v2_pedag_item_lenght_title" = "%d min de lecture";
+"home_v2_pedag_item_lenght_title" = "%d min";
 
 "home_v2_action_type_social" = "Social";
 "home_v2_action_type_clothes" = "Vêtements";
@@ -1960,7 +1960,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_small_talk_card_button" = "Discuter";
 "home_v2_solidarity_tools_title" = "Tes outils solidaires";
 "home_v2_tool_card_map" = "Carte des lieux solidaires";
-"home_v2_tool_card_pedago" = "Contenus pour apprendre et agir";
+"home_v2_tool_card_pedago" = "Ressources utiles";
 "home_v2_tool_card_ethics" = "Charte éthique Entourage";
-"home_v2_moderator_title_format" = "%@, votre contact privilégié";
+"home_v2_moderator_title_format" = "%@, votre contact dédié";
 "home_v2_moderator_subtitle" = "Je fais parti·e de l'équipe Entourage et je suis là pour vous accompagner. N'hésitez pas si vous avez des questions ! 🤗";

--- a/entourage/Scenes/HomeV2/homev2cells/HomeCellActionCollectionViewCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeCellActionCollectionViewCell.swift
@@ -56,7 +56,7 @@ class HomeCellActionCollectionViewCell: UICollectionViewCell {
         ui_label_title.numberOfLines = 2
 
         ui_label_description.font = UIFont(name: "NunitoSans-Regular", size: 13)
-        ui_label_description.textColor = UIColor.lightGray
+        ui_label_description.textColor = UIColor(named: "grey_light")
         ui_label_description.numberOfLines = 3
 
         ui_label_distance.font = UIFont(name: "NunitoSans-Regular", size: 11)
@@ -88,8 +88,8 @@ class HomeCellActionCollectionViewCell: UICollectionViewCell {
 
         // Description
         if let desc = action.description, !desc.isEmpty {
-            let first = desc.prefix(1).uppercased()
-            let other = desc.dropFirst()
+            let first = String(desc.prefix(1)).uppercased()
+            let other = String(desc.dropFirst())
             ui_label_description.text = first + other
         } else {
             ui_label_description.text = ""
@@ -97,9 +97,15 @@ class HomeCellActionCollectionViewCell: UICollectionViewCell {
 
         // Distance
         if let distance = action.distance {
-            ui_label_distance.text = Utils.displayDistance(distance: distance) + " de moi"
+            var distString = Utils.displayDistance(distance: distance)
+            if distString.lowercased().hasPrefix("à ") {
+                distString = String(distString.dropFirst(2))
+            }
+            ui_label_distance.text = distString
+            ui_image_pin.isHidden = false
         } else {
             ui_label_distance.text = "-"
+            ui_image_pin.isHidden = true
         }
     }
 }

--- a/entourage/Scenes/HomeV2/homev2cells/HomeCellPedago.xib
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeCellPedago.xib
@@ -47,10 +47,10 @@
                                 </userDefinedRuntimeAttributes>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pnT-2M-wbY">
-                                <rect key="frame" x="100" y="10" width="42.333333333333343" height="22"/>
+                                <rect key="frame" x="100" y="10" width="36.33333333333334" height="22"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WBt-j9-VNQ">
-                                        <rect key="frame" x="5" y="2" width="32.333333333333336" height="18"/>
+                                        <rect key="frame" x="2" y="2" width="32.333333333333336" height="18"/>
                                         <fontDescription key="fontDescription" name="Quicksand-Bold" family="Quicksand" pointSize="12"/>
                                         <color key="textColor" name="orange_light"/>
                                         <nil key="highlightedColor"/>
@@ -58,13 +58,13 @@
                                 </subviews>
                                 <color key="backgroundColor" name="beige_lighter"/>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="WBt-j9-VNQ" secondAttribute="trailing" constant="5" id="0tL-mI-kGc"/>
-                                    <constraint firstItem="WBt-j9-VNQ" firstAttribute="leading" secondItem="pnT-2M-wbY" secondAttribute="leading" constant="5" id="1qf-B8-XJt"/>
+                                    <constraint firstAttribute="trailing" secondItem="WBt-j9-VNQ" secondAttribute="trailing" constant="2" id="0tL-mI-kGc"/>
+                                    <constraint firstItem="WBt-j9-VNQ" firstAttribute="leading" secondItem="pnT-2M-wbY" secondAttribute="leading" constant="2" id="1qf-B8-XJt"/>
                                     <constraint firstAttribute="height" constant="22" id="CDP-P3-jaC"/>
                                     <constraint firstItem="WBt-j9-VNQ" firstAttribute="centerY" secondItem="pnT-2M-wbY" secondAttribute="centerY" id="IWa-zJ-iFF"/>
                                     <constraint firstItem="WBt-j9-VNQ" firstAttribute="top" secondItem="pnT-2M-wbY" secondAttribute="top" constant="2" id="baw-c5-qBb"/>
                                     <constraint firstAttribute="bottom" secondItem="WBt-j9-VNQ" secondAttribute="bottom" constant="2" id="r49-SW-Wob"/>
-                                    <constraint firstItem="WBt-j9-VNQ" firstAttribute="centerX" secondItem="pnT-2M-wbY" secondAttribute="centerX" id="w9R-XV-dD8"/>
+
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="cradius">

--- a/entourage/Scenes/HomeV2/homev2cells/HomeModeratorCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeModeratorCell.swift
@@ -37,10 +37,10 @@ class HomeModeratorCell:UITableViewCell{
         containerView.layer.shadowColor = UIColor.clear.cgColor
         containerView.layer.shadowOpacity = 0
 
-        ui_label_title.font = UIFont(name: "Quicksand-Bold", size: 14)
+        ui_label_title.font = UIFont(name: "Quicksand-Bold", size: 15)
         ui_label_title.textColor = UIColor(named: "black_app")
 
-        ui_label_description.font = UIFont(name: "Quicksand-Regular", size: 13)
+        ui_label_description.font = UIFont(name: "NunitoSans-Regular", size: 13)
         ui_label_description.textColor = UIColor(named: "black_app")
 
         ui_image.layer.borderColor = UIColor.appOrangeLight.cgColor

--- a/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.swift
@@ -49,9 +49,9 @@ class HomeSolidarityToolsCell: UITableViewCell {
         ui_label_title.font = ApplicationTheme.getFontQuickSandBold(size: 15)
         ui_label_title.textColor = .black
 
-        setupCard(view: ui_view_map, label: ui_lbl_map, image: ui_iv_map, title: "home_v2_tool_card_map".localized, iconName: "ic_card_map", systemIcon: "map.fill")
-        setupCard(view: ui_view_pedago, label: ui_lbl_pedago, image: ui_iv_pedago, title: "home_v2_tool_card_pedago".localized, iconName: "ic_card_pedago", systemIcon: "book.fill")
-        setupCard(view: ui_view_ethics, label: ui_lbl_ethics, image: ui_iv_ethics, title: "home_v2_tool_card_ethics".localized, iconName: "ic_card_charte", systemIcon: "hand.raised.fill")
+        setupCard(view: ui_view_map, label: ui_lbl_map, image: ui_iv_map, title: "home_v2_tool_card_map".localized, iconName: "ic_button_map", systemIcon: "map.fill")
+        setupCard(view: ui_view_pedago, label: ui_lbl_pedago, image: ui_iv_pedago, title: "home_v2_tool_card_pedago".localized, iconName: "ic_button_pedago", systemIcon: "book.fill")
+        setupCard(view: ui_view_ethics, label: ui_lbl_ethics, image: ui_iv_ethics, title: "home_v2_tool_card_ethics".localized, iconName: "ic_button_charte", systemIcon: "hand.raised.fill")
     }
 
     private func setupCard(view: UIView, label: UILabel, image: UIImageView, title: String, iconName: String, systemIcon: String) {
@@ -74,7 +74,7 @@ class HomeSolidarityToolsCell: UITableViewCell {
             image.image = UIImage(systemName: systemIcon)
             image.tintColor = .appOrange
         }
-        image.contentMode = .center
+        image.contentMode = .scaleAspectFit
 
         image.backgroundColor = UIColor.appBeige
         image.layer.cornerRadius = 25

--- a/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellCreateSmallTalk.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellCreateSmallTalk.swift
@@ -27,9 +27,13 @@ class CellCreateSmallTalk:UICollectionViewCell{
         let titleText = "home_v2_small_talk_card_title".localized
         let subtitleText = "home_v2_small_talk_card_subtitle".localized
 
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.paragraphSpacing = 4 // Add spacing between title and subtitle
+
         let attributedString = NSMutableAttributedString(string: titleText + "\n", attributes: [
             .font: ApplicationTheme.getFontQuickSandBold(size: 15),
-            .foregroundColor: UIColor.black
+            .foregroundColor: UIColor.black,
+            .paragraphStyle: paragraphStyle
         ])
 
         attributedString.append(NSAttributedString(string: subtitleText, attributes: [

--- a/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellCreateSmallTalk.xib
+++ b/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellCreateSmallTalk.xib
@@ -56,7 +56,7 @@
                             <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="lnA-Xe-wpR" secondAttribute="bottom" constant="20" id="DLh-Nt-m7u"/>
                             <constraint firstAttribute="trailing" secondItem="W27-Dc-a2R" secondAttribute="trailing" constant="10" id="P9x-kr-0Wy"/>
                             <constraint firstItem="W27-Dc-a2R" firstAttribute="leading" secondItem="ThL-Ar-wbM" secondAttribute="trailing" constant="10" id="Tds-yN-WMa"/>
-                            <constraint firstItem="ThL-Ar-wbM" firstAttribute="height" secondItem="Wof-Yx-i0V" secondAttribute="height" multiplier="0.5" id="VAG-Hz-LDC"/>
+                            <constraint firstItem="ThL-Ar-wbM" firstAttribute="height" secondItem="Wof-Yx-i0V" secondAttribute="height" multiplier="0.4" id="VAG-Hz-LDC"/>
                             <constraint firstItem="lnA-Xe-wpR" firstAttribute="top" secondItem="W27-Dc-a2R" secondAttribute="bottom" constant="20" id="dtY-Ym-oAz"/>
                             <constraint firstItem="ThL-Ar-wbM" firstAttribute="centerY" secondItem="Wof-Yx-i0V" secondAttribute="centerY" id="udv-ia-ZUu"/>
                             <constraint firstItem="W27-Dc-a2R" firstAttribute="top" secondItem="Wof-Yx-i0V" secondAttribute="top" constant="20" id="wSt-iO-yr6"/>


### PR DESCRIPTION
Fixes various Home UI bugs across "Entraides", "Modérateur", "Bonnes ondes", and "Outils solidaires" cards as requested by user.

- **Entraides:** Changed text color to `grey_light`, fixed emoji rendering bug caused by `Substring` manipulation, and updated distance to show the pin icon with correctly formatted "X km".
- **Modérateur:** Updated font size and family, changed string template to "votre contact dédié".
- **Bonnes ondes:** Adjusted XIB multiplier (0.5 to 0.4) so image avoids cropping the text, added `paragraphSpacing` between title and description.
- **Outils solidaires:** Set target image names to `ic_button_...` equivalents, changed UI rendering to aspect fit so it is contained in the beige circle. Updated "Ressources utiles" text and removed "de lecture" from length. Finally, refactored the tag autolayout constraints to fit with 2 points of padding on the trailing/leading edges (4 total).

---
*PR created automatically by Jules for task [15866382209784804024](https://jules.google.com/task/15866382209784804024) started by @clemPerrousset*