### PR TITLE
Fix unstable signable state for event members

### DIFF
--- a/entourage/Scenes/Events/EventDetailFullFeedViewController.swift
+++ b/entourage/Scenes/Events/EventDetailFullFeedViewController.swift
@@ -78,6 +78,7 @@ class EventDetailFullFeedViewController: UIViewController {
     @objc func refreshEvent() {
         EventService.getEventWithId(String(eventId)) { event, error in
             if let event = event {
+                AppSignableManager.shared.updateFromEvent(event: event)
                 self.event = event
                 self.ui_tableview.reloadData()
             }

--- a/entourage/Scenes/Events/EventParamsViewController.swift
+++ b/entourage/Scenes/Events/EventParamsViewController.swift
@@ -96,6 +96,7 @@ class EventParamsViewController: BasePopViewController {
         if let eventId = event?.uid {
             EventService.getEventWithId(String(eventId)) { event, error in
                 if let event = event {
+                    AppSignableManager.shared.updateFromEvent(event: event)
                     self.event = event
                     self.ui_tableview.reloadData()
                 }

--- a/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/NeighBorhoodEventListUsersViewController.swift
@@ -119,6 +119,7 @@ class NeighBorhoodEventListUsersViewController: BasePopViewController {
         if isEvent, let eventId = event?.uid {
             EventService.getEventWithId(String(eventId)) { [weak self] event, error in
                 guard let self = self, let event = event else { return }
+                AppSignableManager.shared.updateFromEvent(event: event)
                 self.event?.metadata?.unsubscribed_participants_ask_for_help = event.metadata?.unsubscribed_participants_ask_for_help
                 self.event?.metadata?.unsubscribed_participants_offer_help = event.metadata?.unsubscribed_participants_offer_help
                 self.updateUnsubscribedBottomViews()


### PR DESCRIPTION
Fix unstable signable state for event members

Ensure `AppSignableManager` is updated whenever `EventService.getEventWithId` retrieves event details. This fixes intermittent UI issues where checkboxes for event participants would disappear because the global signable state wasn't updated correctly.

---
*PR created automatically by Jules for task [3757024358119531666](https://jules.google.com/task/3757024358119531666) started by @clemPerrousset*