### PR TITLE
Fix conversation list date display

### DIFF
--- a/entourage/Models/Conversation.swift
+++ b/entourage/Models/Conversation.swift
@@ -257,6 +257,7 @@ struct ConversationMembership: Decodable {
     let numberOfUnreadMessages: Int?
     let lastChatMessageText: String?
     let lastChatMessageImageUrl: String?
+    let lastChatMessageDate: String?
 
     private enum CodingKeys: String, CodingKey {
         case status
@@ -271,6 +272,7 @@ struct ConversationMembership: Decodable {
         case numberOfUnreadMessages = "number_of_unread_messages"
         case lastChatMessageText = "last_chat_message"
         case lastChatMessageImageUrl = "last_chat_message_image_url"
+        case lastChatMessageDate = "last_chat_message_date"
     }
 }
 

--- a/entourage/Scenes/Conversations/ConversationListMainCell.swift
+++ b/entourage/Scenes/Conversations/ConversationListMainCell.swift
@@ -63,7 +63,21 @@ class ConversationListMainCell: UITableViewCell {
         } else {
             ui_username.text = message.title
         }
-        ui_role.text = message.getRolesWithPartnerFormated()
+        let rolesText = message.getRolesWithPartnerFormated()
+        ui_role.text = rolesText
+        ui_role.isHidden = (rolesText?.isEmpty ?? true)
+
+        if message.type == "outing" {
+            ui_date.isHidden = true
+
+            ui_role.isHidden = false
+            ui_role.text = message.subname
+            ui_role.textColor = .appOrangeLight
+        } else {
+            ui_date.isHidden = false
+            ui_date.text = message.createdDateFormatted
+        }
+
         if let _message = message.getLastMessage {
             ui_detail_message.text = _message
             ui_detail_message.handleURLTap { url in
@@ -77,7 +91,6 @@ class ConversationListMainCell: UITableViewCell {
         else {
             ui_detail_message.text = message.getLastMessage
         }
-        ui_date.text = message.subname
         
         self.delegate = delegate
         self.position = position
@@ -107,11 +120,15 @@ class ConversationListMainCell: UITableViewCell {
         if message.hasUnread {
             ui_nb_unread.isHidden = false
             ui_nb_unread.text = "\(message.numberUnreadMessages!)"
-            ui_date.textColor = .appOrange
+            if message.type != "outing" {
+                ui_date.textColor = .appOrange
+            }
             ui_detail_message.setupFontAndColor(style: MJTextFontColorStyle(font: ApplicationTheme.getFontNunitoSemiBold(size: 13), color: .black))
         }
         else {
-            ui_date.textColor = .appGrisSombre40
+            if message.type != "outing" {
+                ui_date.textColor = .appGrisSombre40
+            }
             ui_nb_unread.isHidden = true
             ui_detail_message.setupFontAndColor(style: ApplicationTheme.getFontChampDefault(size: 13, color: .appGrisSombre40))
         }

--- a/entourage/Scenes/Conversations/ConversationsMainHomeViewController.swift
+++ b/entourage/Scenes/Conversations/ConversationsMainHomeViewController.swift
@@ -172,7 +172,9 @@ class ConversationsMainHomeViewController: UIViewController {
         conv.title = membership.name ?? ""
         conv.subname = formattedDate
         if let text = membership.lastChatMessageText {
-            conv.lastMessage = LastMessage(text: text, dateStr: nil)
+            conv.lastMessage = LastMessage(text: text, dateStr: membership.lastChatMessageDate)
+        } else if let imageUrl = membership.lastChatMessageImageUrl, !imageUrl.isEmpty {
+            conv.lastMessage = LastMessage(text: nil, dateStr: membership.lastChatMessageDate)
         }
         conv.numberUnreadMessages = membership.numberOfUnreadMessages
         conv.members_count = membership.numberOfPeople


### PR DESCRIPTION
- Added `lastChatMessageDate` to `ConversationMembership` so we get the date of the last message from the API.
- Passed `lastChatMessageDate` to `LastMessage` in `ConversationsMainHomeViewController` mapping.
- In `ConversationListMainCell`, customized `ui_date` to show the formatted `lastMessage.date` for private and small_talk conversations, and hid it for events.
- Used `ui_role` label to show the event date (`subname`) under the title for events (`outing`).

---
*PR created automatically by Jules for task [4102096682014057454](https://jules.google.com/task/4102096682014057454) started by @clemPerrousset*