### PR TITLE
fix: Hide welcome journey for associations and team members

### DIFF
--- a/entourage/Scenes/HomeV2/HomeV2ViewController.swift
+++ b/entourage/Scenes/HomeV2/HomeV2ViewController.swift
@@ -398,8 +398,9 @@ class HomeV2ViewController: UIViewController {
         welcomeJourneyVM.update(with: userHome.events, hasInitiallyCompletedAll: &self.hasInitiallyCompletedAll)
 
         let hasShownCelebration = UserDefaults.standard.bool(forKey: "hasShownWelcomeCelebration")
+        let isUserProOrTeam = (UserDefaults.currentUser?.partner != nil)
 
-        if !welcomeJourneyVM.hideEntirely {
+        if !welcomeJourneyVM.hideEntirely && !isUserProOrTeam {
             tableDTO.append(.cellWelcomeJourney(viewModel: welcomeJourneyVM))
 
             if welcomeJourneyVM.isFullyCompleted && !hasShownCelebration {


### PR DESCRIPTION
This PR updates the HomeV2ViewController to hide the "Welcome Journey" (parcours de bienvenue) if the logged-in user is part of an association or the Entourage team. This is determined by checking if `UserDefaults.currentUser?.partner` is not null.

---
*PR created automatically by Jules for task [6639235578283730731](https://jules.google.com/task/6639235578283730731) started by @clemPerrousset*