### PR TITLE
Fix extra spacing below sticky buttons in EnhancedViewController

### DIFF
--- a/entourage/Scenes/enhancedOnboarding/EnhancedViewController.swift
+++ b/entourage/Scenes/enhancedOnboarding/EnhancedViewController.swift
@@ -118,7 +118,7 @@ class EnhancedViewController: UIViewController, UIImagePickerControllerDelegate,
         NSLayoutConstraint.activate([
             buttonView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             buttonView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-            buttonView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -10),
+            buttonView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
             buttonView.heightAnchor.constraint(equalToConstant: height)
         ])
         


### PR DESCRIPTION
Removes the extra -10 point constant padding applied below the EnahancedOnboardingButtonCell sticky footer relative to the view's safeAreaLayoutGuide.bottomAnchor. Modern devices with a home indicator natively provide enough padding through the safe area guide, so removing this extra padding anchors the buttons neatly and reduces the excessive whitespace at the bottom of the screen.

---
*PR created automatically by Jules for task [4635909599748332772](https://jules.google.com/task/4635909599748332772) started by @clemPerrousset*