### PR TITLE
Fix phone placeholder update on country change

### DIFF
--- a/entourage/Scenes/Login/OTLoginV2ViewController.swift
+++ b/entourage/Scenes/Login/OTLoginV2ViewController.swift
@@ -85,6 +85,9 @@ private struct AccessoryTextField: UIViewRepresentable {
         if uiView.text != text.wrappedValue {
             uiView.text = text.wrappedValue
         }
+        if uiView.placeholder != placeholder {
+            uiView.placeholder = placeholder
+        }
         // Mise à jour dynamique pour le toggle mot de passe
         if uiView.isSecureTextEntry != isSecureTextEntry {
             uiView.isSecureTextEntry = isSecureTextEntry

--- a/entourage/Scenes/Onboarding/OnboardingPhase1ViewController.swift
+++ b/entourage/Scenes/Onboarding/OnboardingPhase1ViewController.swift
@@ -117,6 +117,9 @@ private struct AccessoryTextField: UIViewRepresentable {
         if uiView.text != text.wrappedValue {
             uiView.text = text.wrappedValue
         }
+        if uiView.placeholder != placeholder {
+            uiView.placeholder = placeholder
+        }
         uiView.keyboardType = keyboardType
         uiView.autocapitalizationType = autocapitalizationType
         uiView.isSecureTextEntry = isSecureTextEntry


### PR DESCRIPTION
Fixed an issue in SwiftUI where changing the selected country did not update the phone number placeholder. Updated the `UIViewRepresentable` text field to ensure `placeholder` is correctly synchronized.

---
*PR created automatically by Jules for task [886820590530650877](https://jules.google.com/task/886820590530650877) started by @clemPerrousset*