### PR TITLE
fix: allow self attendance on event member list

### DIFF
--- a/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUserCell.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUserCell.swift
@@ -139,8 +139,7 @@ class NeighborhoodUserCell: UITableViewCell {
         }
 
         // La visibilité de la checkbox dépend du rôle + règles signable
-        let canShowCheckbox = !isMe
-            && AppSignableManager.shared.signableEvent
+        let canShowCheckbox = AppSignableManager.shared.signableEvent
             && AppSignableManager.shared.signablePermission
         print("eho signable : " , AppSignableManager.shared.signableEvent)
         print("eho signable permission : " , AppSignableManager.shared.signablePermission)


### PR DESCRIPTION
Removed the `!isMe` restriction from the checkbox visibility condition in `NeighborhoodUserCell.swift`. This will allow users to self-attend ("s'auto-émarger") an event when checking the member list.

---
*PR created automatically by Jules for task [6280641183131969443](https://jules.google.com/task/6280641183131969443) started by @clemPerrousset*