### PR TITLE
fix: Provide valid baseURL to fix YouTube embed error 153

### DIFF
--- a/entourage/Scenes/Home/Pedagogic/PedagogicDetailViewController.swift
+++ b/entourage/Scenes/Home/Pedagogic/PedagogicDetailViewController.swift
@@ -26,7 +26,8 @@ class PedagogicDetailViewController: UIViewController, WKUIDelegate {
         ui_webview.navigationDelegate = self
         
         if let htmlBody = htmlBody {
-            ui_webview.loadHTMLString(htmlBody, baseURL: nil)
+            let baseURL = URL(string: "https://www.entourage.social")
+            ui_webview.loadHTMLString(htmlBody, baseURL: baseURL)
         }
         self.getDetailResource()
     }
@@ -43,7 +44,8 @@ class PedagogicDetailViewController: UIViewController, WKUIDelegate {
         HomeService.getResourceWithId(_resourceId) { resource, error in
             if let htmlBody = resource?.bodyHtml {
                 DispatchQueue.main.async {
-                    self.ui_webview.loadHTMLString(htmlBody, baseURL: nil)
+                    let baseURL = URL(string: "https://www.entourage.social")
+                    self.ui_webview.loadHTMLString(htmlBody, baseURL: baseURL)
                 }
             }
         }


### PR DESCRIPTION
This PR updates `PedagogicDetailViewController` to provide `https://www.entourage.social` as the `baseURL` when loading the webview's HTML string.

Previously, `baseURL` was set to `nil`, which caused embedded YouTube iframes within the HTML to lack a valid origin/referrer. This caused the YouTube player API to throw a configuration error (Error 153). Passing a valid domain resolves this issue.

---
*PR created automatically by Jules for task [2221758491277100899](https://jules.google.com/task/2221758491277100899) started by @clemPerrousset*