### PR TITLE
Fix missing color assets in Welcome Journey views causing invisible text

### DIFF
--- a/entourage/Scenes/HomeV2/homev2cells/HomeWelcomeJourneyView.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeWelcomeJourneyView.swift
@@ -136,7 +136,7 @@ struct HomeWelcomeJourneyView: View {
             // Microcopy
             Text(viewModel.microcopy)
                 .font(.custom("NunitoSans-Regular", size: 13))
-                .foregroundColor(Color("grey"))
+                .foregroundColor(Color.gray)
                 .padding(.horizontal, 20)
 
             if viewModel.isFullyCompleted {
@@ -200,7 +200,7 @@ struct WelcomeJourneyStepView: View {
                         HStack(alignment: .top) {
                             Text(step.title)
                                 .font(.custom("Quicksand-Bold", size: 15))
-                                .foregroundColor(step.state == .completed ? Color("green_logout") : (step.state == .future ? Color("grey") : Color.black))
+                                .foregroundColor(step.state == .completed ? Color("green_logout") : (step.state == .future ? Color.gray : Color.black))
                                 .multilineTextAlignment(.leading)
                             Spacer(minLength: 8)
                             if step.state == .completed {
@@ -224,7 +224,7 @@ struct WelcomeJourneyStepView: View {
 
                         Text(step.subtitle)
                             .font(.custom("NunitoSans-Regular", size: 15))
-                            .foregroundColor(step.state == .completed ? Color("green_logout") : Color("grey"))
+                            .foregroundColor(step.state == .completed ? Color("green_logout") : Color.gray)
                             .multilineTextAlignment(.leading)
                             .fixedSize(horizontal: false, vertical: true)
                             .padding(.top, 4)

--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeJourneyCelebrationPopupViewController.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeJourneyCelebrationPopupViewController.swift
@@ -37,7 +37,7 @@ class WelcomeJourneyCelebrationPopupViewController: UIViewController {
         // Title
         titleLabel.text = "home_v2_welcome_celebration_title".localized
         titleLabel.font = .systemFont(ofSize: 22, weight: .bold)
-        titleLabel.textColor = UIColor(named: "black")
+        titleLabel.textColor = UIColor.black
         titleLabel.textAlignment = .center
         titleLabel.numberOfLines = 0
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -46,7 +46,7 @@ class WelcomeJourneyCelebrationPopupViewController: UIViewController {
         // Description
         descriptionLabel.text = "home_v2_welcome_celebration_desc".localized
         descriptionLabel.font = .systemFont(ofSize: 15, weight: .regular)
-        descriptionLabel.textColor = UIColor(named: "grey")
+        descriptionLabel.textColor = UIColor.gray
         descriptionLabel.textAlignment = .center
         descriptionLabel.numberOfLines = 0
         descriptionLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeVideoModalViewController.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeVideoModalViewController.swift
@@ -46,7 +46,7 @@ class WelcomeVideoModalViewController: UIViewController {
         // Title
         titleLabel.text = "home_v2_welcome_video_modal_title".localized
         titleLabel.font = .systemFont(ofSize: 22, weight: .bold)
-        titleLabel.textColor = UIColor(named: "black")
+        titleLabel.textColor = UIColor.black
         titleLabel.numberOfLines = 0
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         containerView.addSubview(titleLabel)
@@ -54,7 +54,7 @@ class WelcomeVideoModalViewController: UIViewController {
         // Description
         descriptionLabel.text = "home_v2_welcome_video_modal_desc".localized
         descriptionLabel.font = .systemFont(ofSize: 15, weight: .regular)
-        descriptionLabel.textColor = UIColor(named: "grey")
+        descriptionLabel.textColor = UIColor.gray
         descriptionLabel.numberOfLines = 0
         descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
         containerView.addSubview(descriptionLabel)
@@ -63,7 +63,7 @@ class WelcomeVideoModalViewController: UIViewController {
         continueButton.setTitle("home_v2_welcome_video_modal_btn".localized, for: .normal)
         continueButton.titleLabel?.font = .systemFont(ofSize: 15, weight: .bold)
         continueButton.setTitleColor(.white, for: .normal)
-        continueButton.backgroundColor = UIColor(named: "grey") // Disabled state initially
+        continueButton.backgroundColor = UIColor.gray // Disabled state initially
         continueButton.layer.cornerRadius = 24
         continueButton.isEnabled = false
         continueButton.addTarget(self, action: #selector(onContinueTap), for: .touchUpInside)
@@ -116,7 +116,7 @@ class WelcomeVideoModalViewController: UIViewController {
             continueButton.backgroundColor = UIColor(named: "orange_app")
 
             // "Play" visual feedback
-            videoIconImageView.tintColor = UIColor(named: "grey")
+            videoIconImageView.tintColor = UIColor.gray
 
             // Open video URL if needed
             let urlStr = "https://www.youtube.com/watch?v=YOUR_VIDEO_ID" // Placeholder


### PR DESCRIPTION
This submission fixes an issue on the new Home Welcome Journey module where text titles and subtitles were rendering completely white or transparent, effectively appearing invisible. This was caused by the usage of non-existent color asset names like `"black"` and `"grey"`. This patch replaces those instances with standard native iOS colors (`Color.black`/`UIColor.black` and `Color.gray`/`UIColor.gray`).

---
*PR created automatically by Jules for task [1551458467635928532](https://jules.google.com/task/1551458467635928532) started by @clemPerrousset*