### PR TITLE
Add "femmes isolées" to unsubscribed participants

### DIFF
--- a/entourage/Models/Event.swift
+++ b/entourage/Models/Event.swift
@@ -406,6 +406,7 @@ struct EventMetadata: Codable {
     var reservedFemale: Bool? = false
     var unsubscribed_participants_ask_for_help: String? = "0"
     var unsubscribed_participants_offer_help: String? = "0"
+    var unsubscribed_participants_female: String? = "0"
     
     var hasPlaceLimit: Bool? {
         get {
@@ -429,6 +430,7 @@ struct EventMetadata: Codable {
         case reservedFemale = "reserved_female"
         case unsubscribed_participants_ask_for_help
         case unsubscribed_participants_offer_help
+        case unsubscribed_participants_female
     }
     
     // 1. On garde un initialiseur vide par défaut pour ne pas casser le reste du code
@@ -463,6 +465,14 @@ struct EventMetadata: Codable {
             unsubscribed_participants_offer_help = stringValue
         } else {
             unsubscribed_participants_offer_help = "0"
+        }
+
+        if let intValue = try? container.decodeIfPresent(Int.self, forKey: .unsubscribed_participants_female) {
+            unsubscribed_participants_female = String(intValue)
+        } else if let stringValue = try? container.decodeIfPresent(String.self, forKey: .unsubscribed_participants_female) {
+            unsubscribed_participants_female = stringValue
+        } else {
+            unsubscribed_participants_female = "0"
         }
 
         // C'EST ICI QUE LA MAGIE OPÈRE ✨

--- a/entourage/Network Managers/Endpoints.swift
+++ b/entourage/Network Managers/Endpoints.swift
@@ -125,7 +125,7 @@ let kAPIParticipateForUser           = "outings/%@/users/%@/participate?token=%@
 let kAPIAcceptPhotoForUser           = "outings/%@/users/%@/photo_acceptance?token=%@"
 let kAPICancelPhotoForUser           = "outings/%@/users/%@/cancel_photo_acceptance?token=%@"
 let kAPICancelParticipationForUser   = "outings/%@/users/%@/cancel_participation?token=%@"
-let kAPIUpdateUnsubscribedParticipants = "outings/%@/users/unsubscribed_participants?token=%@&offer_help=%d&ask_for_help=%d"
+let kAPIUpdateUnsubscribedParticipants = "outings/%@/users/unsubscribed_participants?token=%@&offer_help=%d&ask_for_help=%d&female=%d"
 
 let kAPIOutingsCount = "outings/count?token=%@&within_days=%d&travel_distance=%.2f&latitude=%.6f&longitude=%.6f"
 let kAPIOutingsWeekAverage = "outings/week_average?token=%@&travel_distance=%.2f&latitude=%.6f&longitude=%.6f"

--- a/entourage/Network Managers/EventService.swift
+++ b/entourage/Network Managers/EventService.swift
@@ -817,10 +817,10 @@ struct EventService:ParsingDataCodable {
         }
     }
 
-    static func updateUnsubscribedParticipants(eventId: Int, offerHelp: Int, askForHelp: Int, completion: @escaping (_ error: EntourageNetworkError?) -> Void) {
+    static func updateUnsubscribedParticipants(eventId: Int, offerHelp: Int, askForHelp: Int, female: Int, completion: @escaping (_ error: EntourageNetworkError?) -> Void) {
         guard let token = UserDefaults.token else { return }
         var endpoint = kAPIUpdateUnsubscribedParticipants
-        endpoint = String(format: endpoint, "\(eventId)", token, offerHelp, askForHelp)
+        endpoint = String(format: endpoint, "\(eventId)", token, offerHelp, askForHelp, female)
 
         Logger.print("Endpoint updateUnsubscribedParticipants: \(endpoint)")
 

--- a/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
@@ -121,6 +121,7 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
                 guard let self = self, let event = event else { return }
                 self.event?.metadata?.unsubscribed_participants_ask_for_help = event.metadata?.unsubscribed_participants_ask_for_help
                 self.event?.metadata?.unsubscribed_participants_offer_help = event.metadata?.unsubscribed_participants_offer_help
+                self.event?.metadata?.unsubscribed_participants_female = event.metadata?.unsubscribed_participants_female
                 self.updateUnsubscribedBottomViews()
             }
         }
@@ -261,10 +262,12 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
 
         let askForHelp = Int(event.metadata?.unsubscribed_participants_ask_for_help ?? "0") ?? 0
         let offerHelp = Int(event.metadata?.unsubscribed_participants_offer_help ?? "0") ?? 0
+        let femaleCount = Int(event.metadata?.unsubscribed_participants_female ?? "0") ?? 0
 
         // Met à jour l'interface SwiftUI
         bottomViewModel.askCount = askForHelp
         bottomViewModel.offerCount = offerHelp
+        bottomViewModel.femaleCount = femaleCount
 
         // Ajuste le padding de la tableView pour pouvoir scroller jusqu'au bout
         DispatchQueue.main.async { [weak self] in
@@ -282,19 +285,21 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
 
         let initialAskStr = event?.metadata?.unsubscribed_participants_ask_for_help ?? "0"
         let initialOfferStr = event?.metadata?.unsubscribed_participants_offer_help ?? "0"
+        let initialFemaleStr = event?.metadata?.unsubscribed_participants_female ?? "0"
 
         bottomSheet.initialAskCount = Int(initialAskStr) ?? 0
         bottomSheet.initialOfferCount = Int(initialOfferStr) ?? 0
+        bottomSheet.initialFemaleCount = Int(initialFemaleStr) ?? 0
 
         bottomSheet.onDismiss = {
             NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)
             NotificationCenter.default.post(name: NSNotification.Name(rawValue: kNotificationEventUpdate), object: nil)
         }
-        bottomSheet.onValidate = { [weak self] (offerCount, askCount) in
+        bottomSheet.onValidate = { [weak self] (offerCount, askCount, femaleCount) in
             guard let self = self, let eventId = self.event?.uid else { return }
 
             SVProgressHUD.show()
-            EventService.updateUnsubscribedParticipants(eventId: eventId, offerHelp: offerCount, askForHelp: askCount) { error in
+            EventService.updateUnsubscribedParticipants(eventId: eventId, offerHelp: offerCount, askForHelp: askCount, female: femaleCount) { error in
                 SVProgressHUD.dismiss()
                 if let error = error {
                     SVProgressHUD.showError(withStatus: error.message)
@@ -302,6 +307,7 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
                     if self.event?.metadata == nil { self.event?.metadata = EventMetadata() }
                     self.event?.metadata?.unsubscribed_participants_ask_for_help = String(askCount)
                     self.event?.metadata?.unsubscribed_participants_offer_help = String(offerCount)
+                    self.event?.metadata?.unsubscribed_participants_female = String(femaleCount)
                     
                     self.updateUnsubscribedBottomViews()
                     
@@ -681,6 +687,7 @@ extension Collection {
 class UnsubscribedViewModel: ObservableObject {
     @Published var askCount: Int = 0
     @Published var offerCount: Int = 0
+    @Published var femaleCount: Int = 0
     @Published var showFab: Bool = false
     var onFabTapped: (() -> Void)?
 }
@@ -692,7 +699,7 @@ struct UnsubscribedBottomSwiftUIView: View {
         ZStack(alignment: .bottomTrailing) {
             
             // 1. Fond blanc et contenu textuel (Sticky View)
-            if viewModel.askCount > 0 || viewModel.offerCount > 0 {
+            if viewModel.askCount > 0 || viewModel.offerCount > 0 || viewModel.femaleCount > 0 {
                 VStack(alignment: .leading, spacing: 0) {
                     Divider()
                         .background(Color.clear)
@@ -713,6 +720,11 @@ struct UnsubscribedBottomSwiftUIView: View {
                     if viewModel.offerCount > 0 {
                         let title = viewModel.offerCount > 1 ? "riverains" : "riverain"
                         ParticipantRow(count: viewModel.offerCount, title: title)
+                    }
+
+                    if viewModel.femaleCount > 0 {
+                        let title = viewModel.femaleCount > 1 ? "femmes isolées" : "femme isolée"
+                        ParticipantRow(count: viewModel.femaleCount, title: title)
                     }
                     
                     // 🔥 On force un grand espace en bas de la Stack pour contourner la ligne/encoche système de l'iPhone

--- a/entourage/Scenes/Groups - Neighborhoods/UnsubscribedParticipantsBottomSheet.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/UnsubscribedParticipantsBottomSheet.swift
@@ -17,10 +17,16 @@ class UnsubscribedParticipantsBottomSheet: UIViewController {
     private let helpOfferPlusButton = UIButton()
     private let helpOfferCountLabel = UILabel()
 
+    private let helpFemaleLabel = UILabel()
+    private let helpFemaleMinusButton = UIButton()
+    private let helpFemalePlusButton = UIButton()
+    private let helpFemaleCountLabel = UILabel()
+
     private let validateButton = UIButton()
 
     var initialAskCount: Int = 0
     var initialOfferCount: Int = 0
+    var initialFemaleCount: Int = 0
 
     private var currentAskCount: Int = 0 {
         didSet {
@@ -34,7 +40,13 @@ class UnsubscribedParticipantsBottomSheet: UIViewController {
         }
     }
 
-    var onValidate: ((Int, Int) -> Void)?
+    private var currentFemaleCount: Int = 0 {
+        didSet {
+            helpFemaleCountLabel.text = "\(currentFemaleCount)"
+        }
+    }
+
+    var onValidate: ((Int, Int, Int) -> Void)?
     var onDismiss: (() -> Void)?
 
     override func viewDidLoad() {
@@ -42,6 +54,7 @@ class UnsubscribedParticipantsBottomSheet: UIViewController {
         setupUI()
         currentAskCount = initialAskCount
         currentOfferCount = initialOfferCount
+        currentFemaleCount = initialFemaleCount
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -98,6 +111,15 @@ class UnsubscribedParticipantsBottomSheet: UIViewController {
 
         setupCounter(minusBtn: helpOfferMinusButton, plusBtn: helpOfferPlusButton, countLabel: helpOfferCountLabel, yAnchorView: helpOfferLabel)
 
+        helpFemaleLabel.text = "Combien de femmes isolées supplémentaires ont rejoint l'événement ?"
+        helpFemaleLabel.font = ApplicationTheme.getFontCourantRegularNoir().font
+        helpFemaleLabel.textColor = .black
+        helpFemaleLabel.numberOfLines = 0
+        helpFemaleLabel.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(helpFemaleLabel)
+
+        setupCounter(minusBtn: helpFemaleMinusButton, plusBtn: helpFemalePlusButton, countLabel: helpFemaleCountLabel, yAnchorView: helpFemaleLabel)
+
         validateButton.setTitle("Valider", for: .normal)
         validateButton.backgroundColor = UIColor.appOrange
         validateButton.setTitleColor(.white, for: .normal)
@@ -121,7 +143,11 @@ class UnsubscribedParticipantsBottomSheet: UIViewController {
             helpOfferLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
             helpOfferLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
 
-            validateButton.topAnchor.constraint(equalTo: helpOfferLabel.bottomAnchor, constant: 100),
+            helpFemaleLabel.topAnchor.constraint(equalTo: helpOfferLabel.bottomAnchor, constant: 90),
+            helpFemaleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            helpFemaleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+
+            validateButton.topAnchor.constraint(equalTo: helpFemaleLabel.bottomAnchor, constant: 100),
             validateButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
             validateButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
             validateButton.heightAnchor.constraint(equalToConstant: 50),
@@ -133,6 +159,9 @@ class UnsubscribedParticipantsBottomSheet: UIViewController {
 
         helpOfferMinusButton.addTarget(self, action: #selector(offerMinusAction), for: .touchUpInside)
         helpOfferPlusButton.addTarget(self, action: #selector(offerPlusAction), for: .touchUpInside)
+
+        helpFemaleMinusButton.addTarget(self, action: #selector(femaleMinusAction), for: .touchUpInside)
+        helpFemalePlusButton.addTarget(self, action: #selector(femalePlusAction), for: .touchUpInside)
     }
 
     private func setupCounter(minusBtn: UIButton, plusBtn: UIButton, countLabel: UILabel, yAnchorView: UIView) {
@@ -191,8 +220,18 @@ class UnsubscribedParticipantsBottomSheet: UIViewController {
         currentOfferCount += 1
     }
 
+    @objc private func femaleMinusAction() {
+        if currentFemaleCount > 0 {
+            currentFemaleCount -= 1
+        }
+    }
+
+    @objc private func femalePlusAction() {
+        currentFemaleCount += 1
+    }
+
     @objc private func validateAction() {
-        onValidate?(currentOfferCount, currentAskCount)
+        onValidate?(currentOfferCount, currentAskCount, currentFemaleCount)
         dismiss(animated: true)
     }
 }

--- a/plan.md
+++ b/plan.md
@@ -1,33 +1,23 @@
-1.  **Refactor `NeighBorhoodEventListUsersViewController` to decouple unsubscribed elements from the table view:**
-    - Open `Neighborhood.storyboard` and modify the `users_groupVC` (`NeighBorhoodEventListUsersViewController`) layout.
-    - Reduce the bottom anchor constraint of `ui_tableview` to make room for a new stack view.
-    - Add a `UIStackView` (e.g. `ui_stack_unsubscribed`) at the bottom of the container view (`ui_view_container`), just above the safe area or fixed offset. This will be an exact replica of the unsubscribed cell logic but statically positioned beneath the `UITableView`.
-    - Update the view controller to use UIViews instead of appending them to `tableData`.
-    - Remove the enumeration cases `unsubscribedParticipantsHeader`, `unsubscribedParticipantsAskHelpCell`, and `unsubscribedParticipantsOfferHelpCell` from `TableDTO`.
-    - Remove the related row/cell logic from `UITableViewDataSource` and `UITableViewDelegate` implementations.
-    - Setup the UI views for the bottom area dynamically based on `event?.unsubscribed_participants_ask_for_help` and `event?.unsubscribed_participants_offer_help` values when rebuilding table data. Ensure they only display when these are `> 0`.
-    - Remove unused cells: `NeighborhoodUnsubscribedParticipantsCell`, `NeighborhoodUnsubscribedParticipantsHeaderCell`.
-
-2.  **Fix data transfer and refresh issue:**
-    - The issue states that when returning from `NeighBorhoodEventListUsersViewController`, the information is lost. This happens because the updated `Event` data isn't fetched when we return.
-    - Since `EventDetailFeedViewController`, `EventDetailFullFeedViewController`, and `EventParamsViewController` all open this controller via `present`, we can trigger an event refresh when dismissing `NeighBorhoodEventListUsersViewController`.
-    - However, `NeighBorhoodEventListUsersViewController` already does this for bottom sheet! It posts `NotificationCenter.default.post(name: NSNotification.Name(rawValue: "RefreshEventDetail"), object: nil)`.
-    - Also, `EventDetailFeedViewController` is the only one listening to `"RefreshEventDetail"`. We need to make sure `EventDetailFullFeedViewController` and `EventParamsViewController` also listen to it and update their event models, or we ensure the updated data is transferred differently. Actually, a better approach is to make sure when the `NeighBorhoodEventListUsersViewController` updates the participants by adding or from floaty, the global `kNotificationEventUpdate` is sent, or `EventService.getEventWithId` is called inside `viewWillAppear` or similar. Let's look at `EventParamsViewController`, it listens to `kNotificationEventUpdate` and reloads. `EventDetailFullFeedViewController` doesn't seem to listen.
-    - Let's make `NeighBorhoodEventListUsersViewController` post `kNotificationEventUpdate` upon validating the unsubscribed participants bottom sheet, instead of just `RefreshEventDetail`. Wait, it posts `RefreshEventDetail` when dismissed.
-    - Actually, wait, the problem is simpler: when going TO `NeighBorhoodEventListUsersViewController`, the parent injects its *current* `event` object (`vc.event = event`). If the parent hasn't reloaded the event from the API after the last modification, the passed `event` will have old data!
-    - To fix this properly, let's make `NeighBorhoodEventListUsersViewController` fetch the event details again upon opening, OR have the parent fetch when appearing.
-    - But `NeighBorhoodEventListUsersViewController` already does `EventService.getEventUsers` - it doesn't do `getEventDetail` to get the latest unsubscribed counts!
-    - So, in `NeighBorhoodEventListUsersViewController.viewDidLoad` (or `viewWillAppear`), if `isEvent` is true and `event != nil`, let's do a quick `EventService.getEventWithId` to fetch the latest `unsubscribed_participants_offer_help` and `unsubscribed_participants_ask_for_help`, then build the views. Wait, that would require passing `eventId` which we do have.
-    - Or even simpler: the issue description says: "Actuellement, ces vues ne s'affiche que lorsqu'on vient d'ajouter des membre, si on retourne ca s'affiche plus. Il faudrait transférer l'info de eventDetail a MemberList, quand on envoi dessus, pour que ca se set bien. Egalement, quand on part de Memberlist, re init la vue EventDetail, relancer l'appel et reset la view. pour que quand on renvoi on ait bien les champs."
-    - This translates directly to:
-        1. When going from EventDetail -> MemberList (`NeighBorhoodEventListUsersViewController`), ensure we transfer the fields (it is done by `vc.event = event`).
-        2. When leaving MemberList -> EventDetail, trigger a refresh of EventDetail so it gets the new fields (post a notification that EventDetail listens to).
-        3. Make sure EventDetail's event parsing actually saves those fields properly. Looking at `Event.swift`, `unsubscribed_participants_offer_help` is decoded but wait - the default custom `init(from decoder: Decoder)` in `Event` doesn't decode `unsubscribed_participants_offer_help` or `unsubscribed_participants_ask_for_help`! Wait! I checked `init(from decoder:)` and it's ONLY for `EventMetadata`! No, `Event` doesn't have a custom init. Wait, `Event` has `CodingKeys`.
-        4. Ah, wait. `EventService.getEventWithId` uses `parseData` -> which uses standard Decodable. Does `Event` decode it properly? Let's verify `CodingKeys` in `Event`. Yes, they are in `CodingKeys`.
-        5. Let's make sure that when `NeighBorhoodEventListUsersViewController` disappears or updates, it notifies `EventDetailFeedViewController` to update.
-
-3.  **Execute the fixes:**
-    - I'll create a sticky bottom view in `NeighBorhoodEventListUsersViewController`.
-    - I'll make sure to trigger `kNotificationEventUpdate` or call the appropriate refresh function when `NeighBorhoodEventListUsersViewController` updates the values or disappears, and make sure `EventDetailFeedViewController` catches it and calls `getEventDetail(hasToRefreshLists: true)`.
-
-4.  **Pre commit check**
+1. **Model Modification (`entourage/Models/Event.swift`)**:
+   - Add `var unsubscribed_participants_female: String? = "0"` to `EventMetadata`.
+   - Update `CodingKeys` in `EventMetadata` to include `unsubscribed_participants_female`.
+   - Update `init(from decoder: Decoder)` in `EventMetadata` to safely decode `unsubscribed_participants_female` just like `ask_for_help` and `offer_help`.
+2. **Network Manager Modification**:
+   - In `entourage/Network Managers/Endpoints.swift`, update `kAPIUpdateUnsubscribedParticipants` to `"outings/%@/users/unsubscribed_participants?token=%@&offer_help=%d&ask_for_help=%d&female=%d"`.
+   - In `entourage/Network Managers/EventService.swift`, update the signature of `updateUnsubscribedParticipants` to include `female: Int`, and update the format string parameters.
+3. **Bottom Sheet View Model Modification (`entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift`)**:
+   - Add `@Published var femaleCount: Int = 0` to `UnsubscribedViewModel`.
+   - Update `UnsubscribedBottomSwiftUIView` to display the row for "femmes isolées" (singular: "femme isolée", plural: "femmes isolées") if `femaleCount > 0`.
+   - Update `updateUnsubscribedBottomViews()` to parse `unsubscribed_participants_female` from `event.metadata` and set `femaleCount`.
+   - Update `EventService.updateUnsubscribedParticipants` call inside the `onValidate` callback of `bottomSheet` to also pass `femaleCount`.
+   - Update local state mapping `event?.metadata?.unsubscribed_participants_female` upon successful API response.
+4. **Bottom Sheet Controller Modification (`entourage/Scenes/Groups - Neighborhoods/UnsubscribedParticipantsBottomSheet.swift`)**:
+   - Add UI components for "femmes isolées": `helpFemaleLabel`, `helpFemaleMinusButton`, `helpFemalePlusButton`, `helpFemaleCountLabel`.
+   - Add `initialFemaleCount` and `currentFemaleCount`.
+   - Add layout constraints for the new counter, placing it below the existing ones.
+   - Update the text of `helpFemaleLabel` to `"Combien de femmes isolées supplémentaires ont rejoint l'événement ?"`.
+   - Update `onValidate` signature to `((Int, Int, Int) -> Void)?` and call it with the new `currentFemaleCount`.
+5. **Pre-commit step**:
+   - Call `pre_commit_instructions` to ensure proper testing, verification, review, and reflection are done.
+6. **Submit**:
+   - Submit the changes.


### PR DESCRIPTION
- Added a new field "femmes isolées" alongside the existing "riverains" and "personnes isolées" unsubscribed participants counters.
- Supports both the API updating and parsing for `unsubscribed_participants_female` property.
- Pluralization handled properly (femme isolée / femmes isolées).

---
*PR created automatically by Jules for task [11958254945170650267](https://jules.google.com/task/11958254945170650267) started by @clemPerrousset*