### PR TITLE
feat: add DOM-TOM country codes and auto-detect mobile prefixes during registration

### DIFF
--- a/entourage/Tools/CountryCode.swift
+++ b/entourage/Tools/CountryCode.swift
@@ -23,4 +23,12 @@ public let defaultCountryCode = CountryCode(country: "France", code: "+33", flag
 public let allCountryCodes: [CountryCode] = [
     CountryCode(country: "France",   code: "+33", flag: "🇫🇷"),
     CountryCode(country: "Belgique", code: "+32", flag: "🇧🇪"),
+    CountryCode(country: "Guadeloupe", code: "+590", flag: "🇫🇷"),
+    CountryCode(country: "Martinique", code: "+596", flag: "🇫🇷"),
+    CountryCode(country: "Guyane", code: "+594", flag: "🇫🇷"),
+    CountryCode(country: "La Réunion", code: "+262", flag: "🇫🇷"),
+    CountryCode(country: "Mayotte", code: "+262", flag: "🇫🇷"),
+    CountryCode(country: "Polynésie", code: "+689", flag: "🇫🇷"),
+    CountryCode(country: "Nouvelle-Calédonie", code: "+687", flag: "🇫🇷"),
+    CountryCode(country: "Saint-Martin / St-Barth", code: "+590", flag: "🇫🇷"),
 ]

--- a/entourage/Tools/Utils.swift
+++ b/entourage/Tools/Utils.swift
@@ -100,11 +100,25 @@ import UIKit
     
     static func validatePhoneFormat(countryCode:String?, phone:String) -> String {
         var correctPhone = phone.trimmingCharacters(in: .whitespaces)
+        var appliedCountryCode = countryCode
+
+        // Auto-detect DOM-TOM prefixes if France is selected or no country code is provided
+        if appliedCountryCode == "+33" || appliedCountryCode == nil {
+            if correctPhone.hasPrefix("0690") || correctPhone.hasPrefix("0691") {
+                appliedCountryCode = "+590"
+            } else if correctPhone.hasPrefix("0696") || correctPhone.hasPrefix("0697") {
+                appliedCountryCode = "+596"
+            } else if correctPhone.hasPrefix("0694") {
+                appliedCountryCode = "+594"
+            } else if correctPhone.hasPrefix("0692") || correctPhone.hasPrefix("0693") || correctPhone.hasPrefix("0639") {
+                appliedCountryCode = "+262"
+            }
+        }
         
         if correctPhone.starts(with: "0") {
             //correctPhone.remove(at: .init(encodedOffset: 0))
             correctPhone.remove(at: .init(utf16Offset: 0, in: correctPhone))
-            if let _code = countryCode {
+            if let _code = appliedCountryCode {
                 correctPhone = _code + correctPhone
             }
             else {
@@ -112,7 +126,7 @@ import UIKit
             }
         }
         else if !correctPhone.starts(with: "+") {
-            if let _code = countryCode {
+            if let _code = appliedCountryCode {
                 correctPhone = _code + correctPhone
             }
         }


### PR DESCRIPTION
This commit adds the DOM-TOM territories to the country selection list in `CountryCode.swift` using their respective country names and codes, but with the French flag (`🇫🇷`) as requested. It also enhances `Utils.validatePhoneFormat(countryCode:phone:)` to automatically detect specific DOM-TOM mobile prefixes (e.g., `0690`, `0696`, `0692`) when the user selects France (`+33`) or leaves the country code blank. The correct regional prefix (e.g., `+590`, `+596`, `+262`) is automatically applied and formatted.

---
*PR created automatically by Jules for task [1899077492698153567](https://jules.google.com/task/1899077492698153567) started by @clemPerrousset*