### PR TITLE
Add bottomsheet to track unsubscribed participants at events

### DIFF
--- a/entourage.xcodeproj/project.pbxproj
+++ b/entourage.xcodeproj/project.pbxproj
@@ -394,6 +394,9 @@
 		2483602A2F2A483300CAD0C7 /* UILabel+Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 248360292F2A483300CAD0C7 /* UILabel+Animation.swift */; };
 		24B68C9B2F6847FA00B35F25 /* ConversationStaffWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B68C9A2F6847FA00B35F25 /* ConversationStaffWarningView.swift */; };
 		24CFFF3A2EF1828D0003509F /* SVProgressHUD in Frameworks */ = {isa = PBXBuildFile; productRef = 24CFFF392EF1828D0003509F /* SVProgressHUD */; };
+		24D8DEDF2F975F720081AF8B /* NeighborhoodUnsubscribedParticipantsHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D8DEDD2F975F720081AF8B /* NeighborhoodUnsubscribedParticipantsHeaderCell.swift */; };
+		24D8DEE12F9761C50081AF8B /* NeighborhoodUnsubscribedParticipantsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D8DEE02F9761C50081AF8B /* NeighborhoodUnsubscribedParticipantsCell.swift */; };
+		24D8DEE32F976EAB0081AF8B /* UnsubscribedParticipantsBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D8DEE22F976EAB0081AF8B /* UnsubscribedParticipantsBottomSheet.swift */; };
 		24EAAA8A2F0BB94B002F2A41 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 029E307E27DB60D300B12357 /* FirebaseAnalytics */; };
 		24EAAA8C2F0E4FC0002F2A41 /* AssociationPresentationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24EAAA8B2F0E4FBF002F2A41 /* AssociationPresentationCell.swift */; };
 		24F3EF252F61D135005AD389 /* AddressAutocompleteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F3EF242F61D135005AD389 /* AddressAutocompleteViewModel.swift */; };
@@ -1023,6 +1026,9 @@
 		24832E6B2F63011D00A78F03 /* CellCreateSmallTalkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellCreateSmallTalkView.swift; sourceTree = "<group>"; };
 		248360292F2A483300CAD0C7 /* UILabel+Animation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Animation.swift"; sourceTree = "<group>"; };
 		24B68C9A2F6847FA00B35F25 /* ConversationStaffWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStaffWarningView.swift; sourceTree = "<group>"; };
+		24D8DEDD2F975F720081AF8B /* NeighborhoodUnsubscribedParticipantsHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeighborhoodUnsubscribedParticipantsHeaderCell.swift; sourceTree = "<group>"; };
+		24D8DEE02F9761C50081AF8B /* NeighborhoodUnsubscribedParticipantsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeighborhoodUnsubscribedParticipantsCell.swift; sourceTree = "<group>"; };
+		24D8DEE22F976EAB0081AF8B /* UnsubscribedParticipantsBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsubscribedParticipantsBottomSheet.swift; sourceTree = "<group>"; };
 		24EAAA8B2F0E4FBF002F2A41 /* AssociationPresentationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociationPresentationCell.swift; sourceTree = "<group>"; };
 		24F3EF242F61D135005AD389 /* AddressAutocompleteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressAutocompleteViewModel.swift; sourceTree = "<group>"; };
 		24F46AE52F8650A200A88B91 /* congrat_short_anim 2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "congrat_short_anim 2.json"; sourceTree = "<group>"; };
@@ -1353,6 +1359,7 @@
 		0224597227FF31FC00944DE4 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				24D8DEE02F9761C50081AF8B /* NeighborhoodUnsubscribedParticipantsCell.swift */,
 				02369715296D9F6A00E2CACC /* Message top cell */,
 				0243E7192806D95000208DC7 /* NeighborhoodChoosePhotoCell.swift */,
 				0224597327FF323600944DE4 /* NeighborhoodCreateNameCell.swift */,
