### PR TITLE
fix: align WelcomeEventsList header with login screen

### DIFF
--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeEventsListView.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeEventsListView.swift
@@ -49,28 +49,28 @@ struct WelcomeEventsListView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header
-            HStack {
-                Button(action: {
-                    onBack?()
-                }) {
-                    Image("back_arrow")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundColor(.black)
-                        .padding(12)
-                }
-                Spacer()
-            }
-            .padding(.horizontal, 8)
-            .padding(.top, 8)
 
-            // Title & Subtitle
+            // Header
             VStack(alignment: .leading, spacing: 8) {
-                Text(viewModel.type == .firstStep ? "welcome_welcome_list_title".localized :
-                     viewModel.type == .webinar ? "welcome_webinar_list_title".localized :
-                     "welcome_papotages_list_title".localized)
-                    .font(.custom("Quicksand-Bold", size: 24))
-                    .foregroundColor(.black)
+                HStack(spacing: 16) {
+                    Button(action: {
+                        onBack?()
+                    }) {
+                        Image("back_arrow")
+                            .renderingMode(.template)
+                            .foregroundColor(.black)
+                            .padding(.vertical, 12)
+                    }
+
+                    Text(viewModel.type == .firstStep ? "welcome_welcome_list_title".localized :
+                         viewModel.type == .webinar ? "welcome_webinar_list_title".localized :
+                         "welcome_papotages_list_title".localized)
+                        .font(.custom("Quicksand-Bold", size: 24))
+                        .foregroundColor(.black)
+                        .lineLimit(1)
+
+                    Spacer()
+                }
 
                 Text(viewModel.type == .firstStep ? "welcome_welcome_list_subtitle".localized :
                      viewModel.type == .webinar ? "welcome_webinar_list_subtitle".localized :
@@ -79,7 +79,8 @@ struct WelcomeEventsListView: View {
                     .foregroundColor(.black)
             }
             .padding(.horizontal, 20)
-            .padding(.bottom, 16)
+            .padding(.top, 10)
+            .padding(.bottom, 20)
 
             // Content
             if viewModel.isLoading {


### PR DESCRIPTION
Fixes the alignment of the back arrow and the title on the Welcome Events List screen to be on the same horizontal line, mimicking the behavior of the connection screen, as requested. The subtitle remains below, aligned to the leading edge.

---
*PR created automatically by Jules for task [15997884048207926834](https://jules.google.com/task/15997884048207926834) started by @clemPerrousset*