### PR TITLE
Fix invisible text in Welcome Journey

### DIFF
--- a/entourage/Scenes/HomeV2/homev2cells/HomeWelcomeJourneyView.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeWelcomeJourneyView.swift
@@ -93,7 +93,7 @@ struct HomeWelcomeJourneyView: View {
             HStack(alignment: .bottom) {
                 Text("home_v2_welcome_title".localized)
                     .font(.system(size: 20, weight: .bold))
-                    .foregroundColor(Color("black"))
+                    .foregroundColor(Color.black)
                 Spacer()
                 Text("\(viewModel.completedCount)/\(viewModel.steps.count)")
                     .font(.system(size: 14, weight: .bold))
@@ -122,7 +122,7 @@ struct HomeWelcomeJourneyView: View {
             // Microcopy
             Text("Continuez comme ça, vous allez y arriver 🌟") // Mockup static text - wait, maybe use microcopy logic but just this text
                 .font(.system(size: 14, weight: .regular))
-                .foregroundColor(Color("black"))
+                .foregroundColor(Color.black)
                 .padding(.horizontal, 20)
 
             // Steps List
@@ -167,7 +167,7 @@ struct WelcomeJourneyStepView: View {
                         HStack(alignment: .top) {
                             Text(step.isCompleted ? step.completedTitle : step.title)
                                 .font(.system(size: 16, weight: .bold))
-                                .foregroundColor(step.isCompleted ? Color("green_logout") : Color("black"))
+                                .foregroundColor(step.isCompleted ? Color("green_logout") : Color.black)
                                 .multilineTextAlignment(.leading)
                             Spacer(minLength: 8)
                             if step.isCompleted {

--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeJourneyCelebrationPopupViewController.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeJourneyCelebrationPopupViewController.swift
@@ -37,7 +37,7 @@ class WelcomeJourneyCelebrationPopupViewController: UIViewController {
         // Title
         titleLabel.text = "home_v2_welcome_celebration_title".localized
         titleLabel.font = .systemFont(ofSize: 22, weight: .bold)
-        titleLabel.textColor = UIColor(named: "black")
+        titleLabel.textColor = UIColor.black
         titleLabel.textAlignment = .center
         titleLabel.numberOfLines = 0
         titleLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeVideoModalViewController.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeVideoModalViewController.swift
@@ -46,7 +46,7 @@ class WelcomeVideoModalViewController: UIViewController {
         // Title
         titleLabel.text = "home_v2_welcome_video_modal_title".localized
         titleLabel.font = .systemFont(ofSize: 22, weight: .bold)
-        titleLabel.textColor = UIColor(named: "black")
+        titleLabel.textColor = UIColor.black
         titleLabel.numberOfLines = 0
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         containerView.addSubview(titleLabel)


### PR DESCRIPTION
Fixed an issue where text on the home screen's Welcome Journey module and popups rendered completely transparent/white. This was caused by attempting to load `Color("black")` or `UIColor(named: "black")` which does not exist in the project's Asset Catalog, causing iOS to default to a clear/white color. Replaced these instances with the system-provided `Color.black` and `UIColor.black` in `HomeWelcomeJourneyView`, `WelcomeJourneyCelebrationPopupViewController`, and `WelcomeVideoModalViewController`.

---
*PR created automatically by Jules for task [13974458696377359201](https://jules.google.com/task/13974458696377359201) started by @clemPerrousset*