### PR TITLE
Fix Welcome Video Modal height overflow

### DIFF
--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeVideoModalViewController.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeVideoModalViewController.swift
@@ -151,6 +151,8 @@ class WelcomeVideoModalViewController: UIViewController {
             containerView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            containerView.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+            containerView.bottomAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
 
             closeImageView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 16),
             closeImageView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
@@ -164,7 +166,9 @@ class WelcomeVideoModalViewController: UIViewController {
             webViewContainer.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
             webViewContainer.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 20),
             webViewContainer.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -20),
-            webViewContainer.heightAnchor.constraint(equalTo: webViewContainer.widthAnchor, multiplier: 16.0/9.0),
+            // Height is flexible but we want to make sure it expands as much as possible while maintaining the container's bounds.
+            // Using a low priority constraint for a preferred ratio so it doesn't collapse entirely if not needed,
+            // but it will shrink when the screen is too small.
 
             descriptionLabel.topAnchor.constraint(equalTo: webViewContainer.bottomAnchor, constant: 24),
             descriptionLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 20),
@@ -176,6 +180,12 @@ class WelcomeVideoModalViewController: UIViewController {
             continueButton.heightAnchor.constraint(equalToConstant: 50),
             continueButton.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -20)
         ])
+
+        // Add a flexible ratio constraint with lower priority so the video doesn't just disappear
+        // but can be crushed by the top/bottom constraints of the containerView
+        let heightConstraint = webViewContainer.heightAnchor.constraint(equalTo: webViewContainer.widthAnchor, multiplier: 16.0/9.0)
+        heightConstraint.priority = .defaultLow
+        heightConstraint.isActive = true
     }
 
     private func fetchVideoResource() {


### PR DESCRIPTION
The Welcome Video modal's layout was breaking on smaller screens because the video view was using a strict `16:9` required ratio relative to the device width, creating a massive vertical height that pushed the 'Continue' button off-screen.
This commit restricts the top and bottom of the container to the view's safe layout area, and lowers the priority of the video's aspect ratio constraint to `.defaultLow`, allowing the video to scale down and share available vertical space instead of overflowing the container.

---
*PR created automatically by Jules for task [14224330414173337474](https://jules.google.com/task/14224330414173337474) started by @clemPerrousset*