### PR TITLE
feat: hide + button for adding unsubscribed participants unless event and user are signable

### DIFF
--- a/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
@@ -231,7 +231,9 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
         guard isEvent else { return }
 
         // Configuration du bouton flottant SwiftUI
-        bottomViewModel.showFab = viewerCanUseCheckboxes && !isFromSurvey && !isFromReact
+        let isEventSignable = event?.signable ?? false
+        let isUserSignable = AppSignableManager.shared.signablePermission
+        bottomViewModel.showFab = viewerCanUseCheckboxes && !isFromSurvey && !isFromReact && isEventSignable && isUserSignable
         bottomViewModel.onFabTapped = { [weak self] in
             self?.showBottomSheet()
         }
@@ -263,6 +265,10 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
         let offerHelp = Int(event.metadata?.unsubscribed_participants_offer_help ?? "0") ?? 0
 
         // Met à jour l'interface SwiftUI
+        let isEventSignable = event.signable ?? false
+        let isUserSignable = AppSignableManager.shared.signablePermission
+        bottomViewModel.showFab = viewerCanUseCheckboxes && !isFromSurvey && !isFromReact && isEventSignable && isUserSignable
+
         bottomViewModel.askCount = askForHelp
         bottomViewModel.offerCount = offerHelp
 


### PR DESCRIPTION
Conditionally hide the floating action button (FAB) for adding unsubscribed participants to an event. Now, it only shows when the event is signable and the current user has signable permissions.

---
*PR created automatically by Jules for task [8133038141198549530](https://jules.google.com/task/8133038141198549530) started by @clemPerrousset*