### PR TITLE
Update event discussion box UI

### DIFF
--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -2019,3 +2019,4 @@
 "welcome_webinar_list_subtitle" = "The Entourage team gives you the keys to understand street life and existing aid solutions during a 1-hour online workshop.";
 "welcome_firststep_list_title" = "First steps on Entourage";
 "welcome_firststep_list_subtitle" = "Get to know the app and ask all your questions to the team — in small groups, a 45-minute video call.";
+"event_discussion_desc" = "You can ask your questions and exchange with the organizer and the participants of the event";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -2016,3 +2016,4 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "welcome_webinar_list_subtitle" = "L'équipe Entourage vous donne les clefs pour appréhender le monde de la rue et les solutions d'aide existantes lors d'un atelier en ligne de 1h.";
 "welcome_firststep_list_title" = "Premiers pas sur Entourage";
 "welcome_firststep_list_subtitle" = "Prenez en main l'application et posez toutes vos questions à l'équipe — en petit groupe, en 45 minutes en visio.";
+"event_discussion_desc" = "Vous pouvez poser vos questions et échanger avec l'organisateur et les participants de l'événement";

--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
@@ -41,6 +41,7 @@ class EventDetailTopFullCell: UITableViewCell {
     @IBOutlet weak var ui_constraint_discussion_box_top: NSLayoutConstraint!
     @IBOutlet weak var ui_constraint_discussion_box_bottom: NSLayoutConstraint!
     @IBOutlet weak var ui_constraint_discussion_box_height: NSLayoutConstraint!
+    @IBOutlet weak var ui_label_discussion_desc: UILabel!
     
     
     @IBOutlet weak var ui_view_reserved_female: UIView!
@@ -92,8 +93,11 @@ class EventDetailTopFullCell: UITableViewCell {
         ui_lbl_reserved_female?.setFontTitle(size: 13)
 
         ui_view_place_limit.isHidden = true
-        configureOrangeButton(self.ui_button_go_to_discussion, withTitle: "event_conversation".localized)
+        configureOrangeButton(self.ui_button_go_to_discussion, withTitle: "event_discussion_title".localized)
         self.ui_view_discussion_box.layer.cornerRadius = 20
+        self.ui_view_discussion_box.layer.borderWidth = 1.0
+        self.ui_view_discussion_box.layer.borderColor = UIColor.appOrange.cgColor
+        self.ui_label_discussion_desc.text = "event_discussion_desc".localized
     }
     
     @objc func onParticipateClick() {

--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
@@ -387,17 +387,18 @@
                                     <constraint firstAttribute="width" constant="44" id="w-disc-img"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Discussion de l'événement" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-disc-id">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Discussion de l'événement" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbl-disc-id">
                                 <rect key="frame" x="76" y="28" width="274" height="20.5"/>
-                                <fontDescription key="fontDescription" name="NunitoSans-Bold" family="Nunito Sans" pointSize="15"/>
+                                <fontDescription key="fontDescription" name="NunitoSans-Regular" family="Nunito Sans" pointSize="14"/>
                                 <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="btn-disc-id">
-                                <rect key="frame" x="16" y="76" width="334" height="40"/>
+                                <rect key="frame" x="80" y="76" width="206" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="h-btn-disc"/>
                                 </constraints>
+                                <inset key="contentEdgeInsets" minX="20" minY="0.0" maxX="20" maxY="0.0"/>
                                 <state key="normal" title="Button"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="cradius">
@@ -417,8 +418,7 @@
                             <constraint firstItem="lbl-disc-id" firstAttribute="centerY" secondItem="img-disc-id" secondAttribute="centerY" id="c4-disc"/>
                             <constraint firstAttribute="trailing" secondItem="lbl-disc-id" secondAttribute="trailing" constant="16" id="c5-disc"/>
                             <constraint firstItem="btn-disc-id" firstAttribute="top" secondItem="img-disc-id" secondAttribute="bottom" constant="16" id="c6-disc"/>
-                            <constraint firstItem="btn-disc-id" firstAttribute="leading" secondItem="view-disc-id" secondAttribute="leading" constant="16" id="c7-disc"/>
-                            <constraint firstAttribute="trailing" secondItem="btn-disc-id" secondAttribute="trailing" constant="16" id="c8-disc"/>
+                            <constraint firstItem="btn-disc-id" firstAttribute="centerX" secondItem="view-disc-id" secondAttribute="centerX" id="c7-disc-center"/>
                             <constraint firstAttribute="bottom" secondItem="btn-disc-id" secondAttribute="bottom" constant="20" id="c9-disc"/>
                             <constraint firstAttribute="height" constant="136" id="h-view-disc"/>
                         </constraints>
@@ -500,6 +500,7 @@
                 <outlet property="ui_title" destination="klB-o1-C0m" id="RDE-wl-Ymg"/>
                 <outlet property="ui_view_association" destination="DwY-20-5TL" id="HZX-l1-aAP"/>
                 <outlet property="ui_view_discussion_box" destination="view-disc-id" id="view-disc-id-conn"/>
+                <outlet property="ui_label_discussion_desc" destination="lbl-disc-id" id="lbl-disc-id-conn"/>
                 <outlet property="ui_view_organised_by" destination="BfH-VT-nZB" id="E5B-Jh-TwT"/>
                 <outlet property="ui_view_place_limit" destination="YLQ-hv-Eb2" id="ght-bZ-LHL"/>
                 <outlet property="ui_view_reserved_female" destination="abc-female-banner" id="out-view-reserved"/>


### PR DESCRIPTION
Updates the discussion box in the event details view on iOS to match the Android design. This includes a descriptive multiline text, an orange border, and a smaller centered button.

---
*PR created automatically by Jules for task [6353593941731650923](https://jules.google.com/task/6353593941731650923) started by @clemPerrousset*