### PR TITLE
Fix unsubscribed participants sticky views and synchronization

### DIFF
--- a/entourage/Models/Event.swift
+++ b/entourage/Models/Event.swift
@@ -46,9 +46,6 @@ struct Event:Codable {
     var signable:Bool? = nil
     var manageableByCurrentUser:Bool? = false
 
-    var unsubscribed_participants_ask_for_help: Int? = 0
-    var unsubscribed_participants_offer_help: Int? = 0
-
     private var statusChangedAt:String? = nil
     private var createdAt:String? = nil
     private var updatedAt:String? = nil
@@ -220,8 +217,6 @@ struct Event:Codable {
         case imageId = "entourage_image_id"
         
         case recurrency
-        case unsubscribed_participants_ask_for_help
-        case unsubscribed_participants_offer_help
         case membersCount = "members_count"
         case members
         case isMember = "member"
@@ -409,6 +404,8 @@ struct EventMetadata: Codable {
     var portrait_url: String? = nil
     var landscape_url: String? = nil
     var reservedFemale: Bool? = false
+    var unsubscribed_participants_ask_for_help: String? = "0"
+    var unsubscribed_participants_offer_help: String? = "0"
     
     var hasPlaceLimit: Bool? {
         get {
@@ -430,6 +427,8 @@ struct EventMetadata: Codable {
         case portrait_url
         case landscape_url
         case reservedFemale = "reserved_female"
+        case unsubscribed_participants_ask_for_help
+        case unsubscribed_participants_offer_help
     }
     
     // 1. On garde un initialiseur vide par défaut pour ne pas casser le reste du code
@@ -449,6 +448,23 @@ struct EventMetadata: Codable {
         portrait_url = try container.decodeIfPresent(String.self, forKey: .portrait_url)
         landscape_url = try container.decodeIfPresent(String.self, forKey: .landscape_url)
         
+        // Same logic as reservedFemale but for unsubscribed_participants which can be int or string
+        if let intValue = try? container.decodeIfPresent(Int.self, forKey: .unsubscribed_participants_ask_for_help) {
+            unsubscribed_participants_ask_for_help = String(intValue)
+        } else if let stringValue = try? container.decodeIfPresent(String.self, forKey: .unsubscribed_participants_ask_for_help) {
+            unsubscribed_participants_ask_for_help = stringValue
+        } else {
+            unsubscribed_participants_ask_for_help = "0"
+        }
+
+        if let intValue = try? container.decodeIfPresent(Int.self, forKey: .unsubscribed_participants_offer_help) {
+            unsubscribed_participants_offer_help = String(intValue)
+        } else if let stringValue = try? container.decodeIfPresent(String.self, forKey: .unsubscribed_participants_offer_help) {
+            unsubscribed_participants_offer_help = stringValue
+        } else {
+            unsubscribed_participants_offer_help = "0"
+        }
+
         // C'EST ICI QUE LA MAGIE OPÈRE ✨
         // On essaie d'abord de lire un Bool classique
         if let boolValue = try? container.decodeIfPresent(Bool.self, forKey: .reservedFemale) {

--- a/entourage/Scenes/Events/EventDetailFullFeedViewController.swift
+++ b/entourage/Scenes/Events/EventDetailFullFeedViewController.swift
@@ -24,6 +24,8 @@ class EventDetailFullFeedViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshEvent), name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
+
         ui_tableview.dataSource = self
         ui_tableview.delegate = self
         
@@ -71,6 +73,19 @@ class EventDetailFullFeedViewController: UIViewController {
                 self.goBack()
             }
         }
+    }
+
+    @objc func refreshEvent() {
+        EventService.getEventWithId(String(eventId)) { event, error in
+            if let event = event {
+                self.event = event
+                self.ui_tableview.reloadData()
+            }
+        }
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }
 
@@ -268,7 +283,9 @@ extension EventDetailFullFeedViewController: MJAlertControllerDelegate {
 //MARK: - MJNavBackViewDelegate -
 extension EventDetailFullFeedViewController: MJNavBackViewDelegate {
     func goBack() {
-        self.navigationController?.dismiss(animated: true)
+        self.navigationController?.dismiss(animated: true) {
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
+        }
     }
     func didTapEvent() {
         //Nothing yet

--- a/entourage/Scenes/Events/EventParamsViewController.swift
+++ b/entourage/Scenes/Events/EventParamsViewController.swift
@@ -68,6 +68,12 @@ class EventParamsViewController: BasePopViewController {
             name: NSNotification.Name(rawValue: kNotificationEventUpdate),
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(refreshEventDetail),
+            name: NSNotification.Name(rawValue: "RefreshEventDetail"),
+            object: nil
+        )
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -83,6 +89,17 @@ class EventParamsViewController: BasePopViewController {
         if let _event = notification.userInfo?["event"] as? Event {
             self.event = _event
             self.ui_tableview.reloadData()
+        }
+    }
+
+    @objc func refreshEventDetail() {
+        if let eventId = event?.uid {
+            EventService.getEventWithId(String(eventId)) { event, error in
+                if let event = event {
+                    self.event = event
+                    self.ui_tableview.reloadData()
+                }
+            }
         }
     }
 
@@ -544,6 +561,7 @@ extension EventParamsViewController: MJNavBackViewDelegate {
     func goBack() {
         self.navigationController?.dismiss(animated: true, completion: {
             self.delegate?.reloadView()
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
         })
     }
 

--- a/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
@@ -13,9 +13,6 @@ private enum TableDTO {
     case questionCell(title: String)
     case userCell(user: UserLightNeighborhood, reactionType: ReactionType?)
     case surveySection(title: String, voteCount: Int)
-    case unsubscribedParticipantsHeader
-    case unsubscribedParticipantsAskHelpCell(count: Int)
-    case unsubscribedParticipantsOfferHelpCell(count: Int)
 }
 
 class NeighBorhoodEventListUsersViewController: BasePopViewController {
@@ -24,6 +21,12 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
     @IBOutlet weak var ui_lb_no_result: UILabel!
     @IBOutlet weak var ui_view_no_result: UIView!
     @IBOutlet weak var ui_floaty_button: Floaty!
+
+    // Bottom stack view components
+    let unsubscribedStackView = UIStackView()
+    let headerView = UIView()
+    let askForHelpCell = NeighborhoodUnsubscribedParticipantsCell(style: .default, reuseIdentifier: nil)
+    let offerHelpCell = NeighborhoodUnsubscribedParticipantsCell(style: .default, reuseIdentifier: nil)
 
     var neighborhood: Neighborhood? = nil
     var event: Event? = nil
@@ -71,9 +74,8 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
 
         ui_tableview.register(UINib(nibName: SectionOptionNameCell.identifier, bundle: nil), forCellReuseIdentifier: SectionOptionNameCell.identifier)
         ui_tableview.register(UINib(nibName: QuestionSurveyVoteCell.identifier, bundle: nil), forCellReuseIdentifier: QuestionSurveyVoteCell.identifier)
-        ui_tableview.register(NeighborhoodUnsubscribedParticipantsHeaderCell.self, forCellReuseIdentifier: "UnsubscribedHeaderCell")
-        ui_tableview.register(NeighborhoodUnsubscribedParticipantsCell.self, forCellReuseIdentifier: "UnsubscribedCell")
 
+        setupBottomViews()
         setupFloaty()
 
         var title = isEvent ? "event_users_title".localized : "neighborhood_users_title".localized
@@ -110,6 +112,15 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.hideTransparentNavigationBar()
+
+        if isEvent, let eventId = event?.uid {
+            EventService.getEventWithId(String(eventId)) { [weak self] event, error in
+                guard let self = self, let event = event else { return }
+                self.event?.metadata?.unsubscribed_participants_ask_for_help = event.metadata?.unsubscribed_participants_ask_for_help
+                self.event?.metadata?.unsubscribed_participants_offer_help = event.metadata?.unsubscribed_participants_offer_help
+                self.updateUnsubscribedBottomViews()
+            }
+        }
     }
 
     // MARK: - Survey
@@ -225,22 +236,84 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
     private func rebuildTableDataFromUsers() {
         tableData = [.searchCell] + users.map { .userCell(user: $0, reactionType: nil) }
 
-        if isEvent, let event = event {
-            let askForHelp = event.unsubscribed_participants_ask_for_help ?? 0
-            let offerHelp = event.unsubscribed_participants_offer_help ?? 0
-
-            if askForHelp > 0 || offerHelp > 0 {
-                tableData.append(.unsubscribedParticipantsHeader)
-                if askForHelp > 0 {
-                    tableData.append(.unsubscribedParticipantsAskHelpCell(count: askForHelp))
-                }
-                if offerHelp > 0 {
-                    tableData.append(.unsubscribedParticipantsOfferHelpCell(count: offerHelp))
-                }
-            }
-        }
-
         ui_tableview.reloadData()
+        updateUnsubscribedBottomViews()
+    }
+
+    private func setupBottomViews() {
+        guard isEvent else { return }
+
+        unsubscribedStackView.axis = .vertical
+        unsubscribedStackView.distribution = .fill
+        unsubscribedStackView.alignment = .fill
+        unsubscribedStackView.backgroundColor = .clear
+        unsubscribedStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        self.view.addSubview(unsubscribedStackView)
+
+        NSLayoutConstraint.activate([
+            unsubscribedStackView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            unsubscribedStackView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            unsubscribedStackView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+
+        // Add padding to bottom of tableview so content is not hidden
+        ui_tableview.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 150, right: 0)
+
+        // Header
+        headerView.backgroundColor = .clear
+        let titleLabel = UILabel()
+        titleLabel.font = ApplicationTheme.getFontNunitoBold(size: 13)
+        titleLabel.textColor = .black
+        titleLabel.text = "PARTICIPANTS AJOUTÉS SUR PLACE"
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        headerView.addSubview(titleLabel)
+
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 32),
+            titleLabel.topAnchor.constraint(equalTo: headerView.topAnchor, constant: 16),
+            titleLabel.bottomAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -8)
+        ])
+
+        unsubscribedStackView.addArrangedSubview(headerView)
+        unsubscribedStackView.addArrangedSubview(askForHelpCell)
+        unsubscribedStackView.addArrangedSubview(offerHelpCell)
+
+        askForHelpCell.selectionStyle = .none
+        offerHelpCell.selectionStyle = .none
+
+        // Initially hidden
+        unsubscribedStackView.isHidden = true
+    }
+
+    private func updateUnsubscribedBottomViews() {
+        guard isEvent, let event = event else { return }
+
+        let askForHelpStr = event.metadata?.unsubscribed_participants_ask_for_help ?? "0"
+        let offerHelpStr = event.metadata?.unsubscribed_participants_offer_help ?? "0"
+
+        let askForHelp = Int(askForHelpStr) ?? 0
+        let offerHelp = Int(offerHelpStr) ?? 0
+
+        if askForHelp > 0 || offerHelp > 0 {
+            unsubscribedStackView.isHidden = false
+
+            askForHelpCell.isHidden = (askForHelp <= 0)
+            if askForHelp > 0 {
+                askForHelpCell.configure(count: askForHelp, isAskForHelp: true)
+            }
+
+            offerHelpCell.isHidden = (offerHelp <= 0)
+            if offerHelp > 0 {
+                offerHelpCell.configure(count: offerHelp, isAskForHelp: false)
+            }
+
+            let totalCells = (askForHelp > 0 ? 1 : 0) + (offerHelp > 0 ? 1 : 0)
+            ui_tableview.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: CGFloat(50 + (totalCells * 60)), right: 0)
+        } else {
+            unsubscribedStackView.isHidden = true
+            ui_tableview.contentInset = UIEdgeInsets.zero
+        }
     }
 
     private func setupFloaty() {
@@ -334,16 +407,7 @@ extension NeighBorhoodEventListUsersViewController: UITableViewDataSource, UITab
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        let isUnsubscribedHeader = {
-            if indexPath.row < self.tableData.count {
-                if case .unsubscribedParticipantsHeader = self.tableData[indexPath.row] { return true }
-                if case .unsubscribedParticipantsAskHelpCell = self.tableData[indexPath.row] { return true }
-                if case .unsubscribedParticipantsOfferHelpCell = self.tableData[indexPath.row] { return true }
-            }
-            return false
-        }()
-
-        if indexPath.row < 1 || isUnsubscribedHeader {
+        if indexPath.row < 1 {
             cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: cell.bounds.width)
         } else {
             cell.separatorInset = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)
@@ -358,23 +422,6 @@ extension NeighBorhoodEventListUsersViewController: UITableViewDataSource, UITab
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 
         switch tableData[indexPath.row] {
-
-        case .unsubscribedParticipantsHeader:
-            let cell = tableView.dequeueReusableCell(withIdentifier: "UnsubscribedHeaderCell", for: indexPath) as! NeighborhoodUnsubscribedParticipantsHeaderCell
-            cell.selectionStyle = .none
-            return cell
-
-        case .unsubscribedParticipantsAskHelpCell(let count):
-            let cell = tableView.dequeueReusableCell(withIdentifier: "UnsubscribedCell", for: indexPath) as! NeighborhoodUnsubscribedParticipantsCell
-            cell.selectionStyle = .none
-            cell.configure(count: count, isAskForHelp: true)
-            return cell
-
-        case .unsubscribedParticipantsOfferHelpCell(let count):
-            let cell = tableView.dequeueReusableCell(withIdentifier: "UnsubscribedCell", for: indexPath) as! NeighborhoodUnsubscribedParticipantsCell
-            cell.selectionStyle = .none
-            cell.configure(count: count, isAskForHelp: false)
-            return cell
 
         case .searchCell:
             let cell = tableView.dequeueReusableCell(withIdentifier: "cell_search", for: indexPath) as! NeighborhoodHomeSearchCell
@@ -426,7 +473,7 @@ extension NeighBorhoodEventListUsersViewController: UITableViewDataSource, UITab
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch tableData[indexPath.row] {
-        case .searchCell, .surveySection, .questionCell, .unsubscribedParticipantsHeader, .unsubscribedParticipantsAskHelpCell, .unsubscribedParticipantsOfferHelpCell:
+        case .searchCell, .surveySection, .questionCell:
             return
 
         case .userCell(_, _):
@@ -640,12 +687,17 @@ extension NeighBorhoodEventListUsersViewController: NeighborhoodUserCellDelegate
 extension NeighBorhoodEventListUsersViewController: FloatyDelegate {
     func emptyFloatySelected(_ floaty: Floaty) {
         let bottomSheet = UnsubscribedParticipantsBottomSheet()
-        bottomSheet.initialAskCount = event?.unsubscribed_participants_ask_for_help ?? 0
-        bottomSheet.initialOfferCount = event?.unsubscribed_participants_offer_help ?? 0
+
+        let initialAskStr = event?.metadata?.unsubscribed_participants_ask_for_help ?? "0"
+        let initialOfferStr = event?.metadata?.unsubscribed_participants_offer_help ?? "0"
+
+        bottomSheet.initialAskCount = Int(initialAskStr) ?? 0
+        bottomSheet.initialOfferCount = Int(initialOfferStr) ?? 0
 
         bottomSheet.onDismiss = { [weak self] in
             // Trigger refresh when sheet is dismissed
             NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: kNotificationEventUpdate), object: nil)
         }
         bottomSheet.onValidate = { [weak self] (offerCount, askCount) in
             guard let self = self, let eventId = self.event?.uid else { return }
@@ -656,9 +708,14 @@ extension NeighBorhoodEventListUsersViewController: FloatyDelegate {
                 if let error = error {
                     SVProgressHUD.showError(withStatus: error.message)
                 } else {
-                    self.event?.unsubscribed_participants_ask_for_help = askCount
-                    self.event?.unsubscribed_participants_offer_help = offerCount
+                    if self.event?.metadata == nil {
+                        self.event?.metadata = EventMetadata()
+                    }
+                    self.event?.metadata?.unsubscribed_participants_ask_for_help = String(askCount)
+                    self.event?.metadata?.unsubscribed_participants_offer_help = String(offerCount)
                     self.rebuildTableDataFromUsers()
+                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
+                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: kNotificationEventUpdate), object: nil)
                 }
             }
         }
@@ -686,6 +743,8 @@ extension NeighBorhoodEventListUsersViewController: FloatyDelegate {
 // MARK: - MJNavBackViewDelegate
 extension NeighBorhoodEventListUsersViewController: MJNavBackViewDelegate {
     func goBack() {
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: kNotificationEventUpdate), object: nil)
         self.navigationController?.dismiss(animated: true)
     }
     func didTapEvent() { /* no-op */ }

--- a/patch_f.diff
+++ b/patch_f.diff
@@ -1,0 +1,13 @@
+<<<<<<< SEARCH
+    func goBack() {
+        self.navigationController?.dismiss(animated: true) {
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
+        }
+    }
+=======
+    func goBack() {
+        self.navigationController?.dismiss(animated: true) {
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
+        }
+    }
+>>>>>>> REPLACE

--- a/patch_models.diff
+++ b/patch_models.diff
@@ -1,0 +1,79 @@
+<<<<<<< SEARCH
+    var manageableByCurrentUser:Bool? = false
+
+    var unsubscribed_participants_ask_for_help: Int? = 0
+    var unsubscribed_participants_offer_help: Int? = 0
+
+    private var statusChangedAt:String? = nil
+=======
+    var manageableByCurrentUser:Bool? = false
+
+    private var statusChangedAt:String? = nil
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+        case imageId = "entourage_image_id"
+
+        case recurrency
+        case unsubscribed_participants_ask_for_help
+        case unsubscribed_participants_offer_help
+        case membersCount = "members_count"
+=======
+        case imageId = "entourage_image_id"
+
+        case recurrency
+        case membersCount = "members_count"
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    var reservedFemale: Bool? = false
+
+    var hasPlaceLimit: Bool? {
+=======
+    var reservedFemale: Bool? = false
+    var unsubscribed_participants_ask_for_help: String? = "0"
+    var unsubscribed_participants_offer_help: String? = "0"
+
+    var hasPlaceLimit: Bool? {
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+        case place_limit
+        case portrait_url
+        case landscape_url
+        case reservedFemale = "reserved_female"
+    }
+=======
+        case place_limit
+        case portrait_url
+        case landscape_url
+        case reservedFemale = "reserved_female"
+        case unsubscribed_participants_ask_for_help
+        case unsubscribed_participants_offer_help
+    }
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+        portrait_url = try container.decodeIfPresent(String.self, forKey: .portrait_url)
+        landscape_url = try container.decodeIfPresent(String.self, forKey: .landscape_url)
+
+        // C'EST ICI QUE LA MAGIE OPÈRE ✨
+=======
+        portrait_url = try container.decodeIfPresent(String.self, forKey: .portrait_url)
+        landscape_url = try container.decodeIfPresent(String.self, forKey: .landscape_url)
+
+        // Same logic as reservedFemale but for unsubscribed_participants which can be int or string
+        if let intValue = try? container.decodeIfPresent(Int.self, forKey: .unsubscribed_participants_ask_for_help) {
+            unsubscribed_participants_ask_for_help = String(intValue)
+        } else if let stringValue = try? container.decodeIfPresent(String.self, forKey: .unsubscribed_participants_ask_for_help) {
+            unsubscribed_participants_ask_for_help = stringValue
+        } else {
+            unsubscribed_participants_ask_for_help = "0"
+        }
+
+        if let intValue = try? container.decodeIfPresent(Int.self, forKey: .unsubscribed_participants_offer_help) {
+            unsubscribed_participants_offer_help = String(intValue)
+        } else if let stringValue = try? container.decodeIfPresent(String.self, forKey: .unsubscribed_participants_offer_help) {
+            unsubscribed_participants_offer_help = stringValue
+        } else {
+            unsubscribed_participants_offer_help = "0"
+        }
+
+        // C'EST ICI QUE LA MAGIE OPÈRE ✨
+>>>>>>> REPLACE

--- a/patch_params.diff
+++ b/patch_params.diff
@@ -1,0 +1,21 @@
+<<<<<<< SEARCH
+    func showMembers() {
+        if let navVC = UIStoryboard(name: StoryboardName.neighborhood, bundle: nil)
+            .instantiateViewController(withIdentifier: "users_groupNav") as? UINavigationController,
+           let vc = navVC.topViewController as? NeighBorhoodEventListUsersViewController {
+            vc.event = event
+            vc.isEvent = true
+            self.present(navVC, animated: true, completion: nil)
+        }
+    }
+=======
+    func showMembers() {
+        if let navVC = UIStoryboard(name: StoryboardName.neighborhood, bundle: nil)
+            .instantiateViewController(withIdentifier: "users_groupNav") as? UINavigationController,
+           let vc = navVC.topViewController as? NeighBorhoodEventListUsersViewController {
+            vc.event = event
+            vc.isEvent = true
+            self.present(navVC, animated: true, completion: nil)
+        }
+    }
+>>>>>>> REPLACE

--- a/patch_v.diff
+++ b/patch_v.diff
@@ -1,0 +1,32 @@
+<<<<<<< SEARCH
+        bottomSheet.onDismiss = { [weak self] in
+            // Trigger refresh when sheet is dismissed
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: kNotificationEventUpdate), object: nil)
+        }
+=======
+        bottomSheet.onDismiss = { [weak self] in
+            // Trigger refresh when sheet is dismissed
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: kNotificationEventUpdate), object: nil)
+        }
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+                    self.rebuildTableDataFromUsers()
+                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: kNotificationEventUpdate), object: nil)
+=======
+                    self.rebuildTableDataFromUsers()
+                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
+                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: kNotificationEventUpdate), object: nil)
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    func goBack() {
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: kNotificationEventUpdate), object: nil)
+        self.navigationController?.dismiss(animated: true)
+    }
+=======
+    func goBack() {
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: kNotificationEventUpdate), object: nil)
+        self.navigationController?.dismiss(animated: true)
+    }
+>>>>>>> REPLACE

