### PR TITLE
fix: Resolve SwiftUI regressions in EventCreatePhase3View

### DIFF
--- a/entourage/Scenes/Events/Create/EventCreatePhase3View.swift
+++ b/entourage/Scenes/Events/Create/EventCreatePhase3View.swift
@@ -76,14 +76,18 @@ class EventCreatePhase3ViewModel: ObservableObject {
         self.isOnline = false
         self.onlineUrl = nil
 
-        delegate?.addOnline(url: nil)
-        delegate?.addPlaceType(isOnline: false)
-        delegate?.addPlace(currentlocation: currentlocation, currentLocationName: currentLocationName, googlePlace: googlePlace)
+        // Important: `isOnline = false` triggered its `didSet` block, which nullified the place via `delegate?.addPlace(...)`.
+        // We now need to dispatch the actual place to the delegate AFTER the `isOnline` side effects have settled.
+        DispatchQueue.main.async { [weak self] in
+            self?.delegate?.addOnline(url: nil)
+            self?.delegate?.addPlaceType(isOnline: false)
+            self?.delegate?.addPlace(currentlocation: currentlocation, currentLocationName: currentLocationName, googlePlace: googlePlace)
+        }
     }
 }
 
 struct EventCreatePhase3View: View {
-    @StateObject var viewModel: EventCreatePhase3ViewModel
+    @ObservedObject var viewModel: EventCreatePhase3ViewModel
 
     var body: some View {
         ScrollView {
@@ -212,12 +216,6 @@ struct EventCreatePhase3View: View {
                         .scaleEffect(0.8)
                 }
                 .padding(.horizontal, 20)
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    withAnimation {
-                        viewModel.isReservedFemale.toggle()
-                    }
-                }
 
                 Spacer()
             }


### PR DESCRIPTION
Fixes three regressions introduced during the SwiftUI refactor of the Event Creation Phase 3:
1. The "Reserved for women" switch now properly changes color and state when tapped.
2. The selected address correctly updates and displays in the view after selection.
3. Event creation data from this phase is correctly retained and transmitted, preventing failed event submissions.

---
*PR created automatically by Jules for task [2957798172305432856](https://jules.google.com/task/2957798172305432856) started by @clemPerrousset*