### PR TITLE
Fix: Reload home entirely upon closing welcome video modal

### DIFF
--- a/entourage/Scenes/HomeV2/HomeV2ViewController.swift
+++ b/entourage/Scenes/HomeV2/HomeV2ViewController.swift
@@ -622,10 +622,10 @@ extension HomeV2ViewController: UITableViewDelegate, UITableViewDataSource {
             modalVC.modalPresentationStyle = .overFullScreen
             modalVC.modalTransitionStyle = .crossDissolve
             modalVC.onComplete = { [weak self] in
-                self?.configureDTO()
+                self?.initHome()
             }
             modalVC.onDismissOnly = { [weak self] in
-                self?.configureDTO()
+                self?.initHome()
             }
             self.present(modalVC, animated: true)
 


### PR DESCRIPTION
- Replaced `configureDTO()` with `initHome()` in `HomeV2ViewController.swift` for the `.video` welcome journey step.
- This ensures the home screen data completely reloads when the video pop-up is dismissed or continued.

---
*PR created automatically by Jules for task [141643072874258079](https://jules.google.com/task/141643072874258079) started by @clemPerrousset*