--- a/patch_vc.diff
+++ b/patch_vc.diff
@@ -1,0 +1,275 @@
+<<<<<<< SEARCH
+    case unsubscribedParticipantsHeader
+    case unsubscribedParticipantsAskHelpCell(count: Int)
+    case unsubscribedParticipantsOfferHelpCell(count: Int)
+}
+
+class NeighBorhoodEventListUsersViewController: BasePopViewController {
+
+    @IBOutlet weak var ui_tableview: UITableView!
+    @IBOutlet weak var ui_lb_no_result: UILabel!
+    @IBOutlet weak var ui_view_no_result: UIView!
+    @IBOutlet weak var ui_floaty_button: Floaty!
+=======
+}
+
+class NeighBorhoodEventListUsersViewController: BasePopViewController {
+
+    @IBOutlet weak var ui_tableview: UITableView!
+    @IBOutlet weak var ui_lb_no_result: UILabel!
+    @IBOutlet weak var ui_view_no_result: UIView!
+    @IBOutlet weak var ui_floaty_button: Floaty!
+
+    // Bottom stack view components
+    let unsubscribedStackView = UIStackView()
+    let headerView = UIView()
+    let askForHelpCell = NeighborhoodUnsubscribedParticipantsCell(style: .default, reuseIdentifier: nil)
+    let offerHelpCell = NeighborhoodUnsubscribedParticipantsCell(style: .default, reuseIdentifier: nil)
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+        ui_tableview.register(UINib(nibName: SectionOptionNameCell.identifier, bundle: nil), forCellReuseIdentifier: SectionOptionNameCell.identifier)
+        ui_tableview.register(UINib(nibName: QuestionSurveyVoteCell.identifier, bundle: nil), forCellReuseIdentifier: QuestionSurveyVoteCell.identifier)
+        ui_tableview.register(NeighborhoodUnsubscribedParticipantsHeaderCell.self, forCellReuseIdentifier: "UnsubscribedHeaderCell")
+        ui_tableview.register(NeighborhoodUnsubscribedParticipantsCell.self, forCellReuseIdentifier: "UnsubscribedCell")
+
+        setupFloaty()
+=======
+        ui_tableview.register(UINib(nibName: SectionOptionNameCell.identifier, bundle: nil), forCellReuseIdentifier: SectionOptionNameCell.identifier)
+        ui_tableview.register(UINib(nibName: QuestionSurveyVoteCell.identifier, bundle: nil), forCellReuseIdentifier: QuestionSurveyVoteCell.identifier)
+
+        setupBottomViews()
+        setupFloaty()
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    private func rebuildTableDataFromUsers() {
+        tableData = [.searchCell] + users.map { .userCell(user: $0, reactionType: nil) }
+
+        if isEvent, let event = event {
+            let askForHelp = event.unsubscribed_participants_ask_for_help ?? 0
+            let offerHelp = event.unsubscribed_participants_offer_help ?? 0
+
+            if askForHelp > 0 || offerHelp > 0 {
+                tableData.append(.unsubscribedParticipantsHeader)
+                if askForHelp > 0 {
+                    tableData.append(.unsubscribedParticipantsAskHelpCell(count: askForHelp))
+                }
+                if offerHelp > 0 {
+                    tableData.append(.unsubscribedParticipantsOfferHelpCell(count: offerHelp))
+                }
+            }
+        }
+
+        ui_tableview.reloadData()
+    }
+=======
+    private func rebuildTableDataFromUsers() {
+        tableData = [.searchCell] + users.map { .userCell(user: $0, reactionType: nil) }
+
+        ui_tableview.reloadData()
+        updateUnsubscribedBottomViews()
+    }
+
+    private func setupBottomViews() {
+        guard isEvent else { return }
+
+        unsubscribedStackView.axis = .vertical
+        unsubscribedStackView.distribution = .fill
+        unsubscribedStackView.alignment = .fill
+        unsubscribedStackView.backgroundColor = .clear
+        unsubscribedStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        self.view.addSubview(unsubscribedStackView)
+
+        NSLayoutConstraint.activate([
+            unsubscribedStackView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            unsubscribedStackView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            unsubscribedStackView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+
+        // Add padding to bottom of tableview so content is not hidden
+        ui_tableview.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 150, right: 0)
+
+        // Header
+        headerView.backgroundColor = .clear
+        let titleLabel = UILabel()
+        titleLabel.font = ApplicationTheme.getFontNunitoBold(size: 13)
+        titleLabel.textColor = .black
+        titleLabel.text = "PARTICIPANTS AJOUTÉS SUR PLACE"
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        headerView.addSubview(titleLabel)
+
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 32),
+            titleLabel.topAnchor.constraint(equalTo: headerView.topAnchor, constant: 16),
+            titleLabel.bottomAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -8)
+        ])
+
+        unsubscribedStackView.addArrangedSubview(headerView)
+        unsubscribedStackView.addArrangedSubview(askForHelpCell)
+        unsubscribedStackView.addArrangedSubview(offerHelpCell)
+
+        askForHelpCell.selectionStyle = .none
+        offerHelpCell.selectionStyle = .none
+
+        // Initially hidden
+        unsubscribedStackView.isHidden = true
+    }
+
+    private func updateUnsubscribedBottomViews() {
+        guard isEvent, let event = event else { return }
+
+        let askForHelpStr = event.metadata?.unsubscribed_participants_ask_for_help ?? "0"
+        let offerHelpStr = event.metadata?.unsubscribed_participants_offer_help ?? "0"
+
+        let askForHelp = Int(askForHelpStr) ?? 0
+        let offerHelp = Int(offerHelpStr) ?? 0
+
+        if askForHelp > 0 || offerHelp > 0 {
+            unsubscribedStackView.isHidden = false
+
+            askForHelpCell.isHidden = (askForHelp <= 0)
+            if askForHelp > 0 {
+                askForHelpCell.configure(count: askForHelp, isAskForHelp: true)
+            }
+
+            offerHelpCell.isHidden = (offerHelp <= 0)
+            if offerHelp > 0 {
+                offerHelpCell.configure(count: offerHelp, isAskForHelp: false)
+            }
+
+            let totalCells = (askForHelp > 0 ? 1 : 0) + (offerHelp > 0 ? 1 : 0)
+            ui_tableview.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: CGFloat(50 + (totalCells * 60)), right: 0)
+        } else {
+            unsubscribedStackView.isHidden = true
+            ui_tableview.contentInset = UIEdgeInsets.zero
+        }
+    }
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        let isUnsubscribedHeader = {
+            if indexPath.row < self.tableData.count {
+                if case .unsubscribedParticipantsHeader = self.tableData[indexPath.row] { return true }
+                if case .unsubscribedParticipantsAskHelpCell = self.tableData[indexPath.row] { return true }
+                if case .unsubscribedParticipantsOfferHelpCell = self.tableData[indexPath.row] { return true }
+            }
+            return false
+        }()
+
+        if indexPath.row < 1 || isUnsubscribedHeader {
+            cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: cell.bounds.width)
+        } else {
+            cell.separatorInset = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)
+        }
+=======
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if indexPath.row < 1 {
+            cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: cell.bounds.width)
+        } else {
+            cell.separatorInset = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 15)
+        }
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+        switch tableData[indexPath.row] {
+
+        case .unsubscribedParticipantsHeader:
+            let cell = tableView.dequeueReusableCell(withIdentifier: "UnsubscribedHeaderCell", for: indexPath) as! NeighborhoodUnsubscribedParticipantsHeaderCell
+            cell.selectionStyle = .none
+            return cell
+
+        case .unsubscribedParticipantsAskHelpCell(let count):
+            let cell = tableView.dequeueReusableCell(withIdentifier: "UnsubscribedCell", for: indexPath) as! NeighborhoodUnsubscribedParticipantsCell
+            cell.selectionStyle = .none
+            cell.configure(count: count, isAskForHelp: true)
+            return cell
+
+        case .unsubscribedParticipantsOfferHelpCell(let count):
+            let cell = tableView.dequeueReusableCell(withIdentifier: "UnsubscribedCell", for: indexPath) as! NeighborhoodUnsubscribedParticipantsCell
+            cell.selectionStyle = .none
+            cell.configure(count: count, isAskForHelp: false)
+            return cell
+
+        case .searchCell:
+=======
+        switch tableData[indexPath.row] {
+
+        case .searchCell:
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch tableData[indexPath.row] {
+        case .searchCell, .surveySection, .questionCell, .unsubscribedParticipantsHeader, .unsubscribedParticipantsAskHelpCell, .unsubscribedParticipantsOfferHelpCell:
+            return
+=======
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch tableData[indexPath.row] {
+        case .searchCell, .surveySection, .questionCell:
+            return
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+        let bottomSheet = UnsubscribedParticipantsBottomSheet()
+        bottomSheet.initialAskCount = event?.unsubscribed_participants_ask_for_help ?? 0
+        bottomSheet.initialOfferCount = event?.unsubscribed_participants_offer_help ?? 0
+
+        bottomSheet.onDismiss = { [weak self] in
+            // Trigger refresh when sheet is dismissed
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
+        }
+        bottomSheet.onValidate = { [weak self] (offerCount, askCount) in
+            guard let self = self, let eventId = self.event?.uid else { return }
+
+            SVProgressHUD.show()
+            EventService.updateUnsubscribedParticipants(eventId: eventId, offerHelp: offerCount, askForHelp: askCount) { error in
+                SVProgressHUD.dismiss()
+                if let error = error {
+                    SVProgressHUD.showError(withStatus: error.message)
+                } else {
+                    self.event?.unsubscribed_participants_ask_for_help = askCount
+                    self.event?.unsubscribed_participants_offer_help = offerCount
+                    self.rebuildTableDataFromUsers()
+                }
+            }
+        }
+=======
+        let bottomSheet = UnsubscribedParticipantsBottomSheet()
+
+        let initialAskStr = event?.metadata?.unsubscribed_participants_ask_for_help ?? "0"
+        let initialOfferStr = event?.metadata?.unsubscribed_participants_offer_help ?? "0"
+
+        bottomSheet.initialAskCount = Int(initialAskStr) ?? 0
+        bottomSheet.initialOfferCount = Int(initialOfferStr) ?? 0
+
+        bottomSheet.onDismiss = { [weak self] in
+            // Trigger refresh when sheet is dismissed
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: kNotificationEventUpdate), object: nil)
+        }
+        bottomSheet.onValidate = { [weak self] (offerCount, askCount) in
+            guard let self = self, let eventId = self.event?.uid else { return }
+
+            SVProgressHUD.show()
+            EventService.updateUnsubscribedParticipants(eventId: eventId, offerHelp: offerCount, askForHelp: askCount) { error in
+                SVProgressHUD.dismiss()
+                if let error = error {
+                    SVProgressHUD.showError(withStatus: error.message)
+                } else {
+                    if self.event?.metadata == nil {
+                        self.event?.metadata = EventMetadata()
+                    }
+                    self.event?.metadata?.unsubscribed_participants_ask_for_help = String(askCount)
+                    self.event?.metadata?.unsubscribed_participants_offer_help = String(offerCount)
+                    self.rebuildTableDataFromUsers()
+                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: kNotificationEventUpdate), object: nil)
+                }
+            }
+        }
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    func goBack() {
+        self.navigationController?.dismiss(animated: true)
+    }
+=======
+    func goBack() {
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: kNotificationEventUpdate), object: nil)
+        self.navigationController?.dismiss(animated: true)
+    }
+>>>>>>> REPLACE

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,33 @@
+1.  **Refactor `NeighBorhoodEventListUsersViewController` to decouple unsubscribed elements from the table view:**
+    - Open `Neighborhood.storyboard` and modify the `users_groupVC` (`NeighBorhoodEventListUsersViewController`) layout.
+    - Reduce the bottom anchor constraint of `ui_tableview` to make room for a new stack view.
+    - Add a `UIStackView` (e.g. `ui_stack_unsubscribed`) at the bottom of the container view (`ui_view_container`), just above the safe area or fixed offset. This will be an exact replica of the unsubscribed cell logic but statically positioned beneath the `UITableView`.
+    - Update the view controller to use UIViews instead of appending them to `tableData`.
+    - Remove the enumeration cases `unsubscribedParticipantsHeader`, `unsubscribedParticipantsAskHelpCell`, and `unsubscribedParticipantsOfferHelpCell` from `TableDTO`.
+    - Remove the related row/cell logic from `UITableViewDataSource` and `UITableViewDelegate` implementations.
+    - Setup the UI views for the bottom area dynamically based on `event?.unsubscribed_participants_ask_for_help` and `event?.unsubscribed_participants_offer_help` values when rebuilding table data. Ensure they only display when these are `> 0`.
+    - Remove unused cells: `NeighborhoodUnsubscribedParticipantsCell`, `NeighborhoodUnsubscribedParticipantsHeaderCell`.
+
+2.  **Fix data transfer and refresh issue:**
+    - The issue states that when returning from `NeighBorhoodEventListUsersViewController`, the information is lost. This happens because the updated `Event` data isn't fetched when we return.
+    - Since `EventDetailFeedViewController`, `EventDetailFullFeedViewController`, and `EventParamsViewController` all open this controller via `present`, we can trigger an event refresh when dismissing `NeighBorhoodEventListUsersViewController`.
+    - However, `NeighBorhoodEventListUsersViewController` already does this for bottom sheet! It posts `NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)`.
+    - Also, `EventDetailFeedViewController` is the only one listening to `"RefreshEventDetail"`. We need to make sure `EventDetailFullFeedViewController` and `EventParamsViewController` also listen to it and update their event models, or we ensure the updated data is transferred differently. Actually, a better approach is to make sure when the `NeighBorhoodEventListUsersViewController` updates the participants by adding or from floaty, the global `kNotificationEventUpdate` is sent, or `EventService.getEventWithId` is called inside `viewWillAppear` or similar. Let's look at `EventParamsViewController`, it listens to `kNotificationEventUpdate` and reloads. `EventDetailFullFeedViewController` doesn't seem to listen.
+    - Let's make `NeighBorhoodEventListUsersViewController` post `kNotificationEventUpdate` upon validating the unsubscribed participants bottom sheet, instead of just `RefreshEventDetail`. Wait, it posts `RefreshEventDetail` when dismissed.
+    - Actually, wait, the problem is simpler: when going TO `NeighBorhoodEventListUsersViewController`, the parent injects its *current* `event` object (`vc.event = event`). If the parent hasn't reloaded the event from the API after the last modification, the passed `event` will have old data!
+    - To fix this properly, let's make `NeighBorhoodEventListUsersViewController` fetch the event details again upon opening, OR have the parent fetch when appearing.
+    - But `NeighBorhoodEventListUsersViewController` already does `EventService.getEventUsers` - it doesn't do `getEventDetail` to get the latest unsubscribed counts!
+    - So, in `NeighBorhoodEventListUsersViewController.viewDidLoad` (or `viewWillAppear`), if `isEvent` is true and `event != nil`, let's do a quick `EventService.getEventWithId` to fetch the latest `unsubscribed_participants_offer_help` and `unsubscribed_participants_ask_for_help`, then build the views. Wait, that would require passing `eventId` which we do have.
+    - Or even simpler: the issue description says: "Actuellement, ces vues ne s'affiche que lorsqu'on vient d'ajouter des membre, si on retourne ca s'affiche plus. Il faudrait transférer l'info de eventDetail a MemberList, quand on envoi dessus, pour que ca se set bien. Egalement, quand on part de Memberlist, re init la vue EventDetail, relancer l'appel et reset la view. pour que quand on renvoi on ait bien les champs."
+    - This translates directly to:
+        1. When going from EventDetail -> MemberList (`NeighBorhoodEventListUsersViewController`), ensure we transfer the fields (it is done by `vc.event = event`).
+        2. When leaving MemberList -> EventDetail, trigger a refresh of EventDetail so it gets the new fields (post a notification that EventDetail listens to).
+        3. Make sure EventDetail's event parsing actually saves those fields properly. Looking at `Event.swift`, `unsubscribed_participants_offer_help` is decoded but wait - the default custom `init(from decoder: Decoder)` in `Event` doesn't decode `unsubscribed_participants_offer_help` or `unsubscribed_participants_ask_for_help`! Wait! I checked `init(from decoder:)` and it's ONLY for `EventMetadata`! No, `Event` doesn't have a custom init. Wait, `Event` has `CodingKeys`.
+        4. Ah, wait. `EventService.getEventWithId` uses `parseData` -> which uses standard Decodable. Does `Event` decode it properly? Let's verify `CodingKeys` in `Event`. Yes, they are in `CodingKeys`.
+        5. Let's make sure that when `NeighBorhoodEventListUsersViewController` disappears or updates, it notifies `EventDetailFeedViewController` to update.
+
+3.  **Execute the fixes:**
+    - I'll create a sticky bottom view in `NeighBorhoodEventListUsersViewController`.
+    - I'll make sure to trigger `kNotificationEventUpdate` or call the appropriate refresh function when `NeighBorhoodEventListUsersViewController` updates the values or disappears, and make sure `EventDetailFeedViewController` catches it and calls `getEventDetail(hasToRefreshLists: true)`.
+
+4.  **Pre commit check**


### PR DESCRIPTION
- Refactored `NeighBorhoodEventListUsersViewController` to display `unsubscribed_participants_ask_for_help` and `unsubscribed_participants_offer_help` inside a fixed `UIStackView` at the bottom, removing them from the scrolling list.
- Fixed the API mapping bug where these fields were expected at the root of `Event` instead of inside `metadata`.
- Added robust decoding logic for the `unsubscribed_participants` fields since the API can return them as strings or integers.
- Synchronized navigation updates to post `RefreshEventDetail` and `kNotificationEventUpdate` locally upon dismissal, ensuring that all upstream view controllers re-fetch event details correctly.

---
*PR created automatically by Jules for task [8436383886938644455](https://jules.google.com/task/8436383886938644455) started by @clemPerrousset*