@@ -1922,6 +1929,8 @@
 		02B7921F27F73F34003AFFB9 /* Groups - Neighborhoods */ = {
 			isa = PBXGroup;
 			children = (
+				24D8DEE22F976EAB0081AF8B /* UnsubscribedParticipantsBottomSheet.swift */,
+				24D8DEDD2F975F720081AF8B /* NeighborhoodUnsubscribedParticipantsHeaderCell.swift */,
 				02E7845E2811A91900177F13 /* NeighborhoodHomeViewController.swift */,
 				0243E7172806CE7600208DC7 /* NeighborhoodChoosePictureViewController.swift */,
 				02DD1E90280853CF00538EF4 /* NeighborhoodEditViewController.swift */,
@@ -3046,6 +3055,7 @@
 				02A92C1E2897D347000DFF95 /* ActionCreateMainViewController.swift in Sources */,
 				02C3ABF0279AB50900817B82 /* Extensions_UIColor.swift in Sources */,
 				26E25EFD2E8EB57A0073B46A /* ImageCache.swift in Sources */,
+				24D8DEE32F976EAB0081AF8B /* UnsubscribedParticipantsBottomSheet.swift in Sources */,
 				02A3DD3527FDC6310060EC2E /* NeighborhoodCreatePhase2ViewController.swift in Sources */,
 				02FB5448287DC11100E4B9FA /* EventDetailFullGroupCell.swift in Sources */,
 				02D64F4B2799CA6800F6C4BD /* CustomAnnotation.swift in Sources */,
@@ -3092,6 +3102,7 @@
 				26445C4B2BB46AAF0010A8D8 /* SimpleMJAlertDialog.swift in Sources */,
 				26584C4E2ACC4B1300ABD401 /* CustomGradientView.swift in Sources */,
 				02B57DA027FC9757005A567B /* PartnerDetailNeedsCell.swift in Sources */,
+				24D8DEE12F9761C50081AF8B /* NeighborhoodUnsubscribedParticipantsCell.swift in Sources */,
 				02B37828279B072C00B204EF /* SharingEntourageTableViewCell.swift in Sources */,
 				0232A6D62888126700A47828 /* EventActionLocationFilters.swift in Sources */,
 				2630F6182C21CCB7007BAE56 /* HomeInitialPedagogicHorizontalCell.swift in Sources */,
@@ -3126,6 +3137,7 @@
 				02E21921283520A1002A1FCB /* NeighborhoodUploadPictureService.swift in Sources */,
 				26D13E172BA1FCAC00CAD4F7 /* CreateSurveyViewController.swift in Sources */,
 				02CCE68927D7B51E00D6976C /* TagView.swift in Sources */,
+				24D8DEDF2F975F720081AF8B /* NeighborhoodUnsubscribedParticipantsHeaderCell.swift in Sources */,
 				26F14CDB2D3E8766004C4524 /* ProfileFullStandardCell.swift in Sources */,
 				26D13E1C2BA35DA700CAD4F7 /* QuestionCell.swift in Sources */,
 				023D89C127DFA380008C6A58 /* ParamMenuCell.swift in Sources */,

--- a/entourage/Models/Event.swift
+++ b/entourage/Models/Event.swift
@@ -45,6 +45,10 @@ struct Event:Codable {
     var status = ""
     var signable:Bool? = nil
     var manageableByCurrentUser:Bool? = false
+
+    var unsubscribed_participants_ask_for_help: Int? = 0
+    var unsubscribed_participants_offer_help: Int? = 0
+
     private var statusChangedAt:String? = nil
     private var createdAt:String? = nil
     private var updatedAt:String? = nil
@@ -216,6 +220,8 @@ struct Event:Codable {
         case imageId = "entourage_image_id"
         
         case recurrency
+        case unsubscribed_participants_ask_for_help
+        case unsubscribed_participants_offer_help
         case membersCount = "members_count"
         case members
         case isMember = "member"

--- a/entourage/Network Managers/Endpoints.swift
+++ b/entourage/Network Managers/Endpoints.swift
@@ -125,6 +125,7 @@ let kAPIParticipateForUser           = "outings/%@/users/%@/participate?token=%@
 let kAPIAcceptPhotoForUser           = "outings/%@/users/%@/photo_acceptance?token=%@"
 let kAPICancelPhotoForUser           = "outings/%@/users/%@/cancel_photo_acceptance?token=%@"
 let kAPICancelParticipationForUser   = "outings/%@/users/%@/cancel_participation?token=%@"
+let kAPIUpdateUnsubscribedParticipants = "outings/%@/users/unsubscribed_participants?token=%@&offer_help=%d&ask_for_help=%d"
 
 let kAPIOutingsCount = "outings/count?token=%@&within_days=%d&travel_distance=%.2f&latitude=%.6f&longitude=%.6f"
 let kAPIOutingsWeekAverage = "outings/week_average?token=%@&travel_distance=%.2f&latitude=%.6f&longitude=%.6f"

--- a/entourage/Network Managers/EventService.swift
+++ b/entourage/Network Managers/EventService.swift
@@ -817,4 +817,24 @@ struct EventService:ParsingDataCodable {
         }
     }
 
+    static func updateUnsubscribedParticipants(eventId: Int, offerHelp: Int, askForHelp: Int, completion: @escaping (_ error: EntourageNetworkError?) -> Void) {
+        guard let token = UserDefaults.token else { return }
+        var endpoint = kAPIUpdateUnsubscribedParticipants
+        endpoint = String(format: endpoint, "\(eventId)", token, offerHelp, askForHelp)
+
+        Logger.print("Endpoint updateUnsubscribedParticipants: \(endpoint)")
+
+        NetworkManager.sharedInstance.requestPost(endPoint: endpoint, headers: nil, body: nil) { data, resp, error in
+            let http = resp as? HTTPURLResponse
+            let statusCode = http?.statusCode ?? 500
+            Logger.print("Response updateUnsubscribedParticipants: \(statusCode)")
+
+            if error == nil && statusCode < 300 {
+                DispatchQueue.main.async { completion(nil) }
+            } else {
+                DispatchQueue.main.async { completion(error) }
+            }
+        }
+    }
+
 }

--- a/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUnsubscribedParticipantsCell.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUnsubscribedParticipantsCell.swift
@@ -30,12 +30,12 @@ class NeighborhoodUnsubscribedParticipantsCell: UITableViewCell {
         iconImageView.translatesAutoresizingMaskIntoConstraints = false
         bgIconView.addSubview(iconImageView)
 
-        typeLabel.font = ApplicationTheme.getFontCourantBoldNoir()
+        typeLabel.font = UIFont.boldSystemFont(ofSize: 17)
         typeLabel.textColor = .black
         typeLabel.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(typeLabel)
 
-        subtitleLabel.font = ApplicationTheme.getFontNunitoRegular(size: 13)
+        subtitleLabel.font = UIFont.systemFont(ofSize: 13)
         subtitleLabel.textColor = UIColor(named: "grey_reaction") ?? .gray
         subtitleLabel.text = "Ajoutés sur place"
         subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -73,3 +73,4 @@ class NeighborhoodUnsubscribedParticipantsCell: UITableViewCell {
         }
     }
 }
+

--- a/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUnsubscribedParticipantsCell.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUnsubscribedParticipantsCell.swift
@@ -1,0 +1,75 @@
+import UIKit
+
+class NeighborhoodUnsubscribedParticipantsCell: UITableViewCell {
+
+    let titleLabel = UILabel()
+    let typeLabel = UILabel()
+    let subtitleLabel = UILabel()
+    let iconImageView = UIImageView()
+    let bgIconView = UIView()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+
+    private func setupUI() {
+        contentView.backgroundColor = UIColor(named: "BeigeClair") ?? UIColor(red: 255/255, green: 245/255, blue: 237/255, alpha: 1.0)
+
+        bgIconView.backgroundColor = UIColor(named: "appOrange") ?? .orange
+        bgIconView.layer.cornerRadius = 25
+        bgIconView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(bgIconView)
+
+        iconImageView.contentMode = .scaleAspectFit
+        iconImageView.translatesAutoresizingMaskIntoConstraints = false
+        bgIconView.addSubview(iconImageView)
+
+        typeLabel.font = ApplicationTheme.getFontCourantBoldNoir()
+        typeLabel.textColor = .black
+        typeLabel.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(typeLabel)
+
+        subtitleLabel.font = ApplicationTheme.getFontNunitoRegular(size: 13)
+        subtitleLabel.textColor = UIColor(named: "grey_reaction") ?? .gray
+        subtitleLabel.text = "Ajoutés sur place"
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(subtitleLabel)
+
+        NSLayoutConstraint.activate([
+            bgIconView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            bgIconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            bgIconView.widthAnchor.constraint(equalToConstant: 50),
+            bgIconView.heightAnchor.constraint(equalToConstant: 50),
+
+            iconImageView.centerXAnchor.constraint(equalTo: bgIconView.centerXAnchor),
+            iconImageView.centerYAnchor.constraint(equalTo: bgIconView.centerYAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 24),
+            iconImageView.heightAnchor.constraint(equalToConstant: 24),
+
+            typeLabel.leadingAnchor.constraint(equalTo: bgIconView.trailingAnchor, constant: 12),
+            typeLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
+
+            subtitleLabel.leadingAnchor.constraint(equalTo: typeLabel.leadingAnchor),
+            subtitleLabel.topAnchor.constraint(equalTo: typeLabel.bottomAnchor, constant: 2),
+            subtitleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16)
+        ])
+    }
+
+    func configure(count: Int, isAskForHelp: Bool) {
+        if isAskForHelp {
+            let labelText = count > 1 ? "\(count) personnes isolées" : "\(count) personne isolée"
+            typeLabel.text = labelText
+            iconImageView.image = UIImage(named: "user") // Find the right image
+        } else {
+            let labelText = count > 1 ? "\(count) riverains" : "\(count) riverain"
+            typeLabel.text = labelText
+            iconImageView.image = UIImage(named: "ic_neighb_home") // Find the right image
+        }
+    }
+}

