### PR TITLE
Add SwiftUI Full-Screen Image Viewer with Download and Back Buttons

### DIFF
--- a/entourage.xcodeproj/project.pbxproj
+++ b/entourage.xcodeproj/project.pbxproj
@@ -635,6 +635,7 @@
 		26F14CE12D3E8B7C004C4524 /* ProfileSectionCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26F14CE02D3E8B7C004C4524 /* ProfileSectionCell.xib */; };
 		26F2278B2CE73BEE009EABA7 /* HighlightOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F2278A2CE73BEE009EABA7 /* HighlightOverlayView.swift */; };
 		26F4C7812B485D4E0084070D /* NeighborhoodPostTranslationCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26F4C7802B485D4E0084070D /* NeighborhoodPostTranslationCell.xib */; };
+		44FB28AB84FE1C35684C3B5E /* FullScreenImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AB8181698E450A4449D42 /* FullScreenImageView.swift */; };
 		A21749A2A93E5648C02B4A5B /* EventCreatePhase3View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F024A7293C2D6D6B59A5288 /* EventCreatePhase3View.swift */; };
 /* End PBXBuildFile section */
 
@@ -1068,6 +1069,7 @@
 		262820D22D49042A00A61C30 /* MainStatUserCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainStatUserCell.xib; sourceTree = "<group>"; };
 		262820D42D49069A00A61C30 /* MainStatUserCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainStatUserCell.swift; sourceTree = "<group>"; };
 		2628A0F1298AAA9400F1BF1D /* Extension_UILabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension_UILabel.swift; sourceTree = "<group>"; };
+		262AB8181698E450A4449D42 /* FullScreenImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FullScreenImageView.swift; sourceTree = "<group>"; };
 		2630F6172C21CCB7007BAE56 /* HomeInitialPedagogicHorizontalCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeInitialPedagogicHorizontalCell.swift; sourceTree = "<group>"; };
 		2630F6192C21CCE6007BAE56 /* HomeInitialPedagogicHorizontalCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HomeInitialPedagogicHorizontalCell.xib; sourceTree = "<group>"; };
 		2630F61B2C21D320007BAE56 /* HomeInitialPedagoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeInitialPedagoCell.swift; sourceTree = "<group>"; };
@@ -1500,6 +1502,7 @@
 				266791AE2D37A7A400BEDB4E /* ConversationNotifAskViewCell.xib */,
 				2693F8A52D68CE6F002726FD /* MentionCell.swift */,
 				2693F8A72D68CF35002726FD /* MentionCell.xib */,
+				262AB8181698E450A4449D42 /* FullScreenImageView.swift */,
 			);
 			path = Conversations;
 			sourceTree = "<group>";
@@ -3386,6 +3389,7 @@
 				021FBF9228856DC600710584 /* EventUploadPictureService.swift in Sources */,
 				02DD1E91280853CF00538EF4 /* NeighborhoodEditViewController.swift in Sources */,
 				A21749A2A93E5648C02B4A5B /* EventCreatePhase3View.swift in Sources */,
