### PR TITLE
Update leave conversation button text based on conversation type

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -1750,3 +1750,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "welcome_webinar_list_subtitle" = "يمنحك فريق إنتوراج المفاتيح لفهم عالم الشارع وحلول المساعدة الحالية خلال ورشة عمل عبر الإنترنت مدتها ساعة واحدة.";
 "welcome_firststep_list_title" = "الخطوات الأولى على إنتوراج";
 "welcome_firststep_list_subtitle" = "تعرف على التطبيق واطرح جميع أسئلتك على الفريق - في مجموعات صغيرة، في مكالمة فيديو مدتها 45 دقيقة.";
+
+"conv_param_delete_discussion" = "Delete the discussion";
+"conv_param_no_longer_participate" = "I no longer wish to participate";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -1811,3 +1811,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "welcome_webinar_list_subtitle" = "Das Entourage-Team gibt dir in einem einstündigen Online-Workshop die Schlüssel an die Hand, um die Welt der Straße und bestehende Hilfslösungen zu verstehen.";
 "welcome_firststep_list_title" = "Erste Schritte auf Entourage";
 "welcome_firststep_list_subtitle" = "Mache dich mit der App vertraut und stelle dem Team all deine Fragen — in kleinen Gruppen, in einem 45-minütigen Videoanruf.";
+
+"conv_param_delete_discussion" = "Delete the discussion";
+"conv_param_no_longer_participate" = "I no longer wish to participate";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -2020,3 +2020,6 @@
 "welcome_firststep_list_title" = "First steps on Entourage";
 "welcome_firststep_list_subtitle" = "Get to know the app and ask all your questions to the team — in small groups, a 45-minute video call.";
 "event_discussion_desc" = "You can ask your questions and exchange with the organizer and the participants of the event";
+
+"conv_param_delete_discussion" = "Delete the discussion";
+"conv_param_no_longer_participate" = "I no longer wish to participate";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -3234,3 +3234,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "welcome_webinar_list_subtitle" = "El equipo de Entourage te da las claves para entender el mundo de la calle y las soluciones de ayuda existentes durante un taller online de 1 hora.";
 "welcome_firststep_list_title" = "Primeros pasos en Entourage";
 "welcome_firststep_list_subtitle" = "Familiarízate con la aplicación y hazle todas tus preguntas al equipo — en pequeños grupos, 45 minutos por videollamada.";
+
+"conv_param_delete_discussion" = "Eliminar la discusión";
+"conv_param_no_longer_participate" = "Ya no deseo participar";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -2017,3 +2017,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "welcome_firststep_list_title" = "Premiers pas sur Entourage";
 "welcome_firststep_list_subtitle" = "Prenez en main l'application et posez toutes vos questions à l'équipe — en petit groupe, en 45 minutes en visio.";
 "event_discussion_desc" = "Vous pouvez poser vos questions et échanger avec l'organisateur et les participants de l'événement";
+
+"conv_param_delete_discussion" = "Supprimer la discussion";
+"conv_param_no_longer_participate" = "Je ne souhaite plus participer";

--- a/entourage/Assets/hr.lproj/Localizable.strings
+++ b/entourage/Assets/hr.lproj/Localizable.strings
@@ -1440,3 +1440,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 
 "conversation_staff_warning_message" = "The team is taking a break... 🌙 In case of emergency: 15, 18, or 115. For immediate help, your neighbors are in the group ! 🏠 We will answer you quickly.";
 "conversation_staff_warning_group_link" = "group";
+
+"conv_param_delete_discussion" = "Delete the discussion";
+"conv_param_no_longer_participate" = "I no longer wish to participate";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -1825,3 +1825,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "welcome_webinar_list_subtitle" = "Zespół Entourage daje Ci klucze do zrozumienia świata ulicy i istniejących rozwiązań pomocowych podczas 1-godzinnych warsztatów online.";
 "welcome_firststep_list_title" = "Pierwsze kroki w Entourage";
 "welcome_firststep_list_subtitle" = "Poznaj aplikację i zadaj wszystkie pytania zespołowi — w małych grupach, podczas 45-minutowej rozmowy wideo.";
+
+"conv_param_delete_discussion" = "Delete the discussion";
+"conv_param_no_longer_participate" = "I no longer wish to participate";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -1714,3 +1714,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "welcome_webinar_list_subtitle" = "Echipa Entourage îți oferă cheile pentru a înțelege lumea străzii și soluțiile de ajutor existente în timpul unui atelier online de 1 oră.";
 "welcome_firststep_list_title" = "Primii pași pe Entourage";
 "welcome_firststep_list_subtitle" = "Familiarizează-te cu aplicația și pune-i echipei toate întrebările tale — în grupuri mici, printr-un apel video de 45 de minute.";
+
+"conv_param_delete_discussion" = "Delete the discussion";
+"conv_param_no_longer_participate" = "I no longer wish to participate";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -1791,3 +1791,6 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "welcome_webinar_list_subtitle" = "Команда Entourage дає вам ключі до розуміння світу вулиці та існуючих рішень допомоги під час 1-годинного онлайн-семінару.";
 "welcome_firststep_list_title" = "Перші кроки в Entourage";
 "welcome_firststep_list_subtitle" = "Ознайомтеся з додатком та поставте всі свої питання команді — у невеликих групах, під час 45-хвилинного відеодзвінка.";
+
+"conv_param_delete_discussion" = "Delete the discussion";
+"conv_param_no_longer_participate" = "I no longer wish to participate";

--- a/entourage/Scenes/Conversations/ConversationParametersViewController.swift
+++ b/entourage/Scenes/Conversations/ConversationParametersViewController.swift
@@ -305,14 +305,34 @@ extension ConversationParametersViewController: UITableViewDataSource, UITableVi
             return cell
 
         case .leave:
-            let cell = tableView.dequeueReusableCell(withIdentifier: "cell_alone", for: indexPath) as! ConversationParamCell
-            cell.populateCell(title: "conv_param_qui_action".localized,
-                              subtitle: nil,
-                              isTitleOrange: true,
-                              pictoStr: "ic_leave_conv",
-                              hideSeparator: true,
-                              isIconOrange: true) // ✅ icône orange
-            return cell
+            if isEvent {
+                let cell = tableView.dequeueReusableCell(withIdentifier: "cell_subtitle", for: indexPath) as! ConversationParamCell
+                cell.populateCell(title: "conv_param_no_longer_participate".localized,
+                                  subtitle: "conv_param_delete_discussion".localized,
+                                  isTitleOrange: true,
+                                  pictoStr: "ic_leave_conv",
+                                  hideSeparator: true,
+                                  isIconOrange: true)
+                return cell
+            } else if isOneToOne && !isSmallTalkMode {
+                let cell = tableView.dequeueReusableCell(withIdentifier: "cell_alone", for: indexPath) as! ConversationParamCell
+                cell.populateCell(title: "conv_param_delete_discussion".localized,
+                                  subtitle: nil,
+                                  isTitleOrange: true,
+                                  pictoStr: "ic_leave_conv",
+                                  hideSeparator: true,
+                                  isIconOrange: true)
+                return cell
+            } else {
+                let cell = tableView.dequeueReusableCell(withIdentifier: "cell_alone", for: indexPath) as! ConversationParamCell
+                cell.populateCell(title: "conv_param_qui_action".localized,
+                                  subtitle: nil,
+                                  isTitleOrange: true,
+                                  pictoStr: "ic_leave_conv",
+                                  hideSeparator: true,
+                                  isIconOrange: true)
+                return cell
+            }
         }
     }
 


### PR DESCRIPTION
Updates the "leave conversation" button text in `ConversationParametersViewController` to reflect context better.
- 1-to-1 conversations now display "Delete the discussion".
- Event conversations now display "I no longer wish to participate" with "Delete the discussion" as a subtitle.
- SmallTalk conversations are untouched.
Adds corresponding localizable strings to all languages.

---
*PR created automatically by Jules for task [1002944751164138821](https://jules.google.com/task/1002944751164138821) started by @clemPerrousset*