### PR TITLE
Fix EventCreatePhase3 UI: spacing and switch size

### DIFF
--- a/entourage/Scenes/Events/Create/Cells/EventPlaceLimitCell.swift
+++ b/entourage/Scenes/Events/Create/Cells/EventPlaceLimitCell.swift
@@ -115,8 +115,8 @@ class EventPlaceLimitCell: UITableViewCell {
         if selectedItem == 1 {
             ui_limit_tf.text = ""
             ui_view_limit.isHidden = false
-            bottomConstraint?.constant = 32
-            topConstraint?.constant = 32
+            bottomConstraint?.constant = 12
+            topConstraint?.constant = 12
         }
         else {
             ui_view_limit.isHidden = true

--- a/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.swift
+++ b/entourage/Scenes/Events/Create/Cells/EventReservedFemaleCell.swift
@@ -23,6 +23,7 @@ class EventReservedFemaleCell: UITableViewCell {
         ui_title.text = "event_create_reserved_female_title".localized
 
         ui_switch.onTintColor = .appOrange
+        ui_switch.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
 
         let tap = UITapGestureRecognizer(target: self, action: #selector(toggleSwitch))
         ui_title.superview?.addGestureRecognizer(tap)

--- a/entourage/Storyboards/Event_Create.storyboard
+++ b/entourage/Storyboards/Event_Create.storyboard
@@ -1291,8 +1291,8 @@
                                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="zaQ-ox-JyF" secondAttribute="trailing" constant="20" id="TPx-nb-yNd"/>
                                                         <constraint firstItem="zaQ-ox-JyF" firstAttribute="leading" secondItem="WZv-1r-MoB" secondAttribute="leading" constant="20" id="VTt-Vd-dZv"/>
                                                         <constraint firstItem="9fl-a0-ueb" firstAttribute="top" secondItem="zaQ-ox-JyF" secondAttribute="bottom" constant="8" symbolic="YES" id="cGv-wF-Mne"/>
-                                                        <constraint firstAttribute="bottom" secondItem="uqy-8z-lUR" secondAttribute="bottom" constant="32" id="cNo-hR-pFA"/>
-                                                        <constraint firstItem="uqy-8z-lUR" firstAttribute="top" secondItem="9fl-a0-ueb" secondAttribute="bottom" constant="32" id="dZX-Ec-plU"/>
+                                                        <constraint firstAttribute="bottom" secondItem="uqy-8z-lUR" secondAttribute="bottom" constant="12" id="cNo-hR-pFA"/>
+                                                        <constraint firstItem="uqy-8z-lUR" firstAttribute="top" secondItem="9fl-a0-ueb" secondAttribute="bottom" constant="12" id="dZX-Ec-plU"/>
                                                         <constraint firstItem="9fl-a0-ueb" firstAttribute="leading" secondItem="WZv-1r-MoB" secondAttribute="leading" constant="20" id="hjp-HW-MnT"/>
                                                     </constraints>
                                                 </view>


### PR DESCRIPTION
Addresses the user request to reduce the gap between the "reserved for women" block and the "limited places" block in the 3rd step of event creation, and makes the reserved switch smaller.

---
*PR created automatically by Jules for task [232687992820427717](https://jules.google.com/task/232687992820427717) started by @clemPerrousset*