### PR TITLE
Inline Address Autocomplete for Event Creation

### DIFF
--- a/entourage/Scenes/Events/Create/AddressAutocompleteViewModel.swift
+++ b/entourage/Scenes/Events/Create/AddressAutocompleteViewModel.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Combine
+import GooglePlaces
+import CoreLocation
+
+class AddressAutocompleteViewModel: NSObject, ObservableObject, GMSAutocompleteFetcherDelegate {
+    @Published var suggestions: [GMSAutocompletePrediction] = []
+
+    private var fetcher: GMSAutocompleteFetcher?
+    private var cancellable: AnyCancellable?
+
+    @Published var query: String = ""
+
+    override init() {
+        super.init()
+
+        let neBoundsCorner = CLLocationCoordinate2D(latitude: 51.51, longitude: 6.40)
+        let swBoundsCorner = CLLocationCoordinate2D(latitude: 42.35, longitude: -5.14)
+
+        let filter = GMSAutocompleteFilter()
+        filter.type = .geocode
+        filter.locationBias = GMSPlaceRectangularLocationOption(neBoundsCorner, swBoundsCorner)
+
+        fetcher = GMSAutocompleteFetcher(bounds: nil, filter: filter)
+        fetcher?.delegate = self
+
+        cancellable = $query
+            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
+            .removeDuplicates()
+            .sink { [weak self] newQuery in
+                if newQuery.isEmpty {
+                    self?.suggestions = []
+                } else {
+                    self?.fetcher?.sourceTextHasChanged(newQuery)
+                }
+            }
+    }
+
+    func didAutocomplete(with predictions: [GMSAutocompletePrediction]) {
+        self.suggestions = predictions
+    }
+
+    func didFailAutocompleteWithError(_ error: Error) {
+        print("Error fetching autocomplete predictions: \(error.localizedDescription)")
+    }
+
+    func getPlaceDetails(placeID: String, completion: @escaping (GMSPlace?, Error?) -> Void) {
+        let fields: GMSPlaceField = [.name, .placeID, .formattedAddress, .coordinate, .addressComponents]
+        GMSPlacesClient.shared().fetchPlace(fromPlaceID: placeID, placeFields: fields, sessionToken: nil) { place, error in
+            completion(place, error)
+        }
+    }
+}

--- a/entourage/Scenes/Events/Create/EventCreatePhase3View.swift
+++ b/entourage/Scenes/Events/Create/EventCreatePhase3View.swift
@@ -7,6 +7,7 @@ class EventCreatePhase3ViewModel: ObservableObject {
         didSet {
             if isOnline {
                 placeName = nil
+                addressViewModel.query = ""
                 delegate?.addPlace(currentlocation: nil, currentLocationName: nil, googlePlace: nil)
                 delegate?.addOnline(url: onlineUrl)
             } else {
@@ -23,6 +24,29 @@ class EventCreatePhase3ViewModel: ObservableObject {
     }
 
     @Published var placeName: String? = nil
+
+    // Address autocomplete
+    @Published var addressViewModel = AddressAutocompleteViewModel()
+    @Published var isShowingSuggestions = false
+
+    // Cancellation tracking
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        // Observe query changes to manage suggestion list visibility
+        addressViewModel.$query
+            .receive(on: RunLoop.main)
+            .sink { [weak self] newQuery in
+                // Only show suggestions if the query is non-empty AND we don't already have an exactly matching placeName
+                // (which means they just selected something or we just loaded a place)
+                if newQuery.isEmpty || newQuery == self?.placeName {
+                    self?.isShowingSuggestions = false
+                } else {
+                    self?.isShowingSuggestions = true
+                }
+            }
+            .store(in: &cancellables)
+    }
 
     @Published var hasPlaceLimit: Bool = false {
         didSet {
@@ -57,6 +81,9 @@ class EventCreatePhase3ViewModel: ObservableObject {
             }
             self.onlineUrl = currentEvent.onlineEventUrl
             self.placeName = currentEvent.addressName
+            if let name = self.placeName {
+                self.addressViewModel.query = name
+            }
 
             if let metadata = currentEvent.metadata {
                 if let limit = metadata.place_limit, limit > 0 {
@@ -75,6 +102,9 @@ class EventCreatePhase3ViewModel: ObservableObject {
         self.placeName = currentLocationName
         self.isOnline = false
         self.onlineUrl = nil
+        if let name = currentLocationName {
+            self.addressViewModel.query = name
+        }
 
         // Important: `isOnline = false` triggered its `didSet` block, which nullified the place via `delegate?.addPlace(...)`.
         // We now need to dispatch the actual place to the delegate AFTER the `isOnline` side effects have settled.
@@ -145,17 +175,42 @@ struct EventCreatePhase3View: View {
                                     .foregroundColor(Color("color_legend"))
                             }
 
-                            Button(action: {
-                                viewModel.onShowSelectLocation?()
-                            }) {
-                                HStack {
-                                    Text(viewModel.placeName ?? "event_create_phase3_placeholder_place".localized)
-                                        .font(.custom("NunitoSans-Regular", size: 13))
-                                        .foregroundColor(viewModel.placeName != nil ? .black : Color(UIColor.appGrisSombre40))
-                                    Spacer()
-                                }
+                            TextField("event_create_phase3_placeholder_place".localized, text: $viewModel.addressViewModel.query)
+                                .font(.custom("NunitoSans-Regular", size: 13))
                                 .padding(.bottom, 8)
                                 .overlay(Rectangle().frame(height: 1).padding(.top, 35), alignment: .bottom)
+                                .foregroundColor(.black)
+                                .disableAutocorrection(true)
+
+                            if viewModel.isShowingSuggestions && !viewModel.addressViewModel.suggestions.isEmpty {
+                                VStack(alignment: .leading, spacing: 0) {
+                                    ForEach(viewModel.addressViewModel.suggestions, id: \.placeID) { suggestion in
+                                        Button(action: {
+                                            viewModel.addressViewModel.getPlaceDetails(placeID: suggestion.placeID) { place, error in
+                                                guard let place = place else { return }
+                                                viewModel.setLocation(
+                                                    currentlocation: place.coordinate,
+                                                    currentLocationName: place.formattedAddress ?? place.name,
+                                                    googlePlace: place
+                                                )
+                                            }
+                                        }) {
+                                            VStack(alignment: .leading) {
+                                                Text(suggestion.attributedFullText.string)
+                                                    .font(.custom("NunitoSans-Regular", size: 13))
+                                                    .foregroundColor(.black)
+                                                    .multilineTextAlignment(.leading)
+                                                    .padding(.vertical, 12)
+
+                                                Divider()
+                                            }
+                                        }
+                                    }
+                                }
+                                .background(Color.white)
+                                .cornerRadius(8)
+                                .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
+                                .padding(.top, 4)
                             }
                         }
                     }


### PR DESCRIPTION
Implements an inline Google Places autocomplete feature directly on the SwiftUI event creation screen (Phase 3). This improves the user experience by keeping the user on the same screen rather than pushing/presenting a separate view controller to search for a location.

---
*PR created automatically by Jules for task [13191214065472299537](https://jules.google.com/task/13191214065472299537) started by @clemPerrousset*