### PR TITLE
Modernize EnhancedOnboardingButtonCell height and background

### DIFF
--- a/entourage/Scenes/enhancedOnboarding/EnhancedViewController.swift
+++ b/entourage/Scenes/enhancedOnboarding/EnhancedViewController.swift
@@ -113,7 +113,7 @@ class EnhancedViewController: UIViewController, UIImagePickerControllerDelegate,
         buttonView.translatesAutoresizingMaskIntoConstraints = false
         self.stickyButtonView = buttonView
         
-        let height: CGFloat = 85
+        let height: CGFloat = 64
         
         NSLayoutConstraint.activate([
             buttonView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),

--- a/entourage/Scenes/enhancedOnboarding/cells/EnahancedOnboardingButtonCell.xib
+++ b/entourage/Scenes/enhancedOnboarding/cells/EnahancedOnboardingButtonCell.xib
@@ -15,18 +15,26 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="buttonCell" rowHeight="88" id="Rad-HS-ivA" customClass="EnahancedOnboardingButtonCell" customModule="Ent_Beta" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="525" height="88"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="buttonCell" rowHeight="64" id="Rad-HS-ivA" customClass="EnahancedOnboardingButtonCell" customModule="Ent_Beta" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="525" height="64"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Rad-HS-ivA" id="QeX-nZ-WjH">
-                <rect key="frame" x="0.0" y="0.0" width="525" height="88"/>
+                <rect key="frame" x="0.0" y="0.0" width="525" height="64"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
+                    <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vEv-G1-FqO">
+                        <rect key="frame" x="0.0" y="0.0" width="525" height="64"/>
+                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="B6L-J9-T8K">
+                            <rect key="frame" x="0.0" y="0.0" width="525" height="64"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        </view>
+                        <blurEffect style="regular"/>
+                    </visualEffectView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ku5-G9-opM">
-                        <rect key="frame" x="0.0" y="0.0" width="525" height="80"/>
+                        <rect key="frame" x="0.0" y="0.0" width="525" height="64"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q13-Wm-2Ev">
-                                <rect key="frame" x="19.999999999999986" y="16" width="237.66666666666663" height="48"/>
+                                <rect key="frame" x="19.999999999999986" y="8" width="237.66666666666663" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="48" id="iyY-jY-lSz"/>
                                 </constraints>
@@ -38,7 +46,7 @@
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dJO-20-Ltv">
-                                <rect key="frame" x="267.66666666666669" y="16" width="237.33333333333331" height="48"/>
+                                <rect key="frame" x="267.66666666666669" y="8" width="237.33333333333331" height="48"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="48" id="CLP-oc-Ege"/>
                                 </constraints>
@@ -50,10 +58,10 @@
                                 </state>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="q13-Wm-2Ev" firstAttribute="centerY" secondItem="ku5-G9-opM" secondAttribute="centerY" id="7C6-57-AIw"/>
-                            <constraint firstAttribute="height" constant="80" id="I9Q-rg-EzO"/>
+                            <constraint firstAttribute="height" constant="64" id="I9Q-rg-EzO"/>
                             <constraint firstItem="dJO-20-Ltv" firstAttribute="centerY" secondItem="ku5-G9-opM" secondAttribute="centerY" id="YNX-Qk-AM1"/>
                             <constraint firstItem="q13-Wm-2Ev" firstAttribute="width" secondItem="dJO-20-Ltv" secondAttribute="width" id="dpm-Am-qaz"/>
                             <constraint firstAttribute="trailing" secondItem="dJO-20-Ltv" secondAttribute="trailing" constant="20" id="eSG-8J-Hs5"/>
@@ -63,12 +71,17 @@
                     </view>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="trailing" secondItem="vEv-G1-FqO" secondAttribute="trailing" id="vEv-T1-aBc"/>
+                    <constraint firstItem="vEv-G1-FqO" firstAttribute="top" secondItem="QeX-nZ-WjH" secondAttribute="top" id="vEv-T2-dEf"/>
+                    <constraint firstItem="vEv-G1-FqO" firstAttribute="leading" secondItem="QeX-nZ-WjH" secondAttribute="leading" id="vEv-T3-gHi"/>
+                    <constraint firstAttribute="bottom" secondItem="vEv-G1-FqO" secondAttribute="bottom" id="vEv-T4-jKl"/>
                     <constraint firstAttribute="trailing" secondItem="ku5-G9-opM" secondAttribute="trailing" id="6KX-0E-FsS"/>
                     <constraint firstItem="ku5-G9-opM" firstAttribute="top" secondItem="QeX-nZ-WjH" secondAttribute="top" id="d0U-He-nqb"/>
                     <constraint firstItem="ku5-G9-opM" firstAttribute="leading" secondItem="QeX-nZ-WjH" secondAttribute="leading" id="qR3-X7-jtX"/>
                     <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ku5-G9-opM" secondAttribute="bottom" id="vX4-eq-t3g"/>
                 </constraints>
             </tableViewCellContentView>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <connections>
                 <outlet property="ui_btn_configure_later" destination="q13-Wm-2Ev" id="luo-Dr-PI6"/>
                 <outlet property="ui_btn_next" destination="dJO-20-Ltv" id="c6i-zi-J1K"/>
@@ -76,9 +89,4 @@
             <point key="canvasLocation" x="66.412213740458014" y="35.211267605633807"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>


### PR DESCRIPTION
This update modernizes the sticky button footer used in the Enhanced Onboarding flow (and Main Filter) by making it more compact and applying a frosted glass effect.

- **Height Reduction:** The container height was reduced from ~85 points to 64 points to tighter frame the 48-point buttons, removing excess whitespace.
- **Liquid Glass Effect:** Replaced the opaque white background with a transparent background and a `UIVisualEffectView` (regular blur) to create a modern "frosted glass" look that allows underlying content to subtly show through as the user scrolls.

---
*PR created automatically by Jules for task [4861854457632352658](https://jules.google.com/task/4861854457632352658) started by @clemPerrousset*