### PR TITLE
Remove Mixpanel Token References

### DIFF
--- a/entourage/Managers/EnvironmentConfigurationManager.swift
+++ b/entourage/Managers/EnvironmentConfigurationManager.swift
@@ -18,7 +18,6 @@ struct UserStorageKey {
     static let amazonPictureFolder = "AmazonPictureFolder"
     static let amazonAccessKey = "AmazonAccessKey"
     static let amazonSecretKey = "AmazonSecretKey"
-    static let mixpanelToken = "MixpanelToken"
     static let awsPictureBucket = "AwsPictureBucket"
     static let environmentTypeKey = "EnvironmentType"
     static let googlePlaceApiKey = "GooglePlaceApiKey"
@@ -75,10 +74,6 @@ class EnvironmentConfigurationManager {
     
     var APIKey: NSString {
         return apiKeysConfiguration(forKey: UserStorageKey.APIKey)
-    }
-    
-    var MixpanelToken : NSString {
-        return configuration(forKey: UserStorageKey.mixpanelToken)
     }
     
     var AwsPictureBucket : NSString {


### PR DESCRIPTION
Removes `mixpanelToken` and `MixpanelToken` references from `EnvironmentConfigurationManager.swift`. All other mixpanel SDK usages appear to have been already removed.

---
*PR created automatically by Jules for task [8329558204035028788](https://jules.google.com/task/8329558204035028788) started by @FrPellissier*