### PR TITLE
Fix missing google_place_id and street_address in Event Creation

### DIFF
--- a/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
+++ b/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
@@ -276,14 +276,28 @@ extension EventCreateMainViewController: EventCreateMainDelegate {
     }
     func addPlace(currentlocation: CLLocationCoordinate2D?, currentLocationName: String?, googlePlace: GMSPlace?) {
         newEvent.onlineEventUrl = nil
-        if let currentlocation = currentlocation {
+
+        if newEvent.metadata == nil {
+            newEvent.metadata = EventMetadata()
+        }
+
+        if let googlePlace = googlePlace {
+            newEvent.location = EventLocation(latitude: googlePlace.coordinate.latitude, longitude:  googlePlace.coordinate.longitude)
+            newEvent.addressName = currentLocationName ?? googlePlace.name
+            newEvent.metadata?.street_address = currentLocationName ?? googlePlace.name ?? ""
+            newEvent.metadata?.google_place_id = googlePlace.placeID
+        }
+        else if let currentlocation = currentlocation {
             newEvent.location = EventLocation(latitude: currentlocation.latitude, longitude: currentlocation.longitude)
             newEvent.addressName = currentLocationName
+            newEvent.metadata?.street_address = currentLocationName ?? ""
+            newEvent.metadata?.google_place_id = nil
         }
-        else if let googlePlace = googlePlace {
-            newEvent.location = EventLocation(latitude: googlePlace.coordinate.latitude, longitude:  googlePlace.coordinate.longitude)
-            newEvent.addressName = googlePlace.name
-            newEvent.metadata?.google_place_id = googlePlace.placeID
+        else {
+            newEvent.location = nil
+            newEvent.addressName = nil
+            newEvent.metadata?.street_address = ""
+            newEvent.metadata?.google_place_id = nil
         }
         _ = checkValidation()
     }

--- a/entourage/Scenes/Events/EventEditMainViewController.swift
+++ b/entourage/Scenes/Events/EventEditMainViewController.swift
@@ -356,14 +356,15 @@ extension EventEditMainViewController: EventCreateMainDelegate {
     }
     func addPlace(currentlocation: CLLocationCoordinate2D?, currentLocationName: String?, googlePlace: GMSPlace?) {
         newOnlineEventUrl = nil
-        if let currentlocation = currentlocation {
+        if let googlePlace = googlePlace {
+            newGoogle_place_id = googlePlace.placeID
+            newAddressName = currentLocationName ?? googlePlace.name
+            newLocation = EventLocation(latitude: googlePlace.coordinate.latitude, longitude: googlePlace.coordinate.longitude)
+        }
+        else if let currentlocation = currentlocation {
             newLocation = EventLocation(latitude: currentlocation.latitude, longitude: currentlocation.longitude)
             newAddressName = currentLocationName
-        }
-        else if let googlePlace = googlePlace {
-            newGoogle_place_id = googlePlace.placeID
-            newAddressName = googlePlace.name
-            newLocation = EventLocation(latitude: googlePlace.coordinate.latitude, longitude: googlePlace.coordinate.longitude)
+            newGoogle_place_id = nil
         }
         else {
             newLocation = nil


### PR DESCRIPTION
Fix 400 error on Event Create phase 3 by prioritizing the `googlePlace` to ensure `google_place_id` and `street_address` are successfully added to the request payload.

---
*PR created automatically by Jules for task [15832068966393523166](https://jules.google.com/task/15832068966393523166) started by @clemPerrousset*