### PR TITLE
Fix Welcome Journey styling based on DS and design reviews

### DIFF
--- a/entourage/Scenes/HomeV2/homev2cells/HomeWelcomeJourneyView.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeWelcomeJourneyView.swift
@@ -70,7 +70,7 @@ class WelcomeJourneyViewModel: ObservableObject {
                 title: "home_v2_welcome_video_title".localized,
                 subtitle: "home_v2_welcome_video_subtitle".localized,
                 buttonTitle: "home_v2_welcome_video_btn".localized,
-                iconName: "play.rectangle",
+                iconName: "video.fill",
                 state: step1State
             ),
             WelcomeJourneyStep(
@@ -122,7 +122,7 @@ struct HomeWelcomeJourneyView: View {
                 HStack(alignment: .bottom) {
                     Text("home_v2_welcome_title".localized)
                         .font(.custom("Quicksand-Bold", size: 18))
-                        .foregroundColor(Color(UIColor.darkGray))
+                        .foregroundColor(.black)
                     Spacer()
                     // Affichage du texte uniquement pour le compteur
                     Text("\(viewModel.completedCount)/\(max(viewModel.steps.count, 3))")
@@ -131,27 +131,36 @@ struct HomeWelcomeJourneyView: View {
                 }
                 .padding(.horizontal, 16)
 
-                // Microcopy
-                Text(viewModel.microcopy)
-                    .font(.custom("NunitoSans-Regular", size: 13))
-                    .foregroundColor(Color.gray)
+                ProgressView(value: Double(viewModel.completedCount), total: Double(max(viewModel.steps.count, 3)))
+                    .progressViewStyle(LinearProgressViewStyle(tint: Color("orange_app")))
                     .padding(.horizontal, 16)
+                    .padding(.bottom, 4)
 
                 if viewModel.isFullyCompleted {
                     // Success Layout
                     VStack(spacing: 0) {
                         Text("home_v2_welcome_microcopy_3".localized)
                             .font(.custom("Quicksand-Bold", size: 15))
-                            .foregroundColor(Color("green_logout"))
+                            .foregroundColor(Color(red: 45/255, green: 104/255, blue: 50/255))
                             .multilineTextAlignment(.center)
                     }
                     .padding(12)
                     .frame(maxWidth: .infinity)
                     .background(Color("green_light").opacity(0.15))
                     .cornerRadius(12)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color(red: 45/255, green: 104/255, blue: 50/255), lineWidth: 1)
+                    )
                     .padding(.horizontal, 16)
                     .padding(.bottom, 16)
                 } else {
+                    // Microcopy
+                    Text(viewModel.microcopy)
+                        .font(.custom("NunitoSans-Regular", size: 13))
+                        .foregroundColor(Color.gray)
+                        .padding(.horizontal, 16)
+
                     // Steps List
                     VStack(spacing: 10) {
                         ForEach(viewModel.steps.indices, id: \.self) { index in
@@ -186,7 +195,7 @@ struct WelcomeJourneyStepView: View {
                     // Icon
                     ZStack {
                         Circle()
-                            .fill(step.state == .completed ? Color("green_logout") : Color("orange_light_a50").opacity(0.3))
+                            .fill(step.state == .completed ? Color(red: 45/255, green: 104/255, blue: 50/255) : Color("orange_light_a50").opacity(0.3))
                             .frame(width: 36, height: 36)
 
                         Image(systemName: step.state == .completed ? "checkmark" : step.iconName)
@@ -199,17 +208,21 @@ struct WelcomeJourneyStepView: View {
                         HStack(alignment: .top) {
                             Text(step.title)
                                 .font(.custom("Quicksand-Bold", size: 14))
-                                .foregroundColor(step.state == .completed ? Color("green_logout") : (step.state == .future ? Color.gray : Color.black))
+                                .foregroundColor(step.state == .completed ? Color(red: 45/255, green: 104/255, blue: 50/255) : (step.state == .future ? Color.gray : Color.black))
                                 .multilineTextAlignment(.leading)
                             Spacer(minLength: 8)
                             if step.state == .completed {
                                 Text("home_v2_welcome_done".localized)
                                     .font(.custom("NunitoSans-Bold", size: 12))
-                                    .foregroundColor(Color("green_logout"))
+                                    .foregroundColor(Color(red: 45/255, green: 104/255, blue: 50/255))
                                     .padding(.horizontal, 8)
                                     .padding(.vertical, 4)
                                     .background(Color("green_light").opacity(0.15))
                                     .cornerRadius(12)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 12)
+                                            .stroke(Color(red: 45/255, green: 104/255, blue: 50/255), lineWidth: 1)
+                                    )
                             } else if step.state == .active {
                                 Text("home_v2_welcome_todo".localized)
                                     .font(.custom("NunitoSans-Bold", size: 12))
@@ -223,7 +236,7 @@ struct WelcomeJourneyStepView: View {
 
                         Text(step.subtitle)
                             .font(.custom("NunitoSans-Regular", size: 13))
-                            .foregroundColor(step.state == .completed ? Color("green_logout") : Color.gray)
+                            .foregroundColor(step.state == .completed ? Color(red: 45/255, green: 104/255, blue: 50/255) : Color.gray)
                             .multilineTextAlignment(.leading)
                             .fixedSize(horizontal: false, vertical: true)
                             .padding(.top, 2)
@@ -247,10 +260,10 @@ struct WelcomeJourneyStepView: View {
             .cornerRadius(14)
             .overlay(
                 RoundedRectangle(cornerRadius: 14)
-                    .stroke(step.state == .active ? Color.clear : Color(UIColor.systemGray5), lineWidth: 1)
+                    .stroke(step.state == .active ? Color("orange_app") : (step.state == .completed ? Color(red: 45/255, green: 104/255, blue: 50/255) : Color(UIColor.systemGray5)), lineWidth: step.state == .active ? 2 : 1)
             )
             .shadow(color: Color.black.opacity(step.state == .active ? 0.05 : 0), radius: 8, x: 0, y: 2)
-            .opacity(step.state == .active ? 1.0 : 0.6)
+            .opacity(step.state == .future ? 0.6 : (step.state == .completed ? 0.9 : 1.0))
         }
         .buttonStyle(PlainButtonStyle())
     }

--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeEventsListView.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeEventsListView.swift
@@ -54,7 +54,7 @@ struct WelcomeEventsListView: View {
                 Button(action: {
                     onBack?()
                 }) {
-                    Image(systemName: "chevron.left")
+                    Image("back_arrow")
                         .font(.system(size: 20, weight: .semibold))
                         .foregroundColor(.black)
                         .padding(12)
@@ -174,14 +174,14 @@ struct EventListCellWrap: View {
                         Image("ic_entoutou_logo_woman")
                             .resizable()
                             .frame(width: 22, height: 22)
-                            .padding(.leading, 4)
-                            .padding(.top, -10)
+                            .padding(.leading, 5)
+                            .padding(.top, 68)
                     } else if event.author?.communityRoles?.contains("Équipe Entourage") == true || event.author?.communityRoles?.contains("Animateur Entourage") == true {
                         Image("ic_entoutou_logo_little")
                             .resizable()
                             .frame(width: 23, height: 23)
-                            .padding(.leading, 4)
-                            .padding(.top, -10)
+                            .padding(.leading, 5)
+                            .padding(.top, 68)
                     }
 
                     if event.isCanceled() {

--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeJourneyCelebrationPopupViewController.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeJourneyCelebrationPopupViewController.swift
@@ -1,11 +1,12 @@
 import UIKit
 import SwiftUI
+import Lottie
 
 class WelcomeJourneyCelebrationPopupViewController: UIViewController {
 
     // UI Elements
     private let containerView = UIView()
-    private let starImageView = UIImageView()
+    private let animationView = LottieAnimationView()
     private let titleLabel = UILabel()
     private let descriptionLabel = UILabel()
     private let ctaButton = UIButton(type: .system)
@@ -28,11 +29,12 @@ class WelcomeJourneyCelebrationPopupViewController: UIViewController {
         view.addSubview(containerView)
 
         // Star Icon
-        starImageView.image = UIImage(systemName: "star.fill")
-        starImageView.tintColor = UIColor(named: "orange_app")
-        starImageView.contentMode = .scaleAspectFit
-        starImageView.translatesAutoresizingMaskIntoConstraints = false
-        containerView.addSubview(starImageView)
+        animationView.animation = LottieAnimation.named("congrats_animation")
+        animationView.contentMode = .scaleAspectFit
+        animationView.loopMode = .playOnce
+        animationView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(animationView)
+        animationView.play()
 
         // Title
         titleLabel.text = "home_v2_welcome_celebration_title".localized
@@ -69,12 +71,12 @@ class WelcomeJourneyCelebrationPopupViewController: UIViewController {
             containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
             containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40),
 
-            starImageView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 32),
-            starImageView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
-            starImageView.widthAnchor.constraint(equalToConstant: 80),
-            starImageView.heightAnchor.constraint(equalToConstant: 80),
+            animationView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 32),
+            animationView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            animationView.widthAnchor.constraint(equalToConstant: 80),
+            animationView.heightAnchor.constraint(equalToConstant: 80),
 
-            titleLabel.topAnchor.constraint(equalTo: starImageView.bottomAnchor, constant: 24),
+            titleLabel.topAnchor.constraint(equalTo: animationView.bottomAnchor, constant: 24),
             titleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 24),
             titleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -24),
 

--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeVideoModalViewController.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeVideoModalViewController.swift
@@ -60,7 +60,7 @@ class WelcomeVideoModalViewController: UIViewController {
 
         // Title (Taille légèrement réduite pour gagner de la place)
         titleLabel.text = "home_v2_welcome_video_modal_title".localized
-        titleLabel.font = .systemFont(ofSize: 20, weight: .bold)
+        titleLabel.setFontTitle(size: 20)
         titleLabel.textColor = UIColor.black
         titleLabel.numberOfLines = 0
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -83,15 +83,15 @@ class WelcomeVideoModalViewController: UIViewController {
 
         // Description (Taille légèrement réduite)
         descriptionLabel.text = "home_v2_welcome_video_modal_desc".localized
-        descriptionLabel.font = .systemFont(ofSize: 14, weight: .regular)
-        descriptionLabel.textColor = UIColor.gray
+        descriptionLabel.setFontBody(size: 15)
+        descriptionLabel.textColor = UIColor.black
         descriptionLabel.numberOfLines = 0
         descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
         containerView.addSubview(descriptionLabel)
 
         // Continue Button
         continueButton.setTitle("\(originalButtonText) (\(secondsRemaining))", for: .normal)
-        continueButton.titleLabel?.font = .systemFont(ofSize: 15, weight: .bold)
+        continueButton.titleLabel?.font = UIFont(name: "Quicksand-Bold", size: 15)
         continueButton.setTitleColor(.white, for: .normal)
         continueButton.setTitleColor(.white.withAlphaComponent(0.5), for: .disabled) // Texte un peu transparent quand désactivé
         continueButton.backgroundColor = UIColor.systemGray4 // Gris plus doux pour l'état désactivé


### PR DESCRIPTION
This PR implements several styling and UI/UX updates to the "Parcours de Bienvenue" (Welcome Journey) components to conform better with the design system and overall aesthetics:
- Changes the header color to match the "Participer à un événement" title.
- Switches the play icon to `video.fill`.
- Adds a progress bar reflecting completed steps.
- Applies an orange border to active steps and a dark green border/style to completed steps.
- Swaps out standard back icons with custom back arrows in lists.
- Fixes the padding offset of team logos in event list.
- Replaces a static star with the `congrats_animation` Lottie graphic on the success popup.
- Removes duplicate subtitles and updates styling of success badges.
- Applies standard DS fonts using `setFontTitle` and `setFontBody` in the video popup.

---
*PR created automatically by Jules for task [7774807827057688785](https://jules.google.com/task/7774807827057688785) started by @clemPerrousset*