### PR TITLE
Fix duplicated event address display

### DIFF
--- a/entourage/Models/Event.swift
+++ b/entourage/Models/Event.swift
@@ -667,6 +667,10 @@ struct EventEditing {
             metadatas["place_name"] = place_name
         }
         
+        if let street_address = metadata?.street_address {
+            metadatas["street_address"] = street_address
+        }
+
         if let newGoogle_place_id = metadata?.google_place_id {
             metadatas["google_place_id"] = newGoogle_place_id
         }
@@ -696,6 +700,7 @@ struct EventMetadataEditing {
     var starts_at:String? = nil
     var ends_at:String? = nil
     var place_name:String? = nil
+    var street_address:String? = nil
     var google_place_id:String? = nil
     var place_limit:Int? = 0
     var reservedFemale:Bool? = nil

--- a/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
+++ b/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
@@ -284,7 +284,7 @@ extension EventCreateMainViewController: EventCreateMainDelegate {
         if let googlePlace = googlePlace {
             newEvent.location = EventLocation(latitude: googlePlace.coordinate.latitude, longitude:  googlePlace.coordinate.longitude)
             newEvent.addressName = currentLocationName ?? googlePlace.name
-            newEvent.metadata?.street_address = currentLocationName ?? googlePlace.name ?? ""
+            newEvent.metadata?.street_address = googlePlace.formattedAddress ?? googlePlace.name ?? ""
             newEvent.metadata?.google_place_id = googlePlace.placeID
         }
         else if let currentlocation = currentlocation {

--- a/entourage/Scenes/Events/Create/EventCreatePhase3View.swift
+++ b/entourage/Scenes/Events/Create/EventCreatePhase3View.swift
@@ -195,7 +195,7 @@ struct EventCreatePhase3View: View {
                                                 guard let place = place else { return }
                                                 viewModel.setLocation(
                                                     currentlocation: place.coordinate,
-                                                    currentLocationName: place.formattedAddress ?? place.name,
+                                                    currentLocationName: place.name,
                                                     googlePlace: place
                                                 )
                                             }

--- a/entourage/Scenes/Events/EventEditMainViewController.swift
+++ b/entourage/Scenes/Events/EventEditMainViewController.swift
@@ -41,6 +41,7 @@ class EventEditMainViewController: UIViewController {
     var newOnlineEventUrl:String? = nil
     var newLocation:EventLocation? = nil
     var newAddressName:String? = nil
+    var newStreetAddress:String? = nil
     var newGoogle_place_id:String? = nil
     var newHasPlaceLimit:Bool? = nil
     var newPlace_limit:Int? = nil
@@ -289,6 +290,7 @@ class EventEditMainViewController: UIViewController {
         newEvent.location = newLocation
         
         newEvent.metadata?.place_name = newAddressName
+        newEvent.metadata?.street_address = newStreetAddress
         newEvent.metadata?.google_place_id = newGoogle_place_id
         newEvent.metadata?.place_limit = newPlace_limit
         newEvent.startDate = newStartDate
@@ -359,17 +361,20 @@ extension EventEditMainViewController: EventCreateMainDelegate {
         if let googlePlace = googlePlace {
             newGoogle_place_id = googlePlace.placeID
             newAddressName = currentLocationName ?? googlePlace.name
+            newStreetAddress = googlePlace.formattedAddress ?? googlePlace.name
             newLocation = EventLocation(latitude: googlePlace.coordinate.latitude, longitude: googlePlace.coordinate.longitude)
         }
         else if let currentlocation = currentlocation {
             newLocation = EventLocation(latitude: currentlocation.latitude, longitude: currentlocation.longitude)
             newAddressName = currentLocationName
+            newStreetAddress = currentLocationName
             newGoogle_place_id = nil
         }
         else {
             newLocation = nil
             newGoogle_place_id = nil
             newAddressName = nil
+            newStreetAddress = nil
         }
         _ = checkValidation()
     }


### PR DESCRIPTION
Fix duplicated event address display by separating place_name and street_address

---
*PR created automatically by Jules for task [15185922705002323181](https://jules.google.com/task/15185922705002323181) started by @clemPerrousset*