### PR TITLE
Update Unsubscribed Participants Header UI

### DIFF
--- a/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
@@ -334,7 +334,16 @@ extension NeighBorhoodEventListUsersViewController: UITableViewDataSource, UITab
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        if indexPath.row < 1 {
+        let isUnsubscribedHeader = {
+            if indexPath.row < self.tableData.count {
+                if case .unsubscribedParticipantsHeader = self.tableData[indexPath.row] { return true }
+                if case .unsubscribedParticipantsAskHelpCell = self.tableData[indexPath.row] { return true }
+                if case .unsubscribedParticipantsOfferHelpCell = self.tableData[indexPath.row] { return true }
+            }
+            return false
+        }()
+
+        if indexPath.row < 1 || isUnsubscribedHeader {
             cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: cell.bounds.width)
         } else {
             cell.separatorInset = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)

--- a/entourage/Scenes/Groups - Neighborhoods/NeighborhoodUnsubscribedParticipantsHeaderCell.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/NeighborhoodUnsubscribedParticipantsHeaderCell.swift
@@ -17,7 +17,7 @@ class NeighborhoodUnsubscribedParticipantsHeaderCell: UITableViewCell {
         contentView.backgroundColor = .clear
 
         titleLabel.font = ApplicationTheme.getFontNunitoBold(size: 13)
-        titleLabel.textColor = UIColor(named: "grey_reaction") ?? .gray
+        titleLabel.textColor = .black
         titleLabel.text = "PARTICIPANTS AJOUTÉS SUR PLACE"
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(titleLabel)


### PR DESCRIPTION
Changes the title text color of `NeighborhoodUnsubscribedParticipantsHeaderCell` to `.black` and removes the separator lines below the header cell by adjusting the `separatorInset` in `NeighBorhoodEventListUsersViewController`.

---
*PR created automatically by Jules for task [3659148225805225660](https://jules.google.com/task/3659148225805225660) started by @clemPerrousset*