### PR TITLE
Update display name for Reunion to "La Réunion"

### DIFF
--- a/entourage/Tools/OTCountryCodePickerViewDataSource.m
+++ b/entourage/Tools/OTCountryCodePickerViewDataSource.m
@@ -79,7 +79,7 @@
                             },
                         @{
                             @"Code 2 char" : @"RE",
-                            @"Final list" : @"Réunion",
+                            @"Final list" : @"La Réunion",
                             @"Number" : @"+262",
                             },
                         @{


### PR DESCRIPTION
Updated the display name for Reunion in the country code picker data source to use "La Réunion" instead of "Réunion" for the country list during registration.

---
*PR created automatically by Jules for task [5720468937490740857](https://jules.google.com/task/5720468937490740857) started by @clemPerrousset*