+				44FB28AB84FE1C35684C3B5E /* FullScreenImageView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/entourage/Scenes/Conversations/ConversationDetailMessagesViewController.swift
+++ b/entourage/Scenes/Conversations/ConversationDetailMessagesViewController.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 //
 //  ConversationDetailMessagesViewController.swift
 //  entourage
@@ -1785,33 +1786,13 @@ extension ConversationDetailMessagesViewController: MessageCellSignalDelegate {
     
     
     func showFullScreenImage(_ image: UIImage) {
-        let overlay = UIView()
-        overlay.backgroundColor = .black
-        overlay.alpha = 0
-        overlay.frame = view.bounds
-        overlay.isUserInteractionEnabled = true
-        view.addSubview(overlay)
-
-        let imageView = UIImageView(image: image)
-        imageView.contentMode = .scaleAspectFit
-        imageView.frame = view.bounds
-        imageView.isUserInteractionEnabled = true
-        overlay.addSubview(imageView)
-
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissFullScreenImage(_:)))
-        overlay.addGestureRecognizer(tapGesture)
-
-        UIView.animate(withDuration: 0.3) {
-            overlay.alpha = 1
+        let fullScreenView = FullScreenImageView(image: image) { [weak self] in
+            self?.dismiss(animated: true)
         }
-    }
-
-    @objc private func dismissFullScreenImage(_ sender: UITapGestureRecognizer) {
-        UIView.animate(withDuration: 0.3, animations: {
-            sender.view?.alpha = 0
-        }) { _ in
-            sender.view?.removeFromSuperview()
-        }
+        let hostingController = UIHostingController(rootView: fullScreenView)
+        hostingController.modalPresentationStyle = .overFullScreen
+        hostingController.modalTransitionStyle = .crossDissolve
+        self.present(hostingController, animated: true)
     }
     
     func signalMessage(messageId: Int, userId: Int, textString: String) {

--- a/entourage/Scenes/Conversations/FullScreenImageView.swift
+++ b/entourage/Scenes/Conversations/FullScreenImageView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import UIKit
+
+struct FullScreenImageView: View {
+    let image: UIImage
+    let dismissAction: () -> Void
+
+    @State private var showDownloadAlert = false
+    @State private var downloadMessage = ""
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFit()
+
+            VStack {
+                HStack {
+                    Button(action: {
+                        dismissAction()
+                    }) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 24, weight: .bold))
+                            .foregroundColor(.white)
+                            .padding()
+                            .background(Color.black.opacity(0.4))
+                            .clipShape(Circle())
+                    }
+
+                    Spacer()
+
+                    Button(action: {
+                        saveImage()
+                    }) {
+                        Image(systemName: "square.and.arrow.down")
+                            .font(.system(size: 24, weight: .bold))
+                            .foregroundColor(.white)
+                            .padding()
+                            .background(Color.black.opacity(0.4))
+                            .clipShape(Circle())
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.top, 20)
+
+                Spacer()
+            }
+        }
+        .alert(isPresented: $showDownloadAlert) {
+            Alert(title: Text("Information"), message: Text(downloadMessage), dismissButton: .default(Text("OK")))
+        }
+    }
+
+    private func saveImage() {
+        let saver = ImageSaver()
+        saver.successHandler = {
+            self.downloadMessage = "Image enregistrée dans la pellicule avec succès."
+            self.showDownloadAlert = true
+        }
+        saver.errorHandler = { error in
+            self.downloadMessage = "Erreur lors de l'enregistrement de l'image."
+            self.showDownloadAlert = true
+        }
+        saver.writeToPhotoAlbum(image: image)
+    }
+}
+
+class ImageSaver: NSObject {
+    var successHandler: (() -> Void)?
+    var errorHandler: ((Error) -> Void)?
+
+    func writeToPhotoAlbum(image: UIImage) {
+        UIImageWriteToSavedPhotosAlbum(image, self, #selector(saveCompleted), nil)
+    }
+
+    @objc func saveCompleted(_ image: UIImage, didFinishSavingWithError error: Error?, contextInfo: UnsafeRawPointer) {
+        if let error = error {
+            errorHandler?(error)
+        } else {
+            successHandler?()
+        }
+    }
+}

--- a/entourage/Scenes/Events/EventDetailMessagesViewController.swift
+++ b/entourage/Scenes/Events/EventDetailMessagesViewController.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 //
 //  EventDetailMessagesViewController.swift
 //  entourage
@@ -579,33 +580,13 @@ extension EventDetailMessagesViewController: UITextViewDelegate {
 // MARK: - MessageCellSignalDelegate
 extension EventDetailMessagesViewController: MessageCellSignalDelegate {
     func showFullScreenImage(_ image: UIImage) {
-        let overlay = UIView()
-        overlay.backgroundColor = .black
-        overlay.alpha = 0
-        overlay.frame = view.bounds
-        overlay.isUserInteractionEnabled = true
-        view.addSubview(overlay)
-
-        let imageView = UIImageView(image: image)
-        imageView.contentMode = .scaleAspectFit
-        imageView.frame = view.bounds
-        imageView.isUserInteractionEnabled = true
-        overlay.addSubview(imageView)
-
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissFullScreenImage(_:)))
-        overlay.addGestureRecognizer(tapGesture)
-
-        UIView.animate(withDuration: 0.3) {
-            overlay.alpha = 1
+        let fullScreenView = FullScreenImageView(image: image) { [weak self] in
+            self?.dismiss(animated: true)
         }
-    }
-
-    @objc private func dismissFullScreenImage(_ sender: UITapGestureRecognizer) {
-        UIView.animate(withDuration: 0.3, animations: {
-            sender.view?.alpha = 0
-        }) { _ in
-            sender.view?.removeFromSuperview()
-        }
+        let hostingController = UIHostingController(rootView: fullScreenView)
+        hostingController.modalPresentationStyle = .overFullScreen
+        hostingController.modalTransitionStyle = .crossDissolve
+        self.present(hostingController, animated: true)
     }
     
     func signalMessage(messageId: Int, userId: Int, textString: String) {

--- a/entourage/Scenes/Groups - Neighborhoods/NeighborhoodDetailMessagesViewController.swift
+++ b/entourage/Scenes/Groups - Neighborhoods/NeighborhoodDetailMessagesViewController.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 //
 //  NeighborhoodDetailMessagesViewController.swift
 //  entourage
@@ -696,33 +697,13 @@ extension NeighborhoodDetailMessagesViewController: UITextViewDelegate {
 // MARK: - MessageCellSignalDelegate
 extension NeighborhoodDetailMessagesViewController: MessageCellSignalDelegate {
     func showFullScreenImage(_ image: UIImage) {
-        let overlay = UIView()
-        overlay.backgroundColor = .black
-        overlay.alpha = 0
-        overlay.frame = view.bounds
-        overlay.isUserInteractionEnabled = true
-        view.addSubview(overlay)
-
-        let imageView = UIImageView(image: image)
-        imageView.contentMode = .scaleAspectFit
-        imageView.frame = view.bounds
-        imageView.isUserInteractionEnabled = true
-        overlay.addSubview(imageView)
-
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissFullScreenImage(_:)))
-        overlay.addGestureRecognizer(tapGesture)
-
-        UIView.animate(withDuration: 0.3) {
-            overlay.alpha = 1
+        let fullScreenView = FullScreenImageView(image: image) { [weak self] in
+            self?.dismiss(animated: true)
         }
-    }
-
-    @objc private func dismissFullScreenImage(_ sender: UITapGestureRecognizer) {
-        UIView.animate(withDuration: 0.3, animations: {
-            sender.view?.alpha = 0
-        }) { _ in
-            sender.view?.removeFromSuperview()
-        }
+        let hostingController = UIHostingController(rootView: fullScreenView)
+        hostingController.modalPresentationStyle = .overFullScreen
+        hostingController.modalTransitionStyle = .crossDissolve
+        self.present(hostingController, animated: true)
     }
     func signalMessage(messageId: Int, userId: Int, textString: String) {
         if let navVC = UIStoryboard(name: StoryboardName.neighborhoodReport, bundle: nil)


### PR DESCRIPTION
Replaced the legacy `UIView` overlay in `showFullScreenImage` methods across three ViewControllers (Conversations, Events, Neighborhoods) with a new, pure SwiftUI `FullScreenImageView`. 
- The new view includes a back button and a download button to natively save images to the device's camera roll using `UIImageWriteToSavedPhotosAlbum`.
- Uses `UIHostingController` with cross dissolve transition to preserve the visual feel of the old overlay while improving architectural robustness and meeting new feature requirements.

---
*PR created automatically by Jules for task [8355786918623200780](https://jules.google.com/task/8355786918623200780) started by @clemPerrousset*