### PR TITLE
Feat: Add staff warning banner during off-hours

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -1701,3 +1701,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_moderator_subtitle" = "أنا جزء من فريق Entourage وأنا هنا لمرافقتك. لا تتردد إذا كان لديك أي أسئلة! 🤗";
 "eventCreatephase3_swiftUI_title_limit" = "هل للحدث عدد محدود من الأماكن؟";
 "eventCreatephase3_swiftUI_title_place" = "المكان";
+
+"conversation_staff_warning_message" = "The team is taking a break... 🌙 In case of emergency: 15, 18, or 115. For immediate help, your neighbors are in the group ! 🏠 We will answer you quickly.";
+"conversation_staff_warning_group_link" = "group";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -1762,3 +1762,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_moderator_subtitle" = "Ich gehöre zum Entourage-Team und bin hier, um Sie zu unterstützen. Zögern Sie nicht, wenn Sie Fragen haben! 🤗";
 "eventCreatephase3_swiftUI_title_limit" = "Hat die Veranstaltung eine begrenzte Teilnehmerzahl?";
 "eventCreatephase3_swiftUI_title_place" = "Ort";
+
+"conversation_staff_warning_message" = "The team is taking a break... 🌙 In case of emergency: 15, 18, or 115. For immediate help, your neighbors are in the group ! 🏠 We will answer you quickly.";
+"conversation_staff_warning_group_link" = "group";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -1969,3 +1969,6 @@
 "home_v2_moderator_subtitle" = "I am part of the Entourage team and I am here to support you. Do not hesitate if you have any questions! 🤗";
 "eventCreatephase3_swiftUI_title_limit" = "Does the event have a limited number of places?";
 "eventCreatephase3_swiftUI_title_place" = "Location";
+
+"conversation_staff_warning_message" = "The team is taking a break... 🌙 In case of emergency: 15, 18, or 115. For immediate help, your neighbors are in the group ! 🏠 We will answer you quickly.";
+"conversation_staff_warning_group_link" = "group";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -3185,3 +3185,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_moderator_subtitle" = "Formo parte del equipo de Entourage y estoy aquí para acompañarte. ¡No dudes en preguntar si tienes alguna duda! 🤗";
 "eventCreatephase3_swiftUI_title_limit" = "¿El evento tiene un número limitado de plazas?";
 "eventCreatephase3_swiftUI_title_place" = "Lugar";
+
+"conversation_staff_warning_message" = "The team is taking a break... 🌙 In case of emergency: 15, 18, or 115. For immediate help, your neighbors are in the group ! 🏠 We will answer you quickly.";
+"conversation_staff_warning_group_link" = "group";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -1966,3 +1966,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_moderator_subtitle" = "Je fais parti·e de l'équipe Entourage et je suis là pour vous accompagner. N'hésitez pas si vous avez des questions ! 🤗";
 "eventCreatephase3_swiftUI_title_limit" = "L’événement a-t-il un nombre de places limité ?";
 "eventCreatephase3_swiftUI_title_place" = "Lieu";
+
+"conversation_staff_warning_message" = "L’équipe est en pause... 🌙 En cas d'urgence : 15, 18 ou 115. Pour une aide immédiate, vos voisins sont sur le groupe ! 🏠 On vous répond vite.";
+"conversation_staff_warning_group_link" = "groupe";

--- a/entourage/Assets/hr.lproj/Localizable.strings
+++ b/entourage/Assets/hr.lproj/Localizable.strings
@@ -1437,3 +1437,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_title_small_talk" = "Pridružite se solidarnoj raspravi";
 "small_talk_subtitle_match" = "Povezujemo vas s malom grupom ljudi koji dijele vaše interese, bilo gdje u Francuskoj.";
 "Tomorrow" = "Sutra";
+
+"conversation_staff_warning_message" = "The team is taking a break... 🌙 In case of emergency: 15, 18, or 115. For immediate help, your neighbors are in the group ! 🏠 We will answer you quickly.";
+"conversation_staff_warning_group_link" = "group";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -1776,3 +1776,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_moderator_subtitle" = "Jestem częścią zespołu Entourage i jestem tutaj, aby ci towarzyszyć. Nie wahaj się, jeśli masz pytania! 🤗";
 "eventCreatephase3_swiftUI_title_limit" = "Czy wydarzenie ma ograniczoną liczbę miejsc?";
 "eventCreatephase3_swiftUI_title_place" = "Miejsce";
+
+"conversation_staff_warning_message" = "The team is taking a break... 🌙 In case of emergency: 15, 18, or 115. For immediate help, your neighbors are in the group ! 🏠 We will answer you quickly.";
+"conversation_staff_warning_group_link" = "group";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -1665,3 +1665,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_moderator_subtitle" = "Fac parte din echipa Entourage și sunt aici să te însoțesc. Nu ezita dacă ai întrebări! 🤗";
 "eventCreatephase3_swiftUI_title_limit" = "Evenimentul are un număr limitat de locuri?";
 "eventCreatephase3_swiftUI_title_place" = "Locație";
+
+"conversation_staff_warning_message" = "The team is taking a break... 🌙 In case of emergency: 15, 18, or 115. For immediate help, your neighbors are in the group ! 🏠 We will answer you quickly.";
+"conversation_staff_warning_group_link" = "group";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -1742,3 +1742,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_moderator_subtitle" = "Я є частиною команди Entourage і тут, щоб супроводжувати тебе. Не соромся, якщо у тебе є питання! 🤗";
 "eventCreatephase3_swiftUI_title_limit" = "Чи має подія обмежену кількість місць?";
 "eventCreatephase3_swiftUI_title_place" = "Місце";
+
+"conversation_staff_warning_message" = "The team is taking a break... 🌙 In case of emergency: 15, 18, or 115. For immediate help, your neighbors are in the group ! 🏠 We will answer you quickly.";
+"conversation_staff_warning_group_link" = "group";

--- a/entourage/Scenes/Conversations/ConversationDetailMessagesViewController.swift
+++ b/entourage/Scenes/Conversations/ConversationDetailMessagesViewController.swift
@@ -81,7 +81,10 @@ class ConversationDetailMessagesViewController: UIViewController {
     
     @IBOutlet weak var ui_width_btn: NSLayoutConstraint!
     
-    private var imagePreviewOverlay: UIView?
+        private var staffWarningView: ConversationStaffWarningView?
+    private var isStaffWarningDismissed = false
+
+private var imagePreviewOverlay: UIView?
     private var selectedImage: UIImage? = nil
     private var labelCamera: UILabel!
     private var labelGalery: UILabel!
@@ -841,7 +844,76 @@ class ConversationDetailMessagesViewController: UIViewController {
     }
 
     // MARK: - View New Conversation
-    func checkNewConv() {
+        func checkStaffWarning() {
+        if isStaffWarningDismissed { return }
+        if !isOneToOne { return }
+
+        // Check if the other user has "Équipe Entourage" role
+        var isStaff = false
+        if let members = currentConversation?.members {
+            for member in members {
+                if member.uid != self.meId, let roles = member.roles, roles.contains("Équipe Entourage") {
+                    isStaff = true
+                    break
+                }
+            }
+        } else {
+            for message in self.messages {
+                if let _user = message.user, _user.uid != self.meId, let _roles = _user.roles, _roles.contains("Équipe Entourage") {
+                    isStaff = true
+                    break
+                }
+            }
+        }
+
+        if isStaff {
+            if isStaffOut() {
+                showStaffWarning()
+            }
+        }
+    }
+
+    private func isStaffOut() -> Bool {
+        let calendar = Calendar.current
+        let now = Date()
+        let hour = calendar.component(.hour, from: now)
+        let minute = calendar.component(.minute, from: now)
+        let weekday = calendar.component(.weekday, from: now) // Sunday is 1, Monday is 2... Friday is 6, Saturday is 7
+
+        let limit18 = 18 * 60
+        let limit9 = 9 * 60
+        let currentMinutes = hour * 60 + minute
+
+        if weekday == 7 || weekday == 1 {
+            return true // Saturday or Sunday
+        }
+
+        // Before 9:00 or strictly after 18:00
+        if currentMinutes < limit9 || currentMinutes > limit18 {
+            return true
+        }
+
+        return false
+    }
+
+    private func showStaffWarning() {
+        if staffWarningView == nil {
+            let warning = ConversationStaffWarningView()
+            warning.delegate = self
+            warning.translatesAutoresizingMaskIntoConstraints = false
+            self.view.addSubview(warning)
+
+            NSLayoutConstraint.activate([
+                warning.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+                warning.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+                warning.bottomAnchor.constraint(equalTo: self.ui_tableview_mentions.topAnchor, constant: -8)
+            ])
+            staffWarningView = warning
+        }
+        staffWarningView?.isHidden = false
+    }
+
+func checkNewConv() {
         if !isOneToOne { return }
         for message in self.messages {
             if let _user = message.user,
@@ -953,6 +1025,7 @@ class ConversationDetailMessagesViewController: UIViewController {
 
             // 9. Tout ce qui touche l’UI passe sur le main thread
             DispatchQueue.main.async {
+                self.checkStaffWarning()
                 self.checkNewConv()
                 self.buildConversationCellDTOs()
                 self.ui_view_empty.isHidden = !self.conversationCellDTOs.isEmpty
@@ -1929,6 +2002,22 @@ extension String {
         } catch {
             print("Erreur de parsing HTML: \(error)")
             return nil
+        }
+    }
+}
+
+extension ConversationDetailMessagesViewController: ConversationStaffWarningDelegate {
+    func didTapCloseWarning() {
+        self.isStaffWarningDismissed = true
+        UIView.animate(withDuration: 0.3, animations: {
+            self.staffWarningView?.alpha = 0
+            self.staffWarningView?.transform = CGAffineTransform(translationX: 0, y: 20)
+        }) { _ in
+            self.staffWarningView?.isHidden = true
+            self.staffWarningView?.alpha = 1
+            self.staffWarningView?.transform = .identity
+            self.staffWarningView?.removeFromSuperview()
+            self.staffWarningView = nil
         }
     }
 }

--- a/entourage/Scenes/Conversations/ConversationStaffWarningView.swift
+++ b/entourage/Scenes/Conversations/ConversationStaffWarningView.swift
@@ -1,0 +1,123 @@
+import UIKit
+
+protocol ConversationStaffWarningDelegate: AnyObject {
+    func didTapCloseWarning()
+}
+
+class ConversationStaffWarningView: UIView, UITextViewDelegate {
+
+    weak var delegate: ConversationStaffWarningDelegate?
+
+    private let backgroundView = UIView()
+    private let messageTextView = UITextView()
+    private let closeButton = UIButton(type: .custom)
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    private func setupView() {
+        self.backgroundColor = .clear
+
+        backgroundView.backgroundColor = .appBeigeClair
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        self.addSubview(backgroundView)
+
+        messageTextView.backgroundColor = .clear
+        messageTextView.isEditable = false
+        messageTextView.isScrollEnabled = false
+        messageTextView.delegate = self
+        messageTextView.translatesAutoresizingMaskIntoConstraints = false
+        messageTextView.textContainerInset = .zero
+        messageTextView.textContainer.lineFragmentPadding = 0
+        messageTextView.linkTextAttributes = [
+            .foregroundColor: UIColor.appMarron,
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
+        backgroundView.addSubview(messageTextView)
+
+        closeButton.setImage(UIImage(named: "ic_cross"), for: .normal)
+        closeButton.tintColor = .appOrange
+        closeButton.contentEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        closeButton.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        backgroundView.addSubview(closeButton)
+
+        NSLayoutConstraint.activate([
+            backgroundView.topAnchor.constraint(equalTo: self.topAnchor),
+            backgroundView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            backgroundView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            backgroundView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+
+            messageTextView.topAnchor.constraint(equalTo: backgroundView.topAnchor, constant: 16),
+            messageTextView.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor, constant: 16),
+            messageTextView.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor, constant: -16),
+
+            closeButton.leadingAnchor.constraint(equalTo: messageTextView.trailingAnchor, constant: 8),
+            closeButton.topAnchor.constraint(equalTo: backgroundView.topAnchor, constant: 6),
+            closeButton.trailingAnchor.constraint(equalTo: backgroundView.trailingAnchor, constant: -6),
+            closeButton.widthAnchor.constraint(equalToConstant: 44),
+            closeButton.heightAnchor.constraint(equalToConstant: 44)
+        ])
+
+        setupText()
+    }
+
+    private func setupText() {
+        let text = "conversation_staff_warning_message".localized
+
+        let attributedString = NSMutableAttributedString(string: text, attributes: [
+            .font: ApplicationTheme.getFontCourantRegularNoir(size: 13),
+            .foregroundColor: UIColor.appMarron
+        ])
+
+        // Find ranges
+        let nsText = text as NSString
+        let range15 = nsText.range(of: "15")
+        let range18 = nsText.range(of: "18")
+        let range115 = nsText.range(of: "115")
+        let rangeGroupe = nsText.range(of: "conversation_staff_warning_group_link".localized)
+
+        if range15.location != NSNotFound {
+            attributedString.addAttribute(.link, value: "tel://15", range: range15)
+        }
+        if range18.location != NSNotFound {
+            attributedString.addAttribute(.link, value: "tel://18", range: range18)
+        }
+        if range115.location != NSNotFound {
+            attributedString.addAttribute(.link, value: "tel://115", range: range115)
+        }
+        if rangeGroupe.location != NSNotFound {
+            attributedString.addAttribute(.link, value: "entourage://groupe", range: rangeGroupe)
+        }
+
+        messageTextView.attributedText = attributedString
+    }
+
+    @objc private func closeTapped() {
+        delegate?.didTapCloseWarning()
+    }
+
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        if URL.scheme == "tel" {
+            UIApplication.shared.open(URL, options: [:], completionHandler: nil)
+            return false
+        } else if URL.scheme == "entourage" && URL.host == "groupe" {
+            NeighborhoodService.getDefaultGroup { group, error in
+                DispatchQueue.main.async {
+                    if let group = group {
+                        DeepLinkManager.showNeighborhoodDetail(id: group.uid)
+                    }
+                }
+            }
+            return false
+        }
+        return true
+    }
+}


### PR DESCRIPTION
Adds a new dismissible banner in direct conversations when users message an "Équipe Entourage" staff member outside of working hours, providing them emergency numbers and quick access to their neighborhood group.

---
*PR created automatically by Jules for task [16184257934823228635](https://jules.google.com/task/16184257934823228635) started by @clemPerrousset*