### PR TITLE
feat: Add new countries and dynamic phone number placeholders

### DIFF
--- a/entourage/Scenes/Login/OTLoginV2ViewController.swift
+++ b/entourage/Scenes/Login/OTLoginV2ViewController.swift
@@ -199,10 +199,7 @@ final class LoginViewModel: ObservableObject {
     @Published var showResendConfirmation: Bool = false
     
     // Constants
-    let countries: [CountryCode] = [
-        CountryCode(country: "France", code: "+33", flag: "🇫🇷"),
-        CountryCode(country: "Belgique", code: "+32", flag: "🇧🇪")
-    ]
+    let countries: [CountryCode] = allCountryCodes
     private let minimumCharacters = 9
     
     // External delegates (Navigation callbacks)
@@ -212,7 +209,7 @@ final class LoginViewModel: ObservableObject {
 
     init() {
         // Default Country logic
-        self.selectedCountry = countries.first ?? CountryCode(country: "France", code: "+33", flag: "🇫🇷")
+        self.selectedCountry = countries.first ?? defaultCountryCode
     }
     
     // MARK: - Keychain Logic
@@ -440,7 +437,7 @@ struct LoginView: View {
                             }
                             
                             // Champ numéro
-                            BoxedTextField(placeholder: "login_phone_placeholder".localized, text: $vm.phone)
+                            BoxedTextField(placeholder: vm.selectedCountry.exampleNumber, text: $vm.phone)
                         }
                     }
                     

--- a/entourage/Scenes/Onboarding/OnboardingPhase1ViewController.swift
+++ b/entourage/Scenes/Onboarding/OnboardingPhase1ViewController.swift
@@ -139,7 +139,7 @@ final class OnboardingPhase1VM: ObservableObject {
     @Published var birthday: Date? = nil
 
     // Valeur par défaut locale (pas de dépendance globale)
-    @Published var selectedCountry: CountryCode = CountryCode(country: "France", code: "+33", flag: "🇫🇷")
+    @Published var selectedCountry: CountryCode = defaultCountryCode
 
     @Published var phone: String = ""
     @Published var email: String = ""
@@ -426,10 +426,7 @@ final class OnboardingPhase1VM: ObservableObject {
 struct OnboardingPhase1View: View {
     @ObservedObject var vm: OnboardingPhase1VM
 
-    private let countries: [CountryCode] = [
-        CountryCode(country: "France",   code: "+33", flag: "🇫🇷"),
-        CountryCode(country: "Belgique", code: "+32", flag: "🇧🇪"),
-    ]
+    private let countries: [CountryCode] = allCountryCodes
 
     @State private var showDateSheet = false
     @State private var tempDate = Date()
@@ -570,7 +567,7 @@ private struct ContactSection: View {
                 )
 
                 // ---- Boîte numéro (52) — même style EXACT ----
-                BoxedTextField(placeholder: "06 XX XX XX XX", text: $vm.phone)
+                BoxedTextField(placeholder: vm.selectedCountry.exampleNumber, text: $vm.phone)
             }
 
             FloatingField(title: "E-mail",
@@ -839,7 +836,7 @@ final class OnboardingPhase1ViewController: UIHostingController<OnboardingPhase1
     // Compat API externe
     var userFirstname: String? { didSet { vm.firstname = userFirstname ?? "" } }
     var userLastname:  String? { didSet { vm.lastname  = userLastname  ?? "" } }
-    var countryCode:   CountryCode = CountryCode(country: "France", code: "+33", flag: "🇫🇷") { didSet { vm.selectedCountry = countryCode } }
+    var countryCode:   CountryCode = defaultCountryCode { didSet { vm.selectedCountry = countryCode } }
     var phone:         String? { didSet { vm.phone = phone ?? "" } }
     var email:         String? { didSet { vm.email = email ?? "" } }
     var hasConsent:    Bool = false { didSet { vm.consent = hasConsent } }

--- a/entourage/Scenes/Onboarding/OnboardingStartCell.swift
+++ b/entourage/Scenes/Onboarding/OnboardingStartCell.swift
@@ -56,10 +56,7 @@ class OnboardingStartCell: UITableViewCell {
     var tempPhone = ""
 
     // Data for country picker (déjà en dur chez toi)
-    let pickerDatas: [CountryCode] = [
-        CountryCode(country: "France",   code: "+33", flag: "🇫🇷"),
-        CountryCode(country: "Belgique", code: "+32", flag: "🇧🇪")
-    ]
+    let pickerDatas: [CountryCode] = allCountryCodes
 
     // --- Dynamic data (depuis l'API) ---
     // /home/metadata
@@ -229,7 +226,7 @@ class OnboardingStartCell: UITableViewCell {
         ui_title_phone.text = "onboard_welcome_phone".localized
         ui_title_email.text = "onboard_welcome_mail".localized
         ui_info_mailing.text = "onboard_welcome_consent".localized
-        ui_tf_phone.placeholder = "0600000000"
+        ui_tf_phone.placeholder = countryCode.exampleNumber
         ui_tf_email.placeholder = "onboard_welcome_placeholder_mail".localized
         ui_label_mandatory.text = "onboard_welcome_info_mandatory".localized
         ui_label_title_birthday.text = "Date d'anniversaire".localized
@@ -429,6 +426,7 @@ class OnboardingStartCell: UITableViewCell {
 
         if let countryCode = countryCode {
             self.countryCode = countryCode
+            ui_tf_phone.placeholder = countryCode.exampleNumber
         }
 
         selectPickerCountry()
@@ -601,6 +599,32 @@ extension OnboardingStartCell: UIPickerViewDelegate, UIPickerViewDataSource {
         case 3: return enterpriseOptions[safe: row]
         case 4: return eventOptions[safe: row]
         default: return "\(pickerDatas[row].flag) \(pickerDatas[row].country)"
+        }
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        if pickerView.tag == 1 {
+            genderTextField.text = genderOptions[safe: row]
+            delegate?.validateGender(gender: genderTextField.text)
+        } else if pickerView.tag == 2 {
+            howWeMetTextField.text = howWeMetOptions[safe: row]
+            delegate?.validateHowWeMet(howWeMet: howWeMetTextField.text)
+        } else if pickerView.tag == 3 {
+            companyTextField.text = enterpriseOptions[safe: row]
+            if let selectedCompany = enterprises[safe: row] {
+                delegate?.validateCompany(company: String(selectedCompany.id ?? 0))
+                loadEvents(forEnterpriseAt: row)
+            }
+        } else if pickerView.tag == 4 {
+            eventTextField.text = eventOptions[safe: row]
+            if let selectedEvent = eventsForSelectedEnterprise[safe: row] {
+                delegate?.validateEvent(event: String(selectedEvent.id ?? 0))
+            }
+        } else {
+            if pickerDatas.indices.contains(row) {
+                let selectedCountry = pickerDatas[row]
+                self.countryCode = selectedCountry
+                ui_tf_country.text = selectedCountry.flag
+                ui_tf_phone.placeholder = selectedCountry.exampleNumber
+            }
         }
     }
 

--- a/entourage/Tools/CountryCode.swift
+++ b/entourage/Tools/CountryCode.swift
@@ -11,16 +11,21 @@ public struct CountryCode: Equatable {
     public let country: String
     public let code: String
     public let flag: String
-    public init(country: String, code: String, flag: String) {
-        self.country = country; self.code = code; self.flag = flag
+    public let exampleNumber: String
+
+    public init(country: String, code: String, flag: String, exampleNumber: String = "06 XX XX XX XX") {
+        self.country = country; self.code = code; self.flag = flag; self.exampleNumber = exampleNumber
     }
 }
 
 // Source de vérité unique
-public let defaultCountryCode = CountryCode(country: "France", code: "+33", flag: "🇫🇷")
+public let defaultCountryCode = CountryCode(country: "France", code: "+33", flag: "🇫🇷", exampleNumber: "06 XX XX XX XX")
 
 // Optionnel : liste réutilisable
 public let allCountryCodes: [CountryCode] = [
-    CountryCode(country: "France",   code: "+33", flag: "🇫🇷"),
-    CountryCode(country: "Belgique", code: "+32", flag: "🇧🇪"),
+    CountryCode(country: "France",     code: "+33",  flag: "🇫🇷", exampleNumber: "06 XX XX XX XX"),
+    CountryCode(country: "Belgique",   code: "+32",  flag: "🇧🇪", exampleNumber: "04XX XX XX XX"),
+    CountryCode(country: "La Réunion", code: "+262", flag: "🇷🇪", exampleNumber: "06 XX XX XX XX"),
+    CountryCode(country: "Guadeloupe", code: "+590", flag: "🇬🇵", exampleNumber: "06 XX XX XX XX"),
+    CountryCode(country: "Maroc",      code: "+212", flag: "🇲🇦", exampleNumber: "06 XX XX XX XX"),
 ]


### PR DESCRIPTION
Added La Réunion, Guadeloupe, and Maroc support for phone number selection during authentication and onboarding flows. Additionally, the phone number placeholder text now dynamically updates to show a relevant formatting example according to the currently selected country code.

---
*PR created automatically by Jules for task [6429277425762960283](https://jules.google.com/task/6429277425762960283) started by @clemPerrousset*