### PR TITLE
Fix iOS Event Detail View Layout

### DIFF
--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
@@ -47,6 +47,9 @@ class EventDetailTopFullCell: UITableViewCell {
     @IBOutlet weak var ui_constraint_height_reserved_female: NSLayoutConstraint!
     @IBOutlet weak var ui_lbl_reserved_female: UILabel?
 
+    @IBOutlet weak var ui_mapview: MKMapView!
+    @IBOutlet weak var ui_height_map_view: NSLayoutConstraint!
+
     weak var delegate: EventDetailTopCellDelegate? = nil
     
     let topMarginConstraint: CGFloat = 24

--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
@@ -336,7 +336,7 @@
                             <constraint firstAttribute="bottom" secondItem="abz-tt-vMF" secondAttribute="bottom" id="wL4-Py-not"/>
                         </constraints>
                     </view>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UXs-ZL-Ra7">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UXs-ZL-Ra7">
                         <rect key="frame" x="20" y="323" width="358" height="0.0"/>
                         <constraints>
                             <constraint firstAttribute="height" id="FyJ-jQ-Gmx"/>
@@ -345,7 +345,7 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="&quot; Bio bio bio &quot;" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CsR-kO-usD" customClass="ActiveLabel" customModule="ActiveLabel">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="&quot; Bio bio bio &quot;" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CsR-kO-usD" customClass="ActiveLabel" customModule="ActiveLabel">
                         <rect key="frame" x="20" y="327" width="358" height="20.5"/>
                         <fontDescription key="fontDescription" name="NunitoSans-Regular" family="Nunito Sans" pointSize="15"/>
                         <nil key="textColor"/>
@@ -356,7 +356,7 @@
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </label>
-                    <view contentMode="scaleToFill" verticalHuggingPriority="252" verticalCompressionResistancePriority="752" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fuU-Rj-r2w" customClass="TagListView" customModule="Ent_Beta" customModuleProvider="target">
+                    <view contentMode="scaleToFill" verticalHuggingPriority="252" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="fuU-Rj-r2w" customClass="TagListView" customModule="Ent_Beta" customModuleProvider="target">
                         <rect key="frame" x="20" y="371.5" width="366" height="193.5"/>
                         <color key="backgroundColor" red="1" green="0.61176470589999998" blue="0.36470588240000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
@@ -377,7 +377,7 @@
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </view>
-                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="view-disc-id">
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="view-disc-id">
                         <rect key="frame" x="20" y="649" width="366" height="136"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_messages_top" translatesAutoresizingMaskIntoConstraints="NO" id="img-disc-id">
@@ -423,6 +423,13 @@
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </view>
+
+                    <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" zoomEnabled="YES" scrollEnabled="NO" rotateEnabled="NO" pitchEnabled="NO" showsCompass="NO" translatesAutoresizingMaskIntoConstraints="NO" id="new-map-id">
+                        <rect key="frame" x="20" y="805" width="366" height="180"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="180" id="h-map-new"/>
+                        </constraints>
+                    </mapView>
                 </subviews>
                 <color key="backgroundColor" name="BeigeClair"/>
                 <constraints>
@@ -438,7 +445,6 @@
                     <constraint firstAttribute="trailing" secondItem="fuU-Rj-r2w" secondAttribute="trailing" constant="20" id="RgV-tb-QmG"/>
                     <constraint firstItem="UXs-ZL-Ra7" firstAttribute="leading" secondItem="klB-o1-C0m" secondAttribute="leading" id="UYw-0d-rgq"/>
                     <constraint firstItem="Nfw-W1-dO7" firstAttribute="top" secondItem="abc-female-banner" secondAttribute="bottom" constant="10" id="VQC-kR-A9p"/>
-                    <constraint firstAttribute="bottom" secondItem="view-disc-id" secondAttribute="bottom" constant="20" id="Vpw-kr-Z8k"/>
                     <constraint firstItem="CsR-kO-usD" firstAttribute="leading" secondItem="UXs-ZL-Ra7" secondAttribute="leading" id="aoe-s2-pzF"/>
                     <constraint firstAttribute="trailing" secondItem="klB-o1-C0m" secondAttribute="trailing" constant="20" id="hwX-yn-nXS"/>
                     <constraint firstAttribute="trailing" secondItem="CsR-kO-usD" secondAttribute="trailing" constant="28" id="n7J-Wl-s1L"/>
@@ -447,13 +453,22 @@
                     <constraint firstItem="abc-female-banner" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="klB-o1-C0m" secondAttribute="trailing" id="xyz-banner-trailing"/>
                     <constraint firstItem="klB-o1-C0m" firstAttribute="top" secondItem="3q6-vS-dBw" secondAttribute="top" constant="28" id="yC2-ZV-76o"/>
                     <constraint firstAttribute="trailing" secondItem="UXs-ZL-Ra7" secondAttribute="trailing" constant="28" id="yGN-4g-yQG"/>
+
+                    <constraint firstItem="view-disc-id" firstAttribute="top" secondItem="GxR-dy-Owz" secondAttribute="bottom" constant="20" id="gxZ-top-disc"/>
+                    <constraint firstItem="UXs-ZL-Ra7" firstAttribute="top" secondItem="view-disc-id" secondAttribute="bottom" constant="24" id="uxs-top-disc"/>
+                    <constraint firstItem="new-map-id" firstAttribute="top" secondItem="fuU-Rj-r2w" secondAttribute="bottom" constant="20" id="map-top-tags"/>
+                    <constraint firstAttribute="bottom" secondItem="new-map-id" secondAttribute="bottom" constant="20" id="map-bottom-super"/>
+                    <constraint firstItem="new-map-id" firstAttribute="leading" secondItem="3q6-vS-dBw" secondAttribute="leading" constant="20" id="map-lead-super"/>
+                    <constraint firstAttribute="trailing" secondItem="new-map-id" secondAttribute="trailing" constant="20" id="map-trail-super"/>
+                    <constraint firstItem="view-disc-id" firstAttribute="leading" secondItem="3q6-vS-dBw" secondAttribute="leading" constant="20" id="disc-lead-super"/>
+                    <constraint firstAttribute="trailing" secondItem="view-disc-id" secondAttribute="trailing" constant="20" id="disc-trail-super"/>
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <connections>
                 <outlet property="adress_view_top_constraint" destination="yX0-kE-283" id="tad-Gm-gRd"/>
                 <outlet property="ui_button_go_to_discussion" destination="btn-disc-id" id="Q8G-5Z-zcy"/>
-                <outlet property="ui_constraint_discussion_box_bottom" destination="Vpw-kr-Z8k" id="conn-disc-bottom"/>
+                <outlet property="ui_constraint_discussion_box_bottom" destination="uxs-top-disc" id="conn-disc-bottom"/>
                 <outlet property="ui_constraint_discussion_box_height" destination="h-view-disc" id="conn-disc-height"/>
                 <outlet property="ui_constraint_height_reserved_female" destination="hij-height-constraint" id="out-constraint-height"/>
                 <outlet property="ui_constraint_listview_top_margin" destination="At5-0v-xFn" id="CGo-JX-gSb"/>
@@ -482,6 +497,9 @@
                 <outlet property="ui_view_organised_by" destination="BfH-VT-nZB" id="E5B-Jh-TwT"/>
                 <outlet property="ui_view_place_limit" destination="YLQ-hv-Eb2" id="ght-bZ-LHL"/>
                 <outlet property="ui_view_reserved_female" destination="abc-female-banner" id="out-view-reserved"/>
+
+                <outlet property="ui_mapview" destination="new-map-id" id="map-id-conn"/>
+                <outlet property="ui_height_map_view" destination="h-map-new" id="h-map-new-conn"/>
             </connections>
             <point key="canvasLocation" x="124.6376811594203" y="175.44642857142856"/>
         </tableViewCell>


### PR DESCRIPTION
Fixes the iOS event detail view to look identically to the Android layout (showing the Map and layout of other UI elements).

---
*PR created automatically by Jules for task [9329354466922154414](https://jules.google.com/task/9329354466922154414) started by @clemPerrousset*