### PR TITLE
Fix "Next" button incorrectly disabled in event edit location phase

### DIFF
--- a/entourage/Scenes/Events/Create/EventCreatePhase3View.swift
+++ b/entourage/Scenes/Events/Create/EventCreatePhase3View.swift
@@ -5,8 +5,11 @@ import Combine
 
 // MARK: - ViewModel
 class EventCreatePhase3ViewModel: ObservableObject {
+    var isInitializing: Bool = false
+
     @Published var isOnline: Bool = false {
         didSet {
+            guard !isInitializing else { return }
             if isOnline {
                 placeName = nil
                 addressViewModel.query = ""
@@ -22,6 +25,7 @@ class EventCreatePhase3ViewModel: ObservableObject {
     
     @Published var onlineUrl: String? = nil {
         didSet {
+            guard !isInitializing else { return }
             delegate?.addOnline(url: onlineUrl)
         }
     }
@@ -46,12 +50,14 @@ class EventCreatePhase3ViewModel: ObservableObject {
 
     @Published var hasPlaceLimit: Bool = false {
         didSet {
+            guard !isInitializing else { return }
             delegate?.addPlaceLimit(hasLimit: hasPlaceLimit, nbPlaces: hasPlaceLimit ? nbPlaceLimit : 0)
         }
     }
     
     @Published var nbPlaceLimitString: String = "" {
         didSet {
+            guard !isInitializing else { return }
             let limit = Int(nbPlaceLimitString) ?? 0
             delegate?.addPlaceLimit(hasLimit: hasPlaceLimit, nbPlaces: limit)
         }
@@ -63,6 +69,7 @@ class EventCreatePhase3ViewModel: ObservableObject {
 
     @Published var isReservedFemale: Bool = false {
         didSet {
+            guard !isInitializing else { return }
             delegate?.addReservedFemale(reserved: isReservedFemale)
         }
     }
@@ -71,6 +78,7 @@ class EventCreatePhase3ViewModel: ObservableObject {
     var onShowSelectLocation: (() -> Void)?
 
     func load(currentEvent: Event?, delegate: EventCreateMainDelegate?) {
+        isInitializing = true
         self.delegate = delegate
         if let currentEvent = currentEvent {
             if let eventIsOnline = currentEvent.isOnline { self.isOnline = eventIsOnline }
@@ -88,6 +96,7 @@ class EventCreatePhase3ViewModel: ObservableObject {
                 self.isReservedFemale = metadata.reservedFemale ?? false
             }
         }
+        isInitializing = false
     }
 
     func setLocation(currentlocation: CLLocationCoordinate2D?, displayAddress: String?, backEndAddress: String?, googlePlace: GMSPlace?) {


### PR DESCRIPTION
When editing an event and reaching Phase 3 (Location), the "Next" button was disabled with the message "Please fill in all fields" despite an address already being set for the event. This happened because loading the event properties into the SwiftUI `EventCreatePhase3ViewModel` triggered `@Published` properties like `isOnline` to call `didSet`. These `didSet` callbacks triggered a delegate update that only populated the `isOnline` state but passed `nil` for the location. This partially overwritten state in the UIKit controller made the validation fail. 

This fix introduces an `isInitializing` flag in the ViewModel. It prevents the `didSet` observers from pushing these premature partial updates to the delegate during the `load` sequence. This allows the UIKit controller to retain its initial untouched state, successfully validating Phase 3 and keeping the "Next" button correctly enabled without forcing the user to re-enter their address.

---
*PR created automatically by Jules for task [3686148548963596908](https://jules.google.com/task/3686148548963596908) started by @clemPerrousset*