### PR TITLE
Fix placeholder text being sent as message content when uploading image

### DIFF
--- a/entourage/Scenes/Conversations/ConversationDetailMessagesViewController.swift
+++ b/entourage/Scenes/Conversations/ConversationDetailMessagesViewController.swift
@@ -1455,6 +1455,12 @@ func checkNewConv() {
     /// Convertit l'attributedText du UITextView en une chaîne HTML et en extrait le contenu du <body>.
     func getHTMLMessage() -> String? {
         guard let attributedText = ui_textview_message.attributedText else { return nil }
+
+        let currentText = ui_textview_message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if currentText.isEmpty || currentText == placeholderTxt {
+            return nil
+        }
+
         do {
             let htmlData = try attributedText.data(
                 from: NSRange(location: 0, length: attributedText.length),

--- a/entourage/Scenes/Groups - Neighborhoods/NeighborhoodPostAddViewController.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/NeighborhoodPostAddViewController.swift
@@ -189,6 +189,13 @@ class NeighborhoodPostAddViewController: UIViewController {
     // MARK: - Conversion en HTML pour prendre en compte le texte enrichi (mentions)
     func getHTMLMessage() -> String? {
         guard let attributedText = ui_tv_message.attributedText else { return nil }
+
+        let placeholder = ui_tv_message.placeholderText ?? "neighborhood_add_post_message_placeholder".localized
+        let currentText = ui_tv_message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if currentText.isEmpty || currentText == placeholder {
+            return nil
+        }
+
         do {
             let htmlData = try attributedText.data(from: NSRange(location: 0, length: attributedText.length),
                                                    documentAttributes: [.documentType: NSAttributedString.DocumentType.html])


### PR DESCRIPTION
Fixes an issue where uploading an image without adding any custom text in a group post or a direct message would incorrectly send the text view's placeholder string (e.g., "Écrivez votre message...") as the actual text content.

---
*PR created automatically by Jules for task [806444477566361477](https://jules.google.com/task/806444477566361477) started by @clemPerrousset*