### PR TITLE
Fix inverted CTAs 'Quitter' and 'Annuler' on Event Edit Back popup

### DIFF
--- a/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
+++ b/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
@@ -464,7 +464,7 @@ extension EventCreateMainViewController: MJNavBackViewDelegate {
         let alertVC = MJAlertController()
         let buttonCancel = MJAlertButtonType(title: "eventCreatePopCloseBackCancel".localized, titleStyle:ApplicationTheme.getFontCourantBoldBlanc(), bgColor: .appOrangeLight, cornerRadius: -1)
         let buttonValidate = MJAlertButtonType(title: "eventCreatePopCloseBackQuit".localized, titleStyle:ApplicationTheme.getFontCourantBoldBlanc(), bgColor: .appOrange, cornerRadius: -1)
-        alertVC.configureAlert(alertTitle: "eventCreatePopCloseBackTitle".localized, message: "eventCreatePopCloseBackMessage".localized, buttonrightType: buttonValidate, buttonLeftType: buttonCancel, titleStyle: ApplicationTheme.getFontCourantBoldOrange(), messageStyle: ApplicationTheme.getFontCourantRegularNoir(), mainviewBGColor: .white, mainviewRadius: 35, isButtonCloseHidden: true)
+        alertVC.configureAlert(alertTitle: "eventCreatePopCloseBackTitle".localized, message: "eventCreatePopCloseBackMessage".localized, buttonrightType: buttonCancel, buttonLeftType: buttonValidate, titleStyle: ApplicationTheme.getFontCourantBoldOrange(), messageStyle: ApplicationTheme.getFontCourantRegularNoir(), mainviewBGColor: .white, mainviewRadius: 35, isButtonCloseHidden: true)
         alertVC.delegate = self
         alertVC.show()
     }
@@ -473,10 +473,9 @@ extension EventCreateMainViewController: MJNavBackViewDelegate {
 //MARK: - MJAlertControllerDelegate -
 extension EventCreateMainViewController: MJAlertControllerDelegate {
     func validateLeftButton(alertTag: MJAlertTAG) {
+        self.dismiss(animated: true)
     }
     func validateRightButton(alertTag: MJAlertTAG) {
-        self.dismiss(animated: true)
-
     }
 }
 

--- a/entourage/Scenes/Events/EventEditMainViewController.swift
+++ b/entourage/Scenes/Events/EventEditMainViewController.swift
@@ -532,7 +532,7 @@ extension EventEditMainViewController: MJNavBackViewDelegate {
         let alertVC = MJAlertController()
         let buttonCancel = MJAlertButtonType(title: "eventModPopCloseBackCancel".localized, titleStyle:ApplicationTheme.getFontCourantBoldBlanc(), bgColor: .appOrangeLight, cornerRadius: -1)
         let buttonValidate = MJAlertButtonType(title: "eventModPopCloseBackQuit".localized, titleStyle:ApplicationTheme.getFontCourantBoldBlanc(), bgColor: .appOrange, cornerRadius: -1)
-        alertVC.configureAlert(alertTitle: "eventModPopCloseBackTitle".localized, message: "eventModPopCloseBackMessage".localized, buttonrightType: buttonValidate, buttonLeftType: buttonCancel, titleStyle: ApplicationTheme.getFontCourantBoldOrange(), messageStyle: ApplicationTheme.getFontCourantRegularNoir(), mainviewBGColor: .white, mainviewRadius: 35, isButtonCloseHidden: true)
+        alertVC.configureAlert(alertTitle: "eventModPopCloseBackTitle".localized, message: "eventModPopCloseBackMessage".localized, buttonrightType: buttonCancel, buttonLeftType: buttonValidate, titleStyle: ApplicationTheme.getFontCourantBoldOrange(), messageStyle: ApplicationTheme.getFontCourantRegularNoir(), mainviewBGColor: .white, mainviewRadius: 35, isButtonCloseHidden: true)
         alertVC.delegate = self
         alertVC.show()
     }
@@ -541,15 +541,16 @@ extension EventEditMainViewController: MJNavBackViewDelegate {
 //MARK: - MJAlertControllerDelegate -
 extension EventEditMainViewController: MJAlertControllerDelegate {
     func validateLeftButton(alertTag: MJAlertTAG) {
-        // Le bouton gauche est "Annuler", la popup se ferme toute seule. On ne fait rien d'autre.
+        if alertTag == .None {
+            self.dismiss(animated: true)
+        }
     }
     func validateRightButton(alertTag: MJAlertTAG) {
         if alertTag == .Suppress {
             let isAll = selectedRecurrencyPosition == 1
             self.createEvent(applyToAll:isAll)
         } else if alertTag == .None {
-            // Le bouton droit est "Quitter" pour l'alerte de retour en arriere
-            self.dismiss(animated: true)
+            // "Annuler" ferme juste la popup
         }
     }
     

--- a/entourage/Tools/MJAlertController.swift
+++ b/entourage/Tools/MJAlertController.swift
@@ -183,7 +183,12 @@ class MJAlertController: UIViewController {
         }
         
         initButton(button: ui_button_right, butttonType: buttonRightType)
-        configureWhiteButton(self.ui_button_left, withTitle: choice2 ?? "cancel".localized)
+
+        if hasChoice {
+            configureWhiteButton(self.ui_button_left, withTitle: choice2 ?? "cancel".localized)
+        } else if let buttonLeftType = buttonLeftType {
+            configureWhiteButton(self.ui_button_left, withTitle: buttonLeftType.title)
+        }
     }
     
     private func initButton(button:UIButton, butttonType:MJAlertButtonType) {


### PR DESCRIPTION
Fix inverted CTAs 'Quitter' and 'Annuler' on Event Edit Back popup

- In `EventEditMainViewController` and `EventCreateMainViewController`, the `buttonLeftType` and `buttonrightType` parameters were swapped, causing 'Annuler' to leave the form, and 'Quitter' to just close the popup.
- Fixed `MJAlertController.swift` where `ui_button_left` was overriding `buttonLeftType` texts with `cancel.localized` if `hasChoice` was false.

---
*PR created automatically by Jules for task [5014238125878955484](https://jules.google.com/task/5014238125878955484) started by @clemPerrousset*