### PR TITLE
fix: adjust event discussion button and prevent flicker on join

### DIFF
--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.swift
@@ -108,8 +108,8 @@ class EventDetailTopFullCell: UITableViewCell {
         button.setTitle(title, for: .normal)
         button.backgroundColor = UIColor.appOrange
         button.setTitleColor(.white, for: .normal)
-        button.layer.cornerRadius = 20
-        button.titleLabel?.font = ApplicationTheme.getFontQuickSandBold(size: 15)
+        button.layer.cornerRadius = 25
+        button.titleLabel?.font = ApplicationTheme.getFontQuickSandBold(size: 13)
         button.clipsToBounds = true
         
         if let image = button.imageView?.image {
@@ -126,7 +126,7 @@ class EventDetailTopFullCell: UITableViewCell {
             self.ui_view_discussion_box.isHidden = false
             self.ui_constraint_discussion_box_top?.constant = 20
             self.ui_constraint_discussion_box_bottom?.constant = 20
-            self.ui_constraint_discussion_box_height?.constant = 136
+            self.ui_constraint_discussion_box_height?.constant = 146
         }else{
             self.ui_view_discussion_box.isHidden = true
             self.ui_constraint_discussion_box_top?.constant = 0

--- a/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
+++ b/entourage/Scenes/Events/Cells/Feed/EventDetailTopFullCell.xib
@@ -394,15 +394,15 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="btn-disc-id">
-                                <rect key="frame" x="80" y="76" width="206" height="40"/>
+                                <rect key="frame" x="76" y="76" width="206" height="50"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="40" id="h-btn-disc"/>
+                                    <constraint firstAttribute="height" constant="50" id="h-btn-disc"/>
                                 </constraints>
                                 <inset key="contentEdgeInsets" minX="20" minY="0.0" maxX="20" maxY="0.0"/>
                                 <state key="normal" title="Button"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="cradius">
-                                        <real key="value" value="15"/>
+                                        <real key="value" value="25"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
@@ -417,10 +417,10 @@
                             <constraint firstItem="lbl-disc-id" firstAttribute="leading" secondItem="img-disc-id" secondAttribute="trailing" constant="16" id="c3-disc"/>
                             <constraint firstItem="lbl-disc-id" firstAttribute="centerY" secondItem="img-disc-id" secondAttribute="centerY" id="c4-disc"/>
                             <constraint firstAttribute="trailing" secondItem="lbl-disc-id" secondAttribute="trailing" constant="16" id="c5-disc"/>
-                            <constraint firstItem="btn-disc-id" firstAttribute="top" secondItem="img-disc-id" secondAttribute="bottom" constant="16" id="c6-disc"/>
-                            <constraint firstItem="btn-disc-id" firstAttribute="centerX" secondItem="view-disc-id" secondAttribute="centerX" id="c7-disc-center"/>
+                            <constraint firstItem="btn-disc-id" firstAttribute="top" secondItem="lbl-disc-id" secondAttribute="bottom" constant="16" id="c6-disc"/>
+                            <constraint firstItem="btn-disc-id" firstAttribute="leading" secondItem="lbl-disc-id" secondAttribute="leading" id="c7-disc-center"/>
                             <constraint firstAttribute="bottom" secondItem="btn-disc-id" secondAttribute="bottom" constant="20" id="c9-disc"/>
-                            <constraint firstAttribute="height" constant="136" id="h-view-disc"/>
+                            <constraint firstAttribute="height" constant="146" id="h-view-disc"/>
                         </constraints>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">

--- a/entourage/Scenes/Events/EventDetailFeedViewController.swift
+++ b/entourage/Scenes/Events/EventDetailFeedViewController.swift
@@ -353,12 +353,12 @@ class EventDetailFeedViewController: UIViewController {
     // MARK: - Joindre / Quitter (action manuelle)
     
     func addRemoveMember(isAdd: Bool) {
-        // Met à jour localement
-        event?.isMember = isAdd
-        // La variable isAfterCreation est conservée, mais non utilisée pour l’affichage
-        // On la laisse telle quelle
-        isAfterCreation = false
-        ui_tableview.reloadData()
+        if !isAdd {
+            // Met à jour localement lorsqu'on quitte (pour éviter un délai visible)
+            event?.isMember = isAdd
+            isAfterCreation = false
+            ui_tableview.reloadData()
+        }
         
         SVProgressHUD.show()
         if isAdd {
@@ -877,11 +877,6 @@ extension EventDetailFeedViewController: CreateSurveyValidationDelegate {
 // MARK: - AmbassadorAskNotificationPopupDelegate
 extension EventDetailFeedViewController: AmbassadorAskNotificationPopupDelegate {
     func joinAsOrganizer() {
-        event?.isMember = true
-        // isAfterCreation reste, mais on ne l’utilise plus pour la cell
-        isAfterCreation = false
-        ui_tableview.reloadData()
-        
         SVProgressHUD.show()
         EventService.joinEventAsOrganizer(eventId: eventId) { _, _ in
             SVProgressHUD.dismiss()
@@ -889,10 +884,6 @@ extension EventDetailFeedViewController: AmbassadorAskNotificationPopupDelegate 
     }
     
     func justParticipate() {
-        event?.isMember = true
-        isAfterCreation = false
-        ui_tableview.reloadData()
-        
         SVProgressHUD.show()
         EventService.joinEvent(eventId: eventId) { _, _ in
             SVProgressHUD.dismiss()


### PR DESCRIPTION
Fixes the styling and layout of the event discussion button and prevents an unwanted UI flicker when joining an event before the transition to the messages view.

---
*PR created automatically by Jules for task [5322294638392203095](https://jules.google.com/task/5322294638392203095) started by @clemPerrousset*