### PR TITLE
feat: Log network requests as cURL commands

### DIFF
--- a/entourage/Network Managers/NetworkManager.swift
+++ b/entourage/Network Managers/NetworkManager.swift
@@ -67,6 +67,7 @@ class NetworkManager {
         }
         
         addRequiereHeaders(urlRequest: &urlRequest)
+        Logger.print("================== CURL ==================\n\(urlRequest.cURL)\n==========================================")
         
         session = URLSession(configuration: sessionConfig, delegate: nil, delegateQueue: nil)
         let task = session.dataTask(with: urlRequest) { (data, response, error) in
@@ -135,6 +136,7 @@ class NetworkManager {
         
         
         addRequiereHeaders(urlRequest: &urlRequest)
+        Logger.print("================== CURL ==================\n\(urlRequest.cURL)\n==========================================")
         session = URLSession(configuration: sessionConfig, delegate: nil, delegateQueue: nil)
         let task = session.dataTask(with: urlRequest) { (data, response, error) in
             
@@ -196,6 +198,7 @@ class NetworkManager {
         }
         
         addRequiereHeaders(urlRequest: &urlRequest)
+        Logger.print("================== CURL ==================\n\(urlRequest.cURL)\n==========================================")
         
         session = URLSession(configuration: sessionConfig, delegate: nil, delegateQueue: nil)
         let task = session.dataTask(with: urlRequest) { (data, response, error) in
@@ -248,6 +251,7 @@ class NetworkManager {
         }
         
         addRequiereHeaders(urlRequest: &urlRequest)
+        Logger.print("================== CURL ==================\n\(urlRequest.cURL)\n==========================================")
         
         session = URLSession(configuration: sessionConfig, delegate: nil, delegateQueue: nil)
         
@@ -300,6 +304,7 @@ class NetworkManager {
         }
         
         addRequiereHeaders(urlRequest: &urlRequest)
+        Logger.print("================== CURL ==================\n\(urlRequest.cURL)\n==========================================")
         
         session = URLSession(configuration: sessionConfig, delegate: nil, delegateQueue: nil)
         let task = session.dataTask(with: urlRequest) { (data, response, error) in
@@ -355,3 +360,31 @@ struct EntourageNetworkError {
     }
 }
 
+extension URLRequest {
+    public var cURL: String {
+        guard let url = self.url else { return "" }
+        var baseCommand = "curl '\(url.absoluteString)'"
+
+        if self.httpMethod == "HEAD" {
+            baseCommand += " --head"
+        }
+
+        var command = [baseCommand]
+
+        if let method = self.httpMethod, method != "GET" && method != "HEAD" {
+            command.append("-X \(method)")
+        }
+
+        if let headers = self.allHTTPHeaderFields {
+            for (key, value) in headers {
+                command.append("-H '\(key): \(value)'")
+            }
+        }
+
+        if let data = self.httpBody, let body = String(data: data, encoding: .utf8) {
+            command.append("-d '\(body)'")
+        }
+
+        return command.joined(separator: " \\\n\t")
+    }
+}


### PR DESCRIPTION
This commit adds functionality to log outgoing network requests as cURL commands in the debug console, specifically for the backend team to reproduce issues easily. The cURL strings contain the keyword "CURL" for easy grepping in logs.

---
*PR created automatically by Jules for task [12636059108906426822](https://jules.google.com/task/12636059108906426822) started by @clemPerrousset*