--- a/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUnsubscribedParticipantsHeaderCell.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUnsubscribedParticipantsHeaderCell.swift
@@ -1,0 +1,31 @@
+import UIKit
+
+class NeighborhoodUnsubscribedParticipantsHeaderCell: UITableViewCell {
+    let titleLabel = UILabel()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+
+    private func setupUI() {
+        contentView.backgroundColor = .clear
+
+        titleLabel.font = ApplicationTheme.getFontNunitoBold(size: 13)
+        titleLabel.textColor = UIColor(named: "grey_reaction") ?? .gray
+        titleLabel.text = "PARTICIPANTS AJOUTÉS SUR PLACE"
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(titleLabel)
+
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 24),
+            titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8)
+        ])
+    }
+}

--- a/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
@@ -13,6 +13,9 @@ private enum TableDTO {
     case questionCell(title: String)
     case userCell(user: UserLightNeighborhood, reactionType: ReactionType?)
     case surveySection(title: String, voteCount: Int)
+    case unsubscribedParticipantsHeader
+    case unsubscribedParticipantsAskHelpCell(count: Int)
+    case unsubscribedParticipantsOfferHelpCell(count: Int)
 }
 
 class NeighBorhoodEventListUsersViewController: BasePopViewController {
@@ -20,6 +23,7 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
     @IBOutlet weak var ui_tableview: UITableView!
     @IBOutlet weak var ui_lb_no_result: UILabel!
     @IBOutlet weak var ui_view_no_result: UIView!
+    @IBOutlet weak var ui_floaty_button: Floaty!
 
     var neighborhood: Neighborhood? = nil
     var event: Event? = nil
@@ -67,6 +71,10 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
 
         ui_tableview.register(UINib(nibName: SectionOptionNameCell.identifier, bundle: nil), forCellReuseIdentifier: SectionOptionNameCell.identifier)
         ui_tableview.register(UINib(nibName: QuestionSurveyVoteCell.identifier, bundle: nil), forCellReuseIdentifier: QuestionSurveyVoteCell.identifier)
+        ui_tableview.register(NeighborhoodUnsubscribedParticipantsHeaderCell.self, forCellReuseIdentifier: "UnsubscribedHeaderCell")
+        ui_tableview.register(NeighborhoodUnsubscribedParticipantsCell.self, forCellReuseIdentifier: "UnsubscribedCell")
+
+        setupFloaty()
 
         var title = isEvent ? "event_users_title".localized : "neighborhood_users_title".localized
         if isFromReact { title = "see_member_react".localized }
@@ -216,7 +224,38 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
 
     private func rebuildTableDataFromUsers() {
         tableData = [.searchCell] + users.map { .userCell(user: $0, reactionType: nil) }
+
+        if isEvent, let event = event {
+            let askForHelp = event.unsubscribed_participants_ask_for_help ?? 0
+            let offerHelp = event.unsubscribed_participants_offer_help ?? 0
+
+            if askForHelp > 0 || offerHelp > 0 {
+                tableData.append(.unsubscribedParticipantsHeader)
+                if askForHelp > 0 {
+                    tableData.append(.unsubscribedParticipantsAskHelpCell(count: askForHelp))
+                }
+                if offerHelp > 0 {
+                    tableData.append(.unsubscribedParticipantsOfferHelpCell(count: offerHelp))
+                }
+            }
+        }
+
         ui_tableview.reloadData()
+    }
+
+    private func setupFloaty() {
+        if let floaty = ui_floaty_button {
+            floaty.isHidden = true // hidden by default
+
+            if isEvent && viewerCanUseCheckboxes && !isFromSurvey && !isFromReact {
+                floaty.isHidden = false
+                floaty.buttonImage = UIImage(named: "ic_button_plus_fill")
+                floaty.buttonColor = UIColor(named: "appOrange") ?? .orange
+                floaty.paddingY = 20
+                floaty.paddingX = 20
+                floaty.fabDelegate = self
+            }
+        }
     }
 
     // MARK: - Search
@@ -311,6 +350,23 @@ extension NeighBorhoodEventListUsersViewController: UITableViewDataSource, UITab
 
         switch tableData[indexPath.row] {
 
+        case .unsubscribedParticipantsHeader:
+            let cell = tableView.dequeueReusableCell(withIdentifier: "UnsubscribedHeaderCell", for: indexPath) as! NeighborhoodUnsubscribedParticipantsHeaderCell
+            cell.selectionStyle = .none
+            return cell
+
+        case .unsubscribedParticipantsAskHelpCell(let count):
+            let cell = tableView.dequeueReusableCell(withIdentifier: "UnsubscribedCell", for: indexPath) as! NeighborhoodUnsubscribedParticipantsCell
+            cell.selectionStyle = .none
+            cell.configure(count: count, isAskForHelp: true)
+            return cell
+
+        case .unsubscribedParticipantsOfferHelpCell(let count):
+            let cell = tableView.dequeueReusableCell(withIdentifier: "UnsubscribedCell", for: indexPath) as! NeighborhoodUnsubscribedParticipantsCell
+            cell.selectionStyle = .none
+            cell.configure(count: count, isAskForHelp: false)
+            return cell
+
         case .searchCell:
             let cell = tableView.dequeueReusableCell(withIdentifier: "cell_search", for: indexPath) as! NeighborhoodHomeSearchCell
             let title = isEvent ? "event_userInput_search".localized : "neighborhood_userInput_search".localized
@@ -361,7 +417,7 @@ extension NeighBorhoodEventListUsersViewController: UITableViewDataSource, UITab
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch tableData[indexPath.row] {
-        case .searchCell, .surveySection, .questionCell:
+        case .searchCell, .surveySection, .questionCell, .unsubscribedParticipantsHeader, .unsubscribedParticipantsAskHelpCell, .unsubscribedParticipantsOfferHelpCell:
             return
 
         case .userCell(_, _):
@@ -568,6 +624,42 @@ extension NeighBorhoodEventListUsersViewController: NeighborhoodUserCellDelegate
                 }
             }
         }
