### PR TITLE
Fix cropped title in WelcomeEventsListView

### DIFF
--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeEventsListView.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeEventsListView.swift
@@ -105,7 +105,7 @@ struct WelcomeEventsListView: View {
                     LazyVStack(spacing: 16) {
                         ForEach(viewModel.events, id: \.uid) { event in
                             EventListCellWrap(event: event)
-                                .frame(height: 140) // Approximation, adjusts natively if configured properly
+
                                 .onTapGesture {
                                     onEventTapped?(event)
                                 }


### PR DESCRIPTION
Fix cropped title in WelcomeEventsListView

Removed hardcoded `frame(height: 140)` constraint on `EventListCellWrap` to allow the cell to naturally resize and accommodate 2-line event titles.

---
*PR created automatically by Jules for task [5485080507450440943](https://jules.google.com/task/5485080507450440943) started by @clemPerrousset*