### PR TITLE
UI: Increase top padding for HomeWelcomeJourneyView

### DIFF
--- a/entourage/Scenes/HomeV2/homev2cells/HomeWelcomeJourneyView.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeWelcomeJourneyView.swift
@@ -177,7 +177,7 @@ struct HomeWelcomeJourneyView: View {
                     .padding(.bottom, 16)
                 }
             }
-            .padding(.top, 16)
+            .padding(.top, 32)
             .background(Color("white_orange_home")) // matches the table view background
             .fixedSize(horizontal: false, vertical: true)
         }


### PR DESCRIPTION
This PR increases the top padding on the `HomeWelcomeJourneyView` from 16 to 32 to add more vertical margin at the top of the welcome section on the home page, as it was previously a bit tight.

---
*PR created automatically by Jules for task [2941605069084353375](https://jules.google.com/task/2941605069084353375) started by @clemPerrousset*