### PR TITLE
Standardize Home titles font and size

### DIFF
--- a/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/HomeSolidarityToolsCell.swift
@@ -50,7 +50,7 @@ class HomeSolidarityToolsCell: UITableViewCell {
 
     private func setupUI() {
         ui_label_title.text = "home_v2_solidarity_tools_title".localized
-        ui_label_title.font = ApplicationTheme.getFontQuickSandBold(size: 15)
+        ui_label_title.font = ApplicationTheme.getFontQuickSandBold(size: 18)
         ui_label_title.textColor = .black
 
         setupCard(view: ui_view_map, label: ui_lbl_map, image: ui_iv_map, imgContainer: ui_cont_map, title: "home_v2_tool_card_map".localized, iconName: "ic_button_map", systemIcon: "map.fill")

--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeEventsListView.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeEventsListView.swift
@@ -69,7 +69,7 @@ struct WelcomeEventsListView: View {
                 Text(viewModel.type == .firstStep ? "welcome_welcome_list_title".localized :
                      viewModel.type == .webinar ? "welcome_webinar_list_title".localized :
                      "welcome_papotages_list_title".localized)
-                    .font(.custom("Quicksand-Bold", size: 24))
+                    .font(.custom("Quicksand-Bold", size: 18))
                     .foregroundColor(.black)
 
                 Text(viewModel.type == .firstStep ? "welcome_welcome_list_subtitle".localized :

--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeJourneyCelebrationPopupViewController.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeJourneyCelebrationPopupViewController.swift
@@ -38,7 +38,7 @@ class WelcomeJourneyCelebrationPopupViewController: UIViewController {
 
         // Title
         titleLabel.text = "home_v2_welcome_celebration_title".localized
-        titleLabel.font = .systemFont(ofSize: 22, weight: .bold)
+        titleLabel.setFontTitle(size: 18)
         titleLabel.textColor = UIColor.black
         titleLabel.textAlignment = .center
         titleLabel.numberOfLines = 0

--- a/entourage/Scenes/HomeV2/homev2cells/WelcomeVideoModalViewController.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/WelcomeVideoModalViewController.swift
@@ -85,7 +85,7 @@ class WelcomeVideoModalViewController: UIViewController {
 
         // Title (Taille légèrement réduite pour gagner de la place)
         titleLabel.text = "home_v2_welcome_video_modal_title".localized
-        titleLabel.setFontTitle(size: 20)
+        titleLabel.setFontTitle(size: 18)
         titleLabel.textColor = UIColor.black
         titleLabel.numberOfLines = 0
         titleLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellCreateSmallTalkView.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellCreateSmallTalkView.swift
@@ -18,7 +18,7 @@ struct CellCreateSmallTalkView: View {
                 // Titre et Sous-titre
                 VStack(alignment: .leading, spacing: 6) {
                     Text("home_v2_small_talk_card_title".localized)
-                        .font(.custom("Quicksand-Bold", size: 16))
+                        .font(.custom("Quicksand-Bold", size: 18))
                         .foregroundColor(.black)
                     
                     Text("home_v2_small_talk_card_subtitle".localized)

--- a/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellDiscussionSmallTalk.xib
+++ b/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellDiscussionSmallTalk.xib
@@ -73,7 +73,7 @@
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yFg-Oy-05T">
                                 <rect key="frame" x="120" y="25.666666666666664" width="382" height="19"/>
-                                <fontDescription key="fontDescription" name="Quicksand-Bold" family="Quicksand" pointSize="15"/>
+                                <fontDescription key="fontDescription" name="Quicksand-Bold" family="Quicksand" pointSize="18"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>

--- a/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellWaitingSmallTalk.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellWaitingSmallTalk.swift
@@ -20,7 +20,7 @@ class CellWaitingSmallTalk:UICollectionViewCell {
     
     override func awakeFromNib() {
         ui_label_title.text = "small_talk_title_waiting".localized
-        ui_label_title.setFontTitle(size: 15)
+        ui_label_title.setFontTitle(size: 18)
         ui_label_subtitle.text = "small_talk_subtitle_waiting".localized
         ui_label_subtitle.setFontBody(size: 15)
     }

--- a/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellWaitingSmallTalk.xib
+++ b/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/CellWaitingSmallTalk.xib
@@ -43,7 +43,7 @@
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Caf-95-cPB">
                                 <rect key="frame" x="79" y="30" width="312" height="19"/>
-                                <fontDescription key="fontDescription" name="Quicksand-Bold" family="Quicksand" pointSize="15"/>
+                                <fontDescription key="fontDescription" name="Quicksand-Bold" family="Quicksand" pointSize="18"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>


### PR DESCRIPTION
Updated the font and size of all title elements on the Home page, WelcomeListEvent, and related pop-ups (video modal, journey celebration) to use Quicksand-Bold size 18 for consistency.

---
*PR created automatically by Jules for task [10904706607735864563](https://jules.google.com/task/10904706607735864563) started by @clemPerrousset*