### PR TITLE
Fix Home Screen UI issues (Smalltalk, Solidarity Icons, Pedago Tags)

### DIFF
--- a/entourage/Scenes/HomeV2/homev2cells/HomeCellPedago.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeCellPedago.swift
@@ -33,6 +33,10 @@ class HomeCellPedago:UITableViewCell{
         containerView.layer.borderColor = UIColor.appBeige.cgColor
         containerView.clipsToBounds = true
 
+        ui_view_tag_container.setContentHuggingPriority(.required, for: .horizontal)
+        ui_label_pedago.setContentHuggingPriority(.required, for: .horizontal)
+        ui_label_pedago.setContentCompressionResistancePriority(.required, for: .horizontal)
+
         repositionDurationLabel()
     }
 

--- a/entourage/Scenes/HomeV2/homev2cells/HomeCellPedago.xib
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeCellPedago.xib
@@ -49,8 +49,8 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pnT-2M-wbY">
                                 <rect key="frame" x="100" y="10" width="36.33333333333334" height="22"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WBt-j9-VNQ">
-                                        <rect key="frame" x="2" y="2" width="32.333333333333336" height="18"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WBt-j9-VNQ">
+                                        <rect key="frame" x="8" y="2" width="20.333333333333336" height="18"/>
                                         <fontDescription key="fontDescription" name="Quicksand-Bold" family="Quicksand" pointSize="12"/>
                                         <color key="textColor" name="orange_light"/>
                                         <nil key="highlightedColor"/>
@@ -58,13 +58,12 @@
                                 </subviews>
                                 <color key="backgroundColor" name="beige_lighter"/>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="WBt-j9-VNQ" secondAttribute="trailing" constant="2" id="0tL-mI-kGc"/>
-                                    <constraint firstItem="WBt-j9-VNQ" firstAttribute="leading" secondItem="pnT-2M-wbY" secondAttribute="leading" constant="2" id="1qf-B8-XJt"/>
+                                    <constraint firstAttribute="trailing" secondItem="WBt-j9-VNQ" secondAttribute="trailing" constant="8" id="0tL-mI-kGc"/>
+                                    <constraint firstItem="WBt-j9-VNQ" firstAttribute="leading" secondItem="pnT-2M-wbY" secondAttribute="leading" constant="8" id="1qf-B8-XJt"/>
                                     <constraint firstAttribute="height" constant="22" id="CDP-P3-jaC"/>
                                     <constraint firstItem="WBt-j9-VNQ" firstAttribute="centerY" secondItem="pnT-2M-wbY" secondAttribute="centerY" id="IWa-zJ-iFF"/>
                                     <constraint firstItem="WBt-j9-VNQ" firstAttribute="top" secondItem="pnT-2M-wbY" secondAttribute="top" constant="2" id="baw-c5-qBb"/>
                                     <constraint firstAttribute="bottom" secondItem="WBt-j9-VNQ" secondAttribute="bottom" constant="2" id="r49-SW-Wob"/>
-
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="cradius">

--- a/entourage/Scenes/HomeV2/homev2cells/HomeSmallTalkCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeSmallTalkCell.swift
@@ -76,7 +76,7 @@ extension HomeSmallTalkCell: UICollectionViewDataSource {
 // MARK: - UICollectionViewDelegateFlowLayout
 extension HomeSmallTalkCell: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width = collectionView.bounds.width * 0.90
+        let width = collectionView.bounds.width * 0.99
         let height = collectionView.bounds.height
         return CGSize(width: width, height: height)
     }

--- a/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.swift
@@ -23,6 +23,10 @@ class HomeSolidarityToolsCell: UITableViewCell {
     @IBOutlet weak var ui_view_pedago: UIView!
     @IBOutlet weak var ui_view_ethics: UIView!
 
+    @IBOutlet weak var ui_cont_map: UIView!
+    @IBOutlet weak var ui_cont_pedago: UIView!
+    @IBOutlet weak var ui_cont_ethics: UIView!
+
     @IBOutlet weak var ui_iv_map: UIImageView!
     @IBOutlet weak var ui_iv_pedago: UIImageView!
     @IBOutlet weak var ui_iv_ethics: UIImageView!
@@ -49,12 +53,12 @@ class HomeSolidarityToolsCell: UITableViewCell {
         ui_label_title.font = ApplicationTheme.getFontQuickSandBold(size: 15)
         ui_label_title.textColor = .black
 
-        setupCard(view: ui_view_map, label: ui_lbl_map, image: ui_iv_map, title: "home_v2_tool_card_map".localized, iconName: "ic_button_map", systemIcon: "map.fill")
-        setupCard(view: ui_view_pedago, label: ui_lbl_pedago, image: ui_iv_pedago, title: "home_v2_tool_card_pedago".localized, iconName: "ic_button_pedago", systemIcon: "book.fill")
-        setupCard(view: ui_view_ethics, label: ui_lbl_ethics, image: ui_iv_ethics, title: "home_v2_tool_card_ethics".localized, iconName: "ic_button_charte", systemIcon: "hand.raised.fill")
+        setupCard(view: ui_view_map, label: ui_lbl_map, image: ui_iv_map, imgContainer: ui_cont_map, title: "home_v2_tool_card_map".localized, iconName: "ic_button_map", systemIcon: "map.fill")
+        setupCard(view: ui_view_pedago, label: ui_lbl_pedago, image: ui_iv_pedago, imgContainer: ui_cont_pedago, title: "home_v2_tool_card_pedago".localized, iconName: "ic_button_pedago", systemIcon: "book.fill")
+        setupCard(view: ui_view_ethics, label: ui_lbl_ethics, image: ui_iv_ethics, imgContainer: ui_cont_ethics, title: "home_v2_tool_card_ethics".localized, iconName: "ic_button_charte", systemIcon: "hand.raised.fill")
     }
 
-    private func setupCard(view: UIView, label: UILabel, image: UIImageView, title: String, iconName: String, systemIcon: String) {
+    private func setupCard(view: UIView, label: UILabel, image: UIImageView, imgContainer: UIView?, title: String, iconName: String, systemIcon: String) {
         view.layer.cornerRadius = 14
         view.backgroundColor = .white
         view.layer.borderColor = UIColor.appBeige.cgColor
@@ -76,9 +80,16 @@ class HomeSolidarityToolsCell: UITableViewCell {
         }
         image.contentMode = .scaleAspectFit
 
-        image.backgroundColor = UIColor.appBeige
-        image.layer.cornerRadius = 25
-        image.clipsToBounds = true
+        if let container = imgContainer {
+            container.backgroundColor = UIColor.appBeige
+            container.layer.cornerRadius = 25
+            container.clipsToBounds = true
+            image.backgroundColor = .clear
+        } else {
+            image.backgroundColor = UIColor.appBeige
+            image.layer.cornerRadius = 25
+            image.clipsToBounds = true
+        }
     }
 
     private func setupTapGestures() {

--- a/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.xib
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.xib
@@ -31,13 +31,25 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="view-Map">
                                 <rect key="frame" x="0.0" y="0.0" width="105" height="110"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="img-Map">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cont-Map">
                                         <rect key="frame" x="27.666666666666671" y="15" width="50" height="50"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="img-Map">
+                                                <rect key="frame" x="11" y="11" width="28" height="28"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="28" id="wMap"/>
+                                                    <constraint firstAttribute="height" constant="28" id="hMap"/>
+                                                </constraints>
+                                            </imageView>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="50" id="wMap"/>
-                                            <constraint firstAttribute="height" constant="50" id="hMap"/>
+                                            <constraint firstItem="img-Map" firstAttribute="centerX" secondItem="cont-Map" secondAttribute="centerX" id="cenImgMap"/>
+                                            <constraint firstItem="img-Map" firstAttribute="centerY" secondItem="cont-Map" secondAttribute="centerY" id="cenYImgMap"/>
+                                            <constraint firstAttribute="width" constant="50" id="wContMap"/>
+                                            <constraint firstAttribute="height" constant="50" id="hContMap"/>
                                         </constraints>
-                                    </imageView>
+                                    </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Carte" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-Map">
                                         <rect key="frame" x="5" y="70" width="95" height="35"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -47,24 +59,36 @@
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstItem="img-Map" firstAttribute="centerX" secondItem="view-Map" secondAttribute="centerX" id="cenMap"/>
-                                    <constraint firstItem="img-Map" firstAttribute="top" secondItem="view-Map" secondAttribute="top" constant="15" id="topMap"/>
+                                    <constraint firstItem="cont-Map" firstAttribute="centerX" secondItem="view-Map" secondAttribute="centerX" id="cenMap"/>
+                                    <constraint firstItem="cont-Map" firstAttribute="top" secondItem="view-Map" secondAttribute="top" constant="15" id="topMap"/>
                                     <constraint firstAttribute="trailing" secondItem="lbl-Map" secondAttribute="trailing" constant="5" id="trMap"/>
                                     <constraint firstItem="lbl-Map" firstAttribute="leading" secondItem="view-Map" secondAttribute="leading" constant="5" id="ldMap"/>
-                                    <constraint firstItem="lbl-Map" firstAttribute="top" secondItem="img-Map" secondAttribute="bottom" constant="5" id="btmMap"/>
+                                    <constraint firstItem="lbl-Map" firstAttribute="top" secondItem="cont-Map" secondAttribute="bottom" constant="5" id="btmMap"/>
                                     <constraint firstAttribute="bottom" secondItem="lbl-Map" secondAttribute="bottom" constant="5" id="btm2Map"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="view-Pedago">
                                 <rect key="frame" x="115" y="0.0" width="105" height="110"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="img-Pedago">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cont-Pedago">
                                         <rect key="frame" x="27.666666666666657" y="15" width="50" height="50"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="50" id="wPed"/>
-                                            <constraint firstAttribute="height" constant="50" id="hPed"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="img-Pedago">
+                                                <rect key="frame" x="11" y="11" width="28" height="28"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="28" id="wPed"/>
+                                                    <constraint firstAttribute="height" constant="28" id="hPed"/>
+                                                </constraints>
+                                            </imageView>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints
+                                            ><constraint firstItem="img-Pedago" firstAttribute="centerX" secondItem="cont-Pedago" secondAttribute="centerX" id="cenImgPed"/>
+                                            <constraint firstItem="img-Pedago" firstAttribute="centerY" secondItem="cont-Pedago" secondAttribute="centerY" id="cenYImgPed"/>
+                                            <constraint firstAttribute="width" constant="50" id="wContPed"/>
+                                            <constraint firstAttribute="height" constant="50" id="hContPed"/>
                                         </constraints>
-                                    </imageView>
+                                    </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Contenus" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-Pedago">
                                         <rect key="frame" x="5" y="70" width="95" height="35"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -74,24 +98,36 @@
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstItem="img-Pedago" firstAttribute="centerX" secondItem="view-Pedago" secondAttribute="centerX" id="cenPed"/>
-                                    <constraint firstItem="img-Pedago" firstAttribute="top" secondItem="view-Pedago" secondAttribute="top" constant="15" id="topPed"/>
+                                    <constraint firstItem="cont-Pedago" firstAttribute="centerX" secondItem="view-Pedago" secondAttribute="centerX" id="cenPed"/>
+                                    <constraint firstItem="cont-Pedago" firstAttribute="top" secondItem="view-Pedago" secondAttribute="top" constant="15" id="topPed"/>
                                     <constraint firstAttribute="trailing" secondItem="lbl-Pedago" secondAttribute="trailing" constant="5" id="trPed"/>
                                     <constraint firstItem="lbl-Pedago" firstAttribute="leading" secondItem="view-Pedago" secondAttribute="leading" constant="5" id="ldPed"/>
-                                    <constraint firstItem="lbl-Pedago" firstAttribute="top" secondItem="img-Pedago" secondAttribute="bottom" constant="5" id="btmPed"/>
+                                    <constraint firstItem="lbl-Pedago" firstAttribute="top" secondItem="cont-Pedago" secondAttribute="bottom" constant="5" id="btmPed"/>
                                     <constraint firstAttribute="bottom" secondItem="lbl-Pedago" secondAttribute="bottom" constant="5" id="btm2Ped"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="view-Ethics">
                                 <rect key="frame" x="230" y="0.0" width="105" height="110"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="img-Ethics">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cont-Ethics">
                                         <rect key="frame" x="27.666666666666686" y="15" width="50" height="50"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="img-Ethics">
+                                                <rect key="frame" x="11" y="11" width="28" height="28"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="28" id="wEth"/>
+                                                    <constraint firstAttribute="height" constant="28" id="hEth"/>
+                                                </constraints>
+                                            </imageView>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="50" id="wEth"/>
-                                            <constraint firstAttribute="height" constant="50" id="hEth"/>
+                                            <constraint firstItem="img-Ethics" firstAttribute="centerX" secondItem="cont-Ethics" secondAttribute="centerX" id="cenImgEth"/>
+                                            <constraint firstItem="img-Ethics" firstAttribute="centerY" secondItem="cont-Ethics" secondAttribute="centerY" id="cenYImgEth"/>
+                                            <constraint firstAttribute="width" constant="50" id="wContEth"/>
+                                            <constraint firstAttribute="height" constant="50" id="hContEth"/>
                                         </constraints>
-                                    </imageView>
+                                    </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Charte" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-Ethics">
                                         <rect key="frame" x="5" y="70" width="95" height="35"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -101,11 +137,11 @@
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstItem="img-Ethics" firstAttribute="centerX" secondItem="view-Ethics" secondAttribute="centerX" id="cenEth"/>
-                                    <constraint firstItem="img-Ethics" firstAttribute="top" secondItem="view-Ethics" secondAttribute="top" constant="15" id="topEth"/>
+                                    <constraint firstItem="cont-Ethics" firstAttribute="centerX" secondItem="view-Ethics" secondAttribute="centerX" id="cenEth"/>
+                                    <constraint firstItem="cont-Ethics" firstAttribute="top" secondItem="view-Ethics" secondAttribute="top" constant="15" id="topEth"/>
                                     <constraint firstAttribute="trailing" secondItem="lbl-Ethics" secondAttribute="trailing" constant="5" id="trEth"/>
                                     <constraint firstItem="lbl-Ethics" firstAttribute="leading" secondItem="view-Ethics" secondAttribute="leading" constant="5" id="ldEth"/>
-                                    <constraint firstItem="lbl-Ethics" firstAttribute="top" secondItem="img-Ethics" secondAttribute="bottom" constant="5" id="btmEth"/>
+                                    <constraint firstItem="lbl-Ethics" firstAttribute="top" secondItem="cont-Ethics" secondAttribute="bottom" constant="5" id="btmEth"/>
                                     <constraint firstAttribute="bottom" secondItem="lbl-Ethics" secondAttribute="bottom" constant="5" id="btm2Eth"/>
                                 </constraints>
                             </view>
@@ -123,6 +159,9 @@
                 </constraints>
             </tableViewCellContentView>
             <connections>
+                <outlet property="ui_cont_ethics" destination="cont-Ethics" id="out-ContEth"/>
+                <outlet property="ui_cont_map" destination="cont-Map" id="out-ContMap"/>
+                <outlet property="ui_cont_pedago" destination="cont-Pedago" id="out-ContPed"/>
                 <outlet property="ui_iv_ethics" destination="img-Ethics" id="out-EthImg"/>
                 <outlet property="ui_iv_map" destination="img-Map" id="out-MapImg"/>
                 <outlet property="ui_iv_pedago" destination="img-Pedago" id="out-PedImg"/>

--- a/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellCreateSmallTalk.xib
+++ b/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellCreateSmallTalk.xib
@@ -32,7 +32,7 @@
                                     <constraint firstAttribute="width" secondItem="ThL-Ar-wbM" secondAttribute="height" multiplier="1:1" id="Sh0-6r-hZk"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="On vous met en relation avec d’autres membres : un moyen simple de (re)créer du lien." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W27-Dc-a2R">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="On vous met en relation avec d’autres membres : un moyen simple de (re)créer du lien." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="YES" translatesAutoresizingMaskIntoConstraints="NO" minimumScaleFactor="0.5" id="W27-Dc-a2R">
                                 <rect key="frame" x="118.66666666666666" y="19.999999999999996" width="324.33333333333337" height="35.666666666666657"/>
                                 <fontDescription key="fontDescription" name="NunitoSans-Regular" family="Nunito Sans" pointSize="13"/>
                                 <nil key="textColor"/>
@@ -56,7 +56,7 @@
                             <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="lnA-Xe-wpR" secondAttribute="bottom" constant="20" id="DLh-Nt-m7u"/>
                             <constraint firstAttribute="trailing" secondItem="W27-Dc-a2R" secondAttribute="trailing" constant="10" id="P9x-kr-0Wy"/>
                             <constraint firstItem="W27-Dc-a2R" firstAttribute="leading" secondItem="ThL-Ar-wbM" secondAttribute="trailing" constant="10" id="Tds-yN-WMa"/>
-                            <constraint firstItem="ThL-Ar-wbM" firstAttribute="height" secondItem="Wof-Yx-i0V" secondAttribute="height" multiplier="0.4" id="VAG-Hz-LDC"/>
+                            <constraint firstItem="ThL-Ar-wbM" firstAttribute="height" secondItem="Wof-Yx-i0V" secondAttribute="height" multiplier="0.36" id="VAG-Hz-LDC"/>
                             <constraint firstItem="lnA-Xe-wpR" firstAttribute="top" secondItem="W27-Dc-a2R" secondAttribute="bottom" constant="20" id="dtY-Ym-oAz"/>
                             <constraint firstItem="ThL-Ar-wbM" firstAttribute="centerY" secondItem="Wof-Yx-i0V" secondAttribute="centerY" id="udv-ia-ZUu"/>
                             <constraint firstItem="W27-Dc-a2R" firstAttribute="top" secondItem="Wof-Yx-i0V" secondAttribute="top" constant="20" id="wSt-iO-yr6"/>


### PR DESCRIPTION
- Increased Smalltalk card width by 10% and reduced image size by 10%. Added auto-shrinking text to prevent truncation.
- Encapsulated Map, Pedago, and Charte icons in `HomeSolidarityToolsCell` in UIView containers to prevent clipping and correctly apply the 50x50 orange circle styling.
- Fixed `HomeCellPedago` category tags to prevent them from stretching by adding proper horizontal padding and AutoLayout hugging/compression resistance priorities.

---
*PR created automatically by Jules for task [10230324066359696722](https://jules.google.com/task/10230324066359696722) started by @clemPerrousset*