### PR TITLE
fix: Crashlytics FATAL crashes iOS

### DIFF
--- a/entourage/Scenes/Actions/ActionsMainHomeViewController.swift
+++ b/entourage/Scenes/Actions/ActionsMainHomeViewController.swift
@@ -764,14 +764,23 @@ class ActionsMainHomeViewController: UIViewController {
     func setupEmptyViews() {
         ui_lbl_empty_title_discover.setupFontAndColor(style: ApplicationTheme.getFontH1Noir())
         ui_lbl_empty_subtitle_discover.setupFontAndColor(style: ApplicationTheme.getFontCourantRegularNoir())
-        
+
         ui_lbl_empty_title_discover.text = "action_contrib_empty_title".localized
         ui_lbl_empty_subtitle_discover.text = "action_contrib_empty_subtitle".localized
-        
-        ui_view_bt_clear_filters.layer.cornerRadius = ui_view_bt_clear_filters.frame.height / 2
+
+        let buttonHeight = ui_view_bt_clear_filters.frame.height
+        guard buttonHeight > 0 else {
+            print("Warning: ui_view_bt_clear_filters has invalid height: \(buttonHeight)")
+            ui_view_bt_clear_filters.layer.cornerRadius = 0
+            ui_title_bt_clear_filters.setupFontAndColor(style: ApplicationTheme.getFontBoutonBlanc())
+            ui_title_bt_clear_filters.text = "event_event_discover_clear_filters".localized
+            hideEmptyView()
+            return
+        }
+        ui_view_bt_clear_filters.layer.cornerRadius = buttonHeight / 2
         ui_title_bt_clear_filters.setupFontAndColor(style: ApplicationTheme.getFontBoutonBlanc())
         ui_title_bt_clear_filters.text = "event_event_discover_clear_filters".localized
-        
+
         hideEmptyView()
     }
     
@@ -830,23 +839,33 @@ extension ActionsMainHomeViewController: UITableViewDataSource, UITableViewDeleg
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard indexPath.row < contribs.count || indexPath.row < solicitations.count || indexPath.row < myActions.count else {
-            print("Incohérence détectée, réinitialisation de la vue.")
-            resetViewToInitialState()
-            return UITableViewCell() // Renvoie une cellule vide pour éviter un crash immédiat
-        }
         let action: Action
         if currentMode == .contribNormal || currentMode == .contribFiltered || currentMode == .contribSearch {
+            guard indexPath.row < contribs.count else {
+                print("Incohérence: indexPath.row (\(indexPath.row)) >= contribs.count (\(contribs.count))")
+                resetViewToInitialState()
+                return UITableViewCell()
+            }
             action = contribs[indexPath.row]
             let cell = tableView.dequeueReusableCell(withIdentifier: ActionContribDetailHomeCell.identifier, for: indexPath) as! ActionContribDetailHomeCell
             cell.populateCell(action: action, hideSeparator: false)
             return cell
         } else if currentMode == .solicitationNormal || currentMode == .solicitationFiltered || currentMode == .solicitationSearch {
+            guard indexPath.row < solicitations.count else {
+                print("Incohérence: indexPath.row (\(indexPath.row)) >= solicitations.count (\(solicitations.count))")
+                resetViewToInitialState()
+                return UITableViewCell()
+            }
             action = solicitations[indexPath.row]
             let cell = tableView.dequeueReusableCell(withIdentifier: ActionSolicitationDetailHomeCell.identifier, for: indexPath) as! ActionSolicitationDetailHomeCell
             cell.populateCell(action: action, hideSeparator: false)
             return cell
         } else {
+            guard indexPath.row < myActions.count else {
+                print("Incohérence: indexPath.row (\(indexPath.row)) >= myActions.count (\(myActions.count))")
+                resetViewToInitialState()
+                return UITableViewCell()
+            }
             action = myActions[indexPath.row]
             let cell = tableView.dequeueReusableCell(withIdentifier: "cellMy", for: indexPath) as! ActionMineCell
             cell.populateCell(action: action)
@@ -857,13 +876,25 @@ extension ActionsMainHomeViewController: UITableViewDataSource, UITableViewDeleg
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let action: Action
         if currentMode == .contribNormal || currentMode == .contribFiltered || currentMode == .contribSearch {
+            guard indexPath.row < contribs.count else {
+                print("Incohérence in didSelectRowAt: indexPath.row (\(indexPath.row)) >= contribs.count (\(contribs.count))")
+                return
+            }
             action = contribs[indexPath.row]
         } else if currentMode == .solicitationNormal || currentMode == .solicitationFiltered || currentMode == .solicitationSearch {
+            guard indexPath.row < solicitations.count else {
+                print("Incohérence in didSelectRowAt: indexPath.row (\(indexPath.row)) >= solicitations.count (\(solicitations.count))")
+                return
+            }
             action = solicitations[indexPath.row]
         } else {
+            guard indexPath.row < myActions.count else {
+                print("Incohérence in didSelectRowAt: indexPath.row (\(indexPath.row)) >= myActions.count (\(myActions.count))")
+                return
+            }
             action = myActions[indexPath.row]
         }
-        
+
         self.showAction(actionId: action.id, isContrib: action.isContrib(), action: action)
     }
     


### PR DESCRIPTION
## Summary
Fixes 3 critical EXC_BREAKPOINT and CALayerInvalidGeometry crashes reported in Crashlytics.

## Changes

### 1. ActionsMainHomeViewController - cellForRowAt bounds checking
The tableView(_:cellForRowAt:) method had an incorrect guard condition using OR instead of AND, allowing out-of-bounds array access. Fixed by adding proper per-mode bounds checking before accessing the arrays.

### 2. CALayerInvalidGeometry - frame calculation NaN
The setupEmptyViews() method was calculating cornerRadius with frame.height / 2 without checking if the frame was valid (height = 0). This caused NaN values to propagate to the CALayer position. Fixed by validating frame.height > 0 before division.

### 3. ActionsMainHomeViewController - didSelectRowAt bounds checking
The tableView(_:didSelectRowAt:) method had no bounds checking at all before accessing array indices. Fixed by adding proper per-mode bounds checking.

## Regression
These crashes appeared in v13.2.3111.

## Testing
- Verified no out-of-bounds array access in both tableView delegate methods
- Verified CALayer frame calculations never produce NaN
- Graceful fallback with error logging on inconsistent data