### PR TITLE
Fix swapped buttons on event creation/edition abandon popup

### DIFF
--- a/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
+++ b/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
@@ -462,9 +462,9 @@ extension EventCreateMainViewController: MJNavBackViewDelegate {
         }
         
         let alertVC = MJAlertController()
-        let buttonCancel = MJAlertButtonType(title: "eventCreatePopCloseBackCancel".localized, titleStyle:ApplicationTheme.getFontCourantBoldBlanc(), bgColor: .appOrangeLight, cornerRadius: -1)
+        let buttonCancel = MJAlertButtonType(title: "eventCreatePopCloseBackCancel".localized, titleStyle:ApplicationTheme.getFontCourantBoldBlanc(), bgColor: .appOrangeLight, cornerRadius: -1) // Color doesn't matter, it'll be overriden by white button config in setupButton
         let buttonValidate = MJAlertButtonType(title: "eventCreatePopCloseBackQuit".localized, titleStyle:ApplicationTheme.getFontCourantBoldBlanc(), bgColor: .appOrange, cornerRadius: -1)
-        alertVC.configureAlert(alertTitle: "eventCreatePopCloseBackTitle".localized, message: "eventCreatePopCloseBackMessage".localized, buttonrightType: buttonCancel, buttonLeftType: buttonValidate, titleStyle: ApplicationTheme.getFontCourantBoldOrange(), messageStyle: ApplicationTheme.getFontCourantRegularNoir(), mainviewBGColor: .white, mainviewRadius: 35, isButtonCloseHidden: true)
+        alertVC.configureAlert(alertTitle: "eventCreatePopCloseBackTitle".localized, message: "eventCreatePopCloseBackMessage".localized, buttonrightType: buttonValidate, buttonLeftType: buttonCancel, titleStyle: ApplicationTheme.getFontCourantBoldOrange(), messageStyle: ApplicationTheme.getFontCourantRegularNoir(), mainviewBGColor: .white, mainviewRadius: 35, isButtonCloseHidden: true)
         alertVC.delegate = self
         alertVC.show()
     }
@@ -473,9 +473,9 @@ extension EventCreateMainViewController: MJNavBackViewDelegate {
 //MARK: - MJAlertControllerDelegate -
 extension EventCreateMainViewController: MJAlertControllerDelegate {
     func validateLeftButton(alertTag: MJAlertTAG) {
-        self.dismiss(animated: true)
     }
     func validateRightButton(alertTag: MJAlertTAG) {
+        self.dismiss(animated: true)
     }
 }
 

--- a/entourage/Scenes/Events/EventEditMainViewController.swift
+++ b/entourage/Scenes/Events/EventEditMainViewController.swift
@@ -532,7 +532,7 @@ extension EventEditMainViewController: MJNavBackViewDelegate {
         let alertVC = MJAlertController()
         let buttonCancel = MJAlertButtonType(title: "eventModPopCloseBackCancel".localized, titleStyle:ApplicationTheme.getFontCourantBoldBlanc(), bgColor: .appOrangeLight, cornerRadius: -1)
         let buttonValidate = MJAlertButtonType(title: "eventModPopCloseBackQuit".localized, titleStyle:ApplicationTheme.getFontCourantBoldBlanc(), bgColor: .appOrange, cornerRadius: -1)
-        alertVC.configureAlert(alertTitle: "eventModPopCloseBackTitle".localized, message: "eventModPopCloseBackMessage".localized, buttonrightType: buttonCancel, buttonLeftType: buttonValidate, titleStyle: ApplicationTheme.getFontCourantBoldOrange(), messageStyle: ApplicationTheme.getFontCourantRegularNoir(), mainviewBGColor: .white, mainviewRadius: 35, isButtonCloseHidden: true)
+        alertVC.configureAlert(alertTitle: "eventModPopCloseBackTitle".localized, message: "eventModPopCloseBackMessage".localized, buttonrightType: buttonValidate, buttonLeftType: buttonCancel, titleStyle: ApplicationTheme.getFontCourantBoldOrange(), messageStyle: ApplicationTheme.getFontCourantRegularNoir(), mainviewBGColor: .white, mainviewRadius: 35, isButtonCloseHidden: true)
         alertVC.delegate = self
         alertVC.show()
     }
@@ -541,16 +541,13 @@ extension EventEditMainViewController: MJNavBackViewDelegate {
 //MARK: - MJAlertControllerDelegate -
 extension EventEditMainViewController: MJAlertControllerDelegate {
     func validateLeftButton(alertTag: MJAlertTAG) {
-        if alertTag == .None {
-            self.dismiss(animated: true)
-        }
     }
     func validateRightButton(alertTag: MJAlertTAG) {
         if alertTag == .Suppress {
             let isAll = selectedRecurrencyPosition == 1
             self.createEvent(applyToAll:isAll)
         } else if alertTag == .None {
-            // "Annuler" ferme juste la popup
+            self.dismiss(animated: true)
         }
     }
     


### PR DESCRIPTION
This change fixes the swapped buttons on the popup that appears when attempting to leave the event creation or edition screens.

It correctly moves the "Annuler" button to the left so that it uses the white style and only closes the popup, while "Quitter" is moved to the right with the orange CTA style to leave the screen.

---
*PR created automatically by Jules for task [12324919422036478822](https://jules.google.com/task/12324919422036478822) started by @clemPerrousset*