### PR TITLE
Fix tab bar layout and cut text on iOS 18

### DIFF
--- a/entourage/MJTabbarCustom.swift
+++ b/entourage/MJTabbarCustom.swift
@@ -14,57 +14,21 @@ class MJTabbarCustom: UITabBar {
     let tabHeight:CGFloat = 49
     private var shapeLayer: CALayer?
     
-    override func draw(_ rect: CGRect) {
+    override func awakeFromNib() {
+        super.awakeFromNib()
         addShadow()
     }
     
     private func addShadow() {
-        let shapeLayer = CAShapeLayer()
-        
-        shapeLayer.path = createPath()
-        shapeLayer.fillColor = color?.cgColor ?? UIColor.white.cgColor
-        shapeLayer.shadowColor = UIColor.appOrange.cgColor
-        shapeLayer.shadowOffset = CGSize(width: 0   , height: -3);
-        shapeLayer.shadowOpacity = 0.17
-        shapeLayer.shadowPath =  UIBezierPath(roundedRect: bounds, cornerRadius: radius).cgPath
-        
-        
-        if let oldShapeLayer = self.shapeLayer {
-            layer.replaceSublayer(oldShapeLayer, with: shapeLayer)
-        } else {
-            layer.insertSublayer(shapeLayer, at: 0)
-        }
-        
-        self.shapeLayer = shapeLayer
-        
-        let itemsCount = items?.count ?? 1
-        selectionIndicatorImage = createSelectionIndicator(color: UIColor.appOrange, size: CGSize(width: frame.width/CGFloat(itemsCount), height: frame.height), lineWidth: 1)
-    }
-    
-    private func createSelectionIndicator(color: UIColor, size: CGSize, lineWidth: CGFloat) -> UIImage? {
-        UIGraphicsBeginImageContextWithOptions(size, false, 0)
-        color.setFill()
-        UIRectFill(CGRect(x: 0, y: 0, width: size.width, height: lineWidth))
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return image
-    }
-    
-    private func createPath() -> CGPath {
-        let path = UIBezierPath(
-            roundedRect: bounds,
-            byRoundingCorners: [.topLeft, .topRight],
-            cornerRadii: CGSize(width: radius, height: 0.0))
-        
-        return path.cgPath
+        self.layer.shadowColor = UIColor.appOrange.cgColor
+        self.layer.shadowOffset = CGSize(width: 0, height: -3)
+        self.layer.shadowOpacity = 0.17
+        self.layer.shadowRadius = 4
+        self.layer.masksToBounds = false
     }
     
     override func layoutSubviews() {
         super.layoutSubviews()
         self.isTranslucent = true
-        var _frame = self.frame
-        _frame.size.height = tabHeight + (UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? CGFloat.zero)
-        _frame.origin.y = self.frame.origin.y +   ( self.frame.height - tabHeight - (UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? CGFloat.zero))
-        self.frame = _frame
     }
 }

--- a/entourage/MainTabbarViewController.swift
+++ b/entourage/MainTabbarViewController.swift
@@ -27,13 +27,24 @@ class MainTabbarViewController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        delegate = self
+
+        setupVCs()
+
         // --- FIX POUR IPHONE 17 / iOS 15+ (Fond blanc & Layout) ---
+        let itemsCount = CGFloat(self.tabBar.items?.count ?? 5)
+        let indicatorWidth = UIScreen.main.bounds.width / itemsCount
+        let indicatorImage = createSelectionIndicator(color: UIColor.appOrange, size: CGSize(width: indicatorWidth, height: 49), lineWidth: 2)
+
         if #available(iOS 15.0, *) {
             let appearance = UITabBarAppearance()
             appearance.configureWithOpaqueBackground()
             appearance.backgroundColor = UIColor.white
             appearance.shadowColor = UIColor.clear // Optionnel : supprime la ligne grise fine si besoin
             
+            // Selection indicator replacement logic native style
+            appearance.selectionIndicatorImage = indicatorImage
+
             // On applique la configuration aux états "standard" et "scrollEdge" (quand on scroll en bas)
             self.tabBar.standardAppearance = appearance
             self.tabBar.scrollEdgeAppearance = appearance
@@ -44,12 +55,9 @@ class MainTabbarViewController: UITabBarController {
             UITabBar.appearance().tintColor = UIColor.appOrange
             UITabBar.appearance().barTintColor = UIColor.white
             UITabBar.appearance().isTranslucent = false
+            UITabBar.appearance().selectionIndicatorImage = indicatorImage
         }
         // ---------------------------------------------------------
-        
-        delegate = self
-        
-        setupVCs()
         
         AnalyticsLoggerManager.updateAnalyticsWitUser()
         
@@ -285,5 +293,14 @@ extension MainTabbarViewController {
                 self.tabBar.isHidden = hidden
             }
         })
+    }
+
+    private func createSelectionIndicator(color: UIColor, size: CGSize, lineWidth: CGFloat) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        color.setFill()
+        UIRectFill(CGRect(x: 0, y: 0, width: size.width, height: lineWidth))
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
     }
 }


### PR DESCRIPTION
Removed manual frame adjustments in `layoutSubviews` in `MJTabbarCustom.swift` to ensure compatibility with iOS 18+ and native sizing. Updated `MainTabbarViewController` to configure the selection indicator properly using `UITabBarAppearance`.

---
*PR created automatically by Jules for task [13508728093189686366](https://jules.google.com/task/13508728093189686366) started by @clemPerrousset*