### PR TITLE
Fix: User profile ID correctly passed in 1-to-1 conversation

### DIFF
--- a/entourage/Scenes/Conversations/ConversationDetailMessagesViewController.swift
+++ b/entourage/Scenes/Conversations/ConversationDetailMessagesViewController.swift
@@ -1110,6 +1110,10 @@ func checkNewConv() {
                 
                 self.currentConversation = conversation
 
+                if self.isOneToOne {
+                    self.currentUserId = conversation.user?.uid ?? conversation.members?.first(where: { $0.uid != self.meId })?.uid ?? 0
+                }
+
                 // Si on a le type “outing”, on cherche le titre exact de l’événement
                 if self.type == "outing" {
                     self.ui_view_empty.isHidden = true


### PR DESCRIPTION
Fixes a bug where opening a user's profile from a 1-to-1 conversation incorrectly sends `0` as the user ID instead of the actual user's ID, resulting in a blank page or 404 error. This happens because `self.currentUserId` was not being correctly updated after fetching conversation details.

---
*PR created automatically by Jules for task [4419118516815971045](https://jules.google.com/task/4419118516815971045) started by @clemPerrousset*