### PR TITLE
Update event_create_phase3_title_limit to remove mandatory suffix

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -906,7 +906,7 @@
 "event_create_phase3_placeholder_place" = "العنوان .. المدينة ...";
 "event_create_phase3_placeholder_online" = "عنوان الموقع";
 
-"event_create_phase3_title_limit" = "هل الحدث له عدد محدود من الأماكن؟ - إلزامية";
+"event_create_phase3_title_limit" = "هل الحدث له عدد محدود من الأماكن؟";
 "event_create_phase3_title_nb_places" = "عدد الأماكن المتاحة - إلزامي";
 "event_create_phase3_title_nb_places_placeholder" = "عدد الأماكن";
 "event_create_phase3_limit_yes" = "نعم";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -911,7 +911,7 @@
 "event_create_phase3_placeholder_place" = "Adresse, Stadt...";
 "event_create_phase3_placeholder_online" = "Webadresse";
 
-"event_create_phase3_title_limit" = "Hat die Veranstaltung eine begrenzte Anzahl an Plätzen? - OBLIGATORISCH";
+"event_create_phase3_title_limit" = "Hat die Veranstaltung eine begrenzte Anzahl an Plätzen?";
 "event_create_phase3_title_nb_places" = "Anzahl der verfügbaren Plätze – obligatorisch";
 "event_create_phase3_title_nb_places_placeholder" = "Anzahl der Plätze";
 "event_create_phase3_limit_yes" = "Ja";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -895,7 +895,7 @@
 "event_create_phase3_placeholder_place" = "Address, city...";
 "event_create_phase3_placeholder_online" = "Web address";
 
-"event_create_phase3_title_limit" = "Does the event have a limited number of places? - required";
+"event_create_phase3_title_limit" = "Does the event have a limited number of places?";
 "event_create_phase3_title_nb_places" = "Number of places available - mandatory";
 "event_create_phase3_title_nb_places_placeholder" = "Number of places";
 "event_create_phase3_limit_yes" = "Yes";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -911,7 +911,7 @@
 "event_create_phase3_placeholder_place" = "Dirección, ciudad...";
 "event_create_phase3_placeholder_online" = "dirección web";
 
-"event_create_phase3_title_limit" = "¿El evento tiene un número limitado de plazas? - OBLIGATORIO";
+"event_create_phase3_title_limit" = "¿El evento tiene un número limitado de plazas?";
 "event_create_phase3_title_nb_places" = "Número de plazas disponibles - obligatorio";
 "event_create_phase3_title_nb_places_placeholder" = "Número de plazas";
 "event_create_phase3_limit_yes" = "Sí";
@@ -2333,7 +2333,7 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "event_create_phase3_placeholder_place" = "Dirección, ciudad...";
 "event_create_phase3_placeholder_online" = "dirección web";
 
-"event_create_phase3_title_limit" = "¿El evento tiene un número limitado de plazas? - OBLIGATORIO";
+"event_create_phase3_title_limit" = "¿El evento tiene un número limitado de plazas?";
 "event_create_phase3_title_nb_places" = "Número de plazas disponibles - obligatorio";
 "event_create_phase3_title_nb_places_placeholder" = "Número de plazas";
 "event_create_phase3_limit_yes" = "Sí";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -922,7 +922,7 @@
 "event_create_phase3_placeholder_place" = "Adresse, ville ...";
 "event_create_phase3_placeholder_online" = "Adresse web";
 
-"event_create_phase3_title_limit" = "L’événement a-t-il un nombre de places limité ? • obligatoire";
+"event_create_phase3_title_limit" = "L’événement a-t-il un nombre de places limité ?";
 "event_create_phase3_title_nb_places" = "Nombre de places disponibles • obligatoire";
 "event_create_phase3_title_nb_places_placeholder" = "Nombre de places";
 "event_create_phase3_limit_yes" = "Oui";

--- a/entourage/Assets/hr.lproj/Localizable.strings
+++ b/entourage/Assets/hr.lproj/Localizable.strings
@@ -905,7 +905,7 @@
 "event_create_phase3_placeholder_place" = "Adresse, ville ...";
 "event_create_phase3_placeholder_online" = "Adresse web";
 
-"event_create_phase3_title_limit" = "L’événement a-t-il un nombre de places limité ? - obligatoire";
+"event_create_phase3_title_limit" = "L’événement a-t-il un nombre de places limité ?";
 "event_create_phase3_title_nb_places" = "Nombre de places disponibles - obligatoire";
 "event_create_phase3_title_nb_places_placeholder" = "Nombre de places";
 "event_create_phase3_limit_yes" = "Oui";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -923,7 +923,7 @@
 "event_create_phase3_placeholder_place" = "Adresse, ville ...";
 "event_create_phase3_placeholder_online" = "Adresse web";
 
-"event_create_phase3_title_limit" = "L’événement a-t-il un nombre de places limité ? • obligatoire";
+"event_create_phase3_title_limit" = "L’événement a-t-il un nombre de places limité ?";
 "event_create_phase3_title_nb_places" = "Nombre de places disponibles • obligatoire";
 "event_create_phase3_title_nb_places_placeholder" = "Nombre de places";
 "event_create_phase3_limit_yes" = "Oui";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -915,7 +915,7 @@
 "event_create_phase3_placeholder_place" = "Adresa, orasul...";
 "event_create_phase3_placeholder_online" = "Adresa site-ului web";
 
-"event_create_phase3_title_limit" = "Evenimentul are un număr limitat de locuri? - OBLIGATORIU";
+"event_create_phase3_title_limit" = "Evenimentul are un număr limitat de locuri?";
 "event_create_phase3_title_nb_places" = "Numar de locuri disponibile - obligatoriu";
 "event_create_phase3_title_nb_places_placeholder" = "Numărul de locuri";
 "event_create_phase3_limit_yes" = "Da";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -911,7 +911,7 @@
 "event_create_phase3_placeholder_place" = "Адреса, місто...";
 "event_create_phase3_placeholder_online" = "Веб-адреса";
 
-"event_create_phase3_title_limit" = "Чи кількість місць на заході обмежена? - ОБОВ'ЯЗКОВО";
+"event_create_phase3_title_limit" = "Чи кількість місць на заході обмежена?";
 "event_create_phase3_title_nb_places" = "Кількість місць - обов'язкова";
 "event_create_phase3_title_nb_places_placeholder" = "Кількість місць";
 "event_create_phase3_limit_yes" = "Так";


### PR DESCRIPTION
This PR updates the `event_create_phase3_title_limit` key across all `Localizable.strings` files to only contain the base question. The required suffix ("• obligatoire", "- required", etc.) has been removed from this key. The UI will now combine this with `event_create_mandatory` as instructed by the user.

---
*PR created automatically by Jules for task [15168409350819638455](https://jules.google.com/task/15168409350819638455) started by @clemPerrousset*