+    }
+}
+
+// MARK: - FloatyDelegate
+extension NeighBorhoodEventListUsersViewController: FloatyDelegate {
+    func emptyFloatySelected(_ floaty: Floaty) {
+        let bottomSheet = UnsubscribedParticipantsBottomSheet()
+        bottomSheet.initialAskCount = event?.unsubscribed_participants_ask_for_help ?? 0
+        bottomSheet.initialOfferCount = event?.unsubscribed_participants_offer_help ?? 0
+
+        bottomSheet.onValidate = { [weak self] (offerCount, askCount) in
+            guard let self = self, let eventId = self.event?.uid else { return }
+
+            SVProgressHUD.show()
+            EventService.updateUnsubscribedParticipants(eventId: eventId, offerHelp: offerCount, askForHelp: askCount) { error in
+                SVProgressHUD.dismiss()
+                if let error = error {
+                    SVProgressHUD.showError(withStatus: error.message)
+                } else {
+                    self.event?.unsubscribed_participants_ask_for_help = askCount
+                    self.event?.unsubscribed_participants_offer_help = offerCount
+                    self.rebuildTableDataFromUsers()
+                }
+            }
+        }
+
+        if #available(iOS 15.0, *) {
+            if let sheet = bottomSheet.sheetPresentationController {
+                sheet.detents = [.medium()]
+                sheet.prefersGrabberVisible = true
+            }
+        } else {
+            bottomSheet.modalPresentationStyle = .custom
+        }
+
+        self.present(bottomSheet, animated: true, completion: nil)
     }
 }
 

--- a/entourage/Scenes/Groups - Neighborhoods/NeighborhoodUnsubscribedParticipantsHeaderCell.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/NeighborhoodUnsubscribedParticipantsHeaderCell.swift
@@ -1,0 +1,31 @@
+import UIKit
+
+class NeighborhoodUnsubscribedParticipantsHeaderCell: UITableViewCell {
+    let titleLabel = UILabel()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+
+    private func setupUI() {
+        contentView.backgroundColor = .clear
+
+        titleLabel.font = ApplicationTheme.getFontNunitoBold(size: 13)
+        titleLabel.textColor = UIColor(named: "grey_reaction") ?? .gray
+        titleLabel.text = "PARTICIPANTS AJOUTÉS SUR PLACE"
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(titleLabel)
+
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 24),
+            titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8)
+        ])
+    }
+}

--- a/entourage/Scenes/Groups - Neighborhoods/UnsubscribedParticipantsBottomSheet.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/UnsubscribedParticipantsBottomSheet.swift
@@ -52,13 +52,13 @@ class UnsubscribedParticipantsBottomSheet: UIViewController {
         view.addSubview(dismissLine)
 
         titleLabel.text = "Ajouter des participants"
-        titleLabel.font = ApplicationTheme.getFontH1Noir()
+        titleLabel.font = ApplicationTheme.getFontH1Noir().font
         titleLabel.textColor = .black
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(titleLabel)
 
         helpAskLabel.text = "Combien de personnes isolées supplémentaires ont rejoint l'événement ?"
-        helpAskLabel.font = ApplicationTheme.getFontCourantRegularNoir()
+        helpAskLabel.font = ApplicationTheme.getFontCourantRegularNoir().font
         helpAskLabel.textColor = .black
         helpAskLabel.numberOfLines = 0
         helpAskLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -67,7 +67,7 @@ class UnsubscribedParticipantsBottomSheet: UIViewController {
         setupCounter(minusBtn: helpAskMinusButton, plusBtn: helpAskPlusButton, countLabel: helpAskCountLabel, yAnchorView: helpAskLabel)
 
         helpOfferLabel.text = "Combien de riverains supplémentaires ont rejoint l'événement ?"
-        helpOfferLabel.font = ApplicationTheme.getFontCourantRegularNoir()
+        helpOfferLabel.font = ApplicationTheme.getFontCourantRegularNoir().font
         helpOfferLabel.textColor = .black
         helpOfferLabel.numberOfLines = 0
         helpOfferLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -135,7 +135,7 @@ class UnsubscribedParticipantsBottomSheet: UIViewController {
         plusBtn.layer.cornerRadius = 20
         plusBtn.backgroundColor = UIColor(named: "orange_light_a50") ?? UIColor.orange.withAlphaComponent(0.1)
 
-        countLabel.font = ApplicationTheme.getFontH2Noir()
+        countLabel.font = ApplicationTheme.getFontH2Noir().font
         countLabel.textColor = .black
         countLabel.textAlignment = .center
 

--- a/entourage/Scenes/Groups - Neighborhoods/UnsubscribedParticipantsBottomSheet.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/UnsubscribedParticipantsBottomSheet.swift
@@ -1,0 +1,178 @@
+import UIKit
+
+class UnsubscribedParticipantsBottomSheet: UIViewController {
+
+    private let titleLabel = UILabel()
+    private let dismissLine = UIView()
+
+    private let helpAskLabel = UILabel()
+    private let helpAskMinusButton = UIButton()
+    private let helpAskPlusButton = UIButton()
+    private let helpAskCountLabel = UILabel()
+
+    private let helpOfferLabel = UILabel()
+    private let helpOfferMinusButton = UIButton()
+    private let helpOfferPlusButton = UIButton()
+    private let helpOfferCountLabel = UILabel()
+
+    private let validateButton = UIButton()
+
+    var initialAskCount: Int = 0
+    var initialOfferCount: Int = 0
+
+    private var currentAskCount: Int = 0 {
+        didSet {
+            helpAskCountLabel.text = "\(currentAskCount)"
+        }
+    }
+
+    private var currentOfferCount: Int = 0 {
+        didSet {
+            helpOfferCountLabel.text = "\(currentOfferCount)"
+        }
+    }
+
+    var onValidate: ((Int, Int) -> Void)?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        currentAskCount = initialAskCount
+        currentOfferCount = initialOfferCount
+    }
+
+    private func setupUI() {
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 20
+        view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+
+        dismissLine.backgroundColor = UIColor(named: "grey_line") ?? .lightGray
+        dismissLine.layer.cornerRadius = 2
+        dismissLine.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(dismissLine)
+
+        titleLabel.text = "Ajouter des participants"
+        titleLabel.font = ApplicationTheme.getFontH1Noir()
+        titleLabel.textColor = .black
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(titleLabel)
+
+        helpAskLabel.text = "Combien de personnes isolées supplémentaires ont rejoint l'événement ?"
+        helpAskLabel.font = ApplicationTheme.getFontCourantRegularNoir()
+        helpAskLabel.textColor = .black
+        helpAskLabel.numberOfLines = 0
+        helpAskLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(helpAskLabel)
+
+        setupCounter(minusBtn: helpAskMinusButton, plusBtn: helpAskPlusButton, countLabel: helpAskCountLabel, yAnchorView: helpAskLabel)
+
+        helpOfferLabel.text = "Combien de riverains supplémentaires ont rejoint l'événement ?"
+        helpOfferLabel.font = ApplicationTheme.getFontCourantRegularNoir()
+        helpOfferLabel.textColor = .black
+        helpOfferLabel.numberOfLines = 0
+        helpOfferLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(helpOfferLabel)
+
+        setupCounter(minusBtn: helpOfferMinusButton, plusBtn: helpOfferPlusButton, countLabel: helpOfferCountLabel, yAnchorView: helpOfferLabel)
+
+        validateButton.setTitle("Valider", for: .normal)
+        validateButton.backgroundColor = UIColor(named: "appOrange") ?? .orange
+        validateButton.titleLabel?.font = ApplicationTheme.getFontBoutonBlanc().font
+        validateButton.layer.cornerRadius = 8
+        validateButton.translatesAutoresizingMaskIntoConstraints = false
+        validateButton.addTarget(self, action: #selector(validateAction), for: .touchUpInside)
+        view.addSubview(validateButton)
+
+        NSLayoutConstraint.activate([
+            dismissLine.topAnchor.constraint(equalTo: view.topAnchor, constant: 12),
+            dismissLine.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            dismissLine.widthAnchor.constraint(equalToConstant: 40),
+            dismissLine.heightAnchor.constraint(equalToConstant: 4),
+
+            titleLabel.topAnchor.constraint(equalTo: dismissLine.bottomAnchor, constant: 20),
+            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+
+            helpAskLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
+            helpAskLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            helpAskLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+
+            helpOfferLabel.topAnchor.constraint(equalTo: helpAskLabel.bottomAnchor, constant: 90),
+            helpOfferLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            helpOfferLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+
+            validateButton.topAnchor.constraint(equalTo: helpOfferLabel.bottomAnchor, constant: 100),
+            validateButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            validateButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            validateButton.heightAnchor.constraint(equalToConstant: 50),
+            validateButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
+        ])
+
+        helpAskMinusButton.addTarget(self, action: #selector(askMinusAction), for: .touchUpInside)
+        helpAskPlusButton.addTarget(self, action: #selector(askPlusAction), for: .touchUpInside)
+
+        helpOfferMinusButton.addTarget(self, action: #selector(offerMinusAction), for: .touchUpInside)
+        helpOfferPlusButton.addTarget(self, action: #selector(offerPlusAction), for: .touchUpInside)
+    }
+
+    private func setupCounter(minusBtn: UIButton, plusBtn: UIButton, countLabel: UILabel, yAnchorView: UIView) {
+        let stack = UIStackView(arrangedSubviews: [minusBtn, countLabel, plusBtn])
+        stack.axis = .horizontal
+        stack.spacing = 20
+        stack.alignment = .center
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
+
+        minusBtn.setTitle("−", for: .normal)
+        minusBtn.setTitleColor(UIColor(named: "appOrange") ?? .orange, for: .normal)
+        minusBtn.titleLabel?.font = .systemFont(ofSize: 24, weight: .regular)
+        minusBtn.layer.cornerRadius = 20
+        minusBtn.backgroundColor = UIColor(named: "orange_light_a50") ?? UIColor.orange.withAlphaComponent(0.1)
+
+        plusBtn.setTitle("+", for: .normal)
+        plusBtn.setTitleColor(UIColor(named: "appOrange") ?? .orange, for: .normal)
+        plusBtn.titleLabel?.font = .systemFont(ofSize: 24, weight: .regular)
+        plusBtn.layer.cornerRadius = 20
+        plusBtn.backgroundColor = UIColor(named: "orange_light_a50") ?? UIColor.orange.withAlphaComponent(0.1)
+
+        countLabel.font = ApplicationTheme.getFontH2Noir()
+        countLabel.textColor = .black
+        countLabel.textAlignment = .center
+
+        NSLayoutConstraint.activate([
+            minusBtn.widthAnchor.constraint(equalToConstant: 40),
+            minusBtn.heightAnchor.constraint(equalToConstant: 40),
+            plusBtn.widthAnchor.constraint(equalToConstant: 40),
+            plusBtn.heightAnchor.constraint(equalToConstant: 40),
+            countLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 30),
+
+            stack.topAnchor.constraint(equalTo: yAnchorView.bottomAnchor, constant: 16),
+            stack.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+    }
+
+    @objc private func askMinusAction() {
+        if currentAskCount > 0 {
+            currentAskCount -= 1
+        }
+    }
+
+    @objc private func askPlusAction() {
+        currentAskCount += 1
+    }
+
+    @objc private func offerMinusAction() {
+        if currentOfferCount > 0 {
+            currentOfferCount -= 1
+        }
+    }
+
+    @objc private func offerPlusAction() {
+        currentOfferCount += 1
+    }
+
+    @objc private func validateAction() {
+        onValidate?(currentOfferCount, currentAskCount)
+        dismiss(animated: true)
+    }
+}

--- a/entourage/Scenes/Onboarding/OnboardingStartCell.swift
+++ b/entourage/Scenes/Onboarding/OnboardingStartCell.swift
@@ -581,7 +581,7 @@ extension OnboardingStartCell: UITextFieldDelegate {
 // MARK: - UIPickerViewDelegate, UIPickerViewDataSource
 extension OnboardingStartCell: UIPickerViewDelegate, UIPickerViewDataSource {
     func numberOfComponents(in pickerView: UIPickerView) -> Int { 1 }
-
+    
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         switch pickerView.tag {
         case 1: return genderOptions.count
@@ -591,7 +591,7 @@ extension OnboardingStartCell: UIPickerViewDelegate, UIPickerViewDataSource {
         default: return pickerDatas.count
         }
     }
-
+    
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
         switch pickerView.tag {
         case 1: return genderOptions[safe: row]
@@ -600,6 +600,8 @@ extension OnboardingStartCell: UIPickerViewDelegate, UIPickerViewDataSource {
         case 4: return eventOptions[safe: row]
         default: return "\(pickerDatas[row].flag) \(pickerDatas[row].country)"
         }
+    } // <-- ICI se trouvait l'erreur de parenthèse manquante !
+    
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         if pickerView.tag == 1 {
             genderTextField.text = genderOptions[safe: row]
@@ -610,13 +612,17 @@ extension OnboardingStartCell: UIPickerViewDelegate, UIPickerViewDataSource {
         } else if pickerView.tag == 3 {
             companyTextField.text = enterpriseOptions[safe: row]
             if let selectedCompany = enterprises[safe: row] {
-                delegate?.validateCompany(company: String(selectedCompany.id ?? 0))
+                // Conversion sécurisée en String, peu importe que l'ID soit Int ou String de base
+                let companyId = selectedCompany.id != nil ? "\(selectedCompany.id!)" : ""
+                delegate?.validateCompany(company: companyId)
                 loadEvents(forEnterpriseAt: row)
             }
         } else if pickerView.tag == 4 {
             eventTextField.text = eventOptions[safe: row]
             if let selectedEvent = eventsForSelectedEnterprise[safe: row] {
-                delegate?.validateEvent(event: String(selectedEvent.id ?? 0))
+                // Conversion sécurisée en String
+                let eventId = selectedEvent.id != nil ? "\(selectedEvent.id!)" : ""
+                delegate?.validateEvent(event: eventId)
             }
         } else {
             if pickerDatas.indices.contains(row) {
@@ -627,7 +633,4 @@ extension OnboardingStartCell: UIPickerViewDelegate, UIPickerViewDataSource {
             }
         }
     }
-
 }
-
-

--- a/entourage/Storyboards/Neighborhood.storyboard
+++ b/entourage/Storyboards/Neighborhood.storyboard
@@ -1774,10 +1774,24 @@
                                             <constraint firstItem="MUu-JM-Yek" firstAttribute="leading" secondItem="T9h-vF-R4Q" secondAttribute="leading" constant="32" id="rT2-nV-C24"/>
                                         </constraints>
                                     </view>
+                                    <view hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QW-eD-fLt" customClass="Floaty" customModule="Ent_Beta" customModuleProvider="target">
+                                        <rect key="frame" x="324" y="706" width="62" height="62"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <color key="tintColor" name="orange_light_a50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="62" id="1hE-P2-aU3"/>
+                                            <constraint firstAttribute="width" constant="62" id="q8O-QY-5o9"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="image" keyPath="buttonImage" value="ic_button_plus_fill"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </view>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="e6K-FI-yGc" firstAttribute="top" secondItem="Aew-nQ-kXv" secondAttribute="bottom" id="5Ti-3L-Gr7"/>
+                                    <constraint firstAttribute="bottom" secondItem="QW-eD-fLt" secondAttribute="bottom" constant="32" id="B3Q-cR-Qd6"/>
+                                    <constraint firstAttribute="trailing" secondItem="QW-eD-fLt" secondAttribute="trailing" constant="28" id="D0X-qS-k2x"/>
                                     <constraint firstAttribute="trailing" secondItem="T9h-vF-R4Q" secondAttribute="trailing" id="Dx7-SG-lCa"/>
                                     <constraint firstItem="Aew-nQ-kXv" firstAttribute="top" secondItem="fDV-bM-SIb" secondAttribute="top" id="EaS-R7-bdk"/>
                                     <constraint firstItem="e6K-FI-yGc" firstAttribute="leading" secondItem="fDV-bM-SIb" secondAttribute="leading" id="JB9-VI-DvS"/>
@@ -1807,6 +1821,7 @@
                         <outlet property="ui_top_view" destination="Aew-nQ-kXv" id="HPh-S2-oA8"/>
                         <outlet property="ui_view_container" destination="fDV-bM-SIb" id="aPW-Tr-6gQ"/>
                         <outlet property="ui_view_no_result" destination="T9h-vF-R4Q" id="BYD-1r-9CZ"/>
+                        <outlet property="ui_floaty_button" destination="QW-eD-fLt" id="bYD-2r-1C1"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="P0y-Fg-pE6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
This change implements the ability for an event organizer to track and report participants who attended without registering via the app ("personnes isolées" and "riverains"). A floating action button (+) was added to the members list, which presents a bottom sheet with counters. Upon validation, the updated counts are synced to the backend and visually appended to the bottom of the user list.

---
*PR created automatically by Jules for task [5097135622339934262](https://jules.google.com/task/5097135622339934262) started by @clemPerrousset*