### PR TITLE
Fix Unsubscribed Participants Bottom Sheet UI and Data Refresh

### DIFF
--- a/entourage/Scenes/Events/EventDetailFeedViewController.swift
+++ b/entourage/Scenes/Events/EventDetailFeedViewController.swift
@@ -75,6 +75,8 @@ class EventDetailFeedViewController: UIViewController {
     }
     
     override func viewDidLoad() {
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshEvent), name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
+
         super.viewDidLoad()
         SVProgressHUD.show()
         ui_tableview.dataSource = self

--- a/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUnsubscribedParticipantsCell.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUnsubscribedParticipantsCell.swift
@@ -37,12 +37,12 @@ class NeighborhoodUnsubscribedParticipantsCell: UITableViewCell {
         contentView.addSubview(subtitleLabel)
 
         NSLayoutConstraint.activate([
-            iconImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            iconImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 32),
             iconImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             iconImageView.widthAnchor.constraint(equalToConstant: 50),
             iconImageView.heightAnchor.constraint(equalToConstant: 50),
 
-            typeLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 12),
+            typeLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 16),
             typeLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
 
             subtitleLabel.leadingAnchor.constraint(equalTo: typeLabel.leadingAnchor),

--- a/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUnsubscribedParticipantsHeaderCell.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/Cells/NeighborhoodUnsubscribedParticipantsHeaderCell.swift
@@ -23,7 +23,7 @@ class NeighborhoodUnsubscribedParticipantsHeaderCell: UITableViewCell {
         contentView.addSubview(titleLabel)
 
         NSLayoutConstraint.activate([
-            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 32),
             titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 24),
             titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8)
         ])

--- a/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
@@ -634,6 +634,10 @@ extension NeighBorhoodEventListUsersViewController: FloatyDelegate {
         bottomSheet.initialAskCount = event?.unsubscribed_participants_ask_for_help ?? 0
         bottomSheet.initialOfferCount = event?.unsubscribed_participants_offer_help ?? 0
 
+        bottomSheet.onDismiss = { [weak self] in
+            // Trigger refresh when sheet is dismissed
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
+        }
         bottomSheet.onValidate = { [weak self] (offerCount, askCount) in
             guard let self = self, let eventId = self.event?.uid else { return }
 
@@ -652,7 +656,14 @@ extension NeighBorhoodEventListUsersViewController: FloatyDelegate {
 
         if #available(iOS 15.0, *) {
             if let sheet = bottomSheet.sheetPresentationController {
-                sheet.detents = [.medium(), .large()]
+                if #available(iOS 16.0, *) {
+                    let customDetent = UISheetPresentationController.Detent.custom { context in
+                        return 600
+                    }
+                    sheet.detents = [customDetent, .large()]
+                } else {
+                    sheet.detents = [.large()]
+                }
                 sheet.prefersGrabberVisible = true
             }
         } else {

--- a/entourage/Scenes/Groups - Neighborhoods/UnsubscribedParticipantsBottomSheet.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/UnsubscribedParticipantsBottomSheet.swift
@@ -35,12 +35,20 @@ class UnsubscribedParticipantsBottomSheet: UIViewController {
     }
 
     var onValidate: ((Int, Int) -> Void)?
+    var onDismiss: (() -> Void)?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
         currentAskCount = initialAskCount
         currentOfferCount = initialOfferCount
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        if self.isBeingDismissed {
+            onDismiss?()
+        }
     }
 
     private func setupUI() {
@@ -54,7 +62,7 @@ class UnsubscribedParticipantsBottomSheet: UIViewController {
         scrollView.addSubview(contentView)
 
         NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),


### PR DESCRIPTION
Made the Unsubscribed Participants Bottom Sheet larger so the CTA is visible without scrolling, and trigger an event detail refresh when the bottom sheet is dismissed. Also aligned the extra participants items with the other list items in the bottom sheet.

---
*PR created automatically by Jules for task [1004472438491805558](https://jules.google.com/task/1004472438491805558) started by @clemPerrousset*