### PR TITLE
Fix SmallTalk cell text truncation on Home

### DIFF
--- a/entourage/Scenes/HomeV2/HomeV2ViewController.swift
+++ b/entourage/Scenes/HomeV2/HomeV2ViewController.swift
@@ -702,7 +702,7 @@ extension HomeV2ViewController: UITableViewDelegate, UITableViewDataSource {
         case .cellInitialPedago(pedagos: let pedagos):
             return 115
         case .cellSmallTalk(let userRequests):
-            return 230
+            return 240
         case .cellSolidarityTools:
             return UITableView.automaticDimension
         }

--- a/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellCreateSmallTalk.xib
+++ b/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellCreateSmallTalk.xib
@@ -32,7 +32,7 @@
                                     <constraint firstAttribute="width" secondItem="ThL-Ar-wbM" secondAttribute="height" multiplier="1:1" id="Sh0-6r-hZk"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="On vous met en relation avec d’autres membres : un moyen simple de (re)créer du lien." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="YES" translatesAutoresizingMaskIntoConstraints="NO" minimumScaleFactor="0.5" id="W27-Dc-a2R">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="On vous met en relation avec d’autres membres : un moyen simple de (re)créer du lien." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W27-Dc-a2R">
                                 <rect key="frame" x="118.66666666666666" y="19.999999999999996" width="324.33333333333337" height="35.666666666666657"/>
                                 <fontDescription key="fontDescription" name="NunitoSans-Regular" family="Nunito Sans" pointSize="13"/>
                                 <nil key="textColor"/>


### PR DESCRIPTION
Fixes an issue where text on the SmallTalk cards in the Home view was unreadably shrunk.
- Increases the `.cellSmallTalk` row height in `HomeV2ViewController` from 230 to 240.
- Modifies `CellCreateSmallTalk.xib` to disable `minimumScaleFactor` / `adjustsFontSizeToFit` for the title text, ensuring the layout utilizes the existing `numberOfLines="0"` parameter and wraps normally.

---
*PR created automatically by Jules for task [1445918475280849589](https://jules.google.com/task/1445918475280849589) started by @clemPerrousset*