### PR TITLE
Fix deeplinks for Welcome / Webinar events mapping to list view

### DIFF
--- a/entourage/Managers/DeeplinkManager.swift
+++ b/entourage/Managers/DeeplinkManager.swift
@@ -341,17 +341,11 @@ struct DeepLinkManager {
     }
 
     static func showWelcomeEvent() {
-        EventService.getWelcomeEvent { event in
-            guard let event = event else { return }
-            DispatchQueue.main.async {
-                if let navVc = UIStoryboard(name: StoryboardName.event, bundle: nil).instantiateViewController(withIdentifier: "eventDetailNav") as? UINavigationController, let vc = navVc.topViewController as? EventDetailFeedViewController  {
-                    vc.eventId = event.uid
-                    vc.event = event
-                    vc.isAfterCreation = false
-                    vc.modalPresentationStyle = .fullScreen
-                    AppState.getTopViewController()?.present(navVc, animated: true)
-                }
-            }
+        DispatchQueue.main.async {
+            let vc = WelcomeEventsListViewController()
+            vc.eventType = .firstStep
+            vc.modalPresentationStyle = .fullScreen
+            AppState.getTopViewController()?.present(vc, animated: true)
         }
     }
     static func showWelcomeTwo(){
@@ -690,17 +684,11 @@ struct DeepLinkManager {
     }
 
     static func showWelcomeWebinar() {
-        EventService.getWebinarEvent { event in
-            guard let event = event else { return }
-            DispatchQueue.main.async {
-                if let navVc = UIStoryboard(name: StoryboardName.event, bundle: nil).instantiateViewController(withIdentifier: "eventDetailNav") as? UINavigationController, let vc = navVc.topViewController as? EventDetailFeedViewController  {
-                    vc.eventId = event.uid
-                    vc.event = event
-                    vc.isAfterCreation = false
-                    vc.modalPresentationStyle = .fullScreen
-                    AppState.getTopViewController()?.present(navVc, animated: true)
-                }
-            }
+        DispatchQueue.main.async {
+            let vc = WelcomeEventsListViewController()
+            vc.eventType = .webinar
+            vc.modalPresentationStyle = .fullScreen
+            AppState.getTopViewController()?.present(vc, animated: true)
         }
     }
     

--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeEventsListView.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeEventsListView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 enum WelcomeEventType {
+    case firstStep
     case webinar
     case papotages
 }
@@ -31,8 +32,10 @@ class WelcomeEventsListViewModel: ObservableObject {
             }
         }
 
-        if type == .webinar {
+        if type == .firstStep {
             EventService.getWelcomeEvents(completion: completion)
+        } else if type == .webinar {
+            EventService.getWebinarEvents(completion: completion)
         } else {
             EventService.getPapotagesEvents(completion: completion)
         }
@@ -63,11 +66,15 @@ struct WelcomeEventsListView: View {
 
             // Title & Subtitle
             VStack(alignment: .leading, spacing: 8) {
-                Text(viewModel.type == .webinar ? "welcome_webinar_list_title".localized : "welcome_papotages_list_title".localized)
+                Text(viewModel.type == .firstStep ? "welcome_firststep_list_title".localized :
+                     viewModel.type == .webinar ? "welcome_webinar_list_title".localized :
+                     "welcome_papotages_list_title".localized)
                     .font(.custom("Quicksand-Bold", size: 24))
                     .foregroundColor(.black)
 
-                Text(viewModel.type == .webinar ? "welcome_webinar_list_subtitle".localized : "welcome_papotages_list_subtitle".localized)
+                Text(viewModel.type == .firstStep ? "welcome_firststep_list_subtitle".localized :
+                     viewModel.type == .webinar ? "welcome_webinar_list_subtitle".localized :
+                     "welcome_papotages_list_subtitle".localized)
                     .font(.custom("NunitoSans-Regular", size: 15))
                     .foregroundColor(.black)
             }


### PR DESCRIPTION
This fixes an issue where the app would try to compile or run calls for single event fetch methods (`getWelcomeEvent` and `getWebinarEvent`) which don't exist in `EventService`. Instead of creating endpoints for these (which didn't match the Android design which opens lists instead), we now show the list of these events via `WelcomeEventsListViewController`.

---
*PR created automatically by Jules for task [7729602374321646975](https://jules.google.com/task/7729602374321646975) started by @clemPerrousset*