### PR TITLE
Fix last message date parsing and displaying on iOS

### DIFF
--- a/entourage/Scenes/Conversations/ConversationsMainHomeViewController.swift
+++ b/entourage/Scenes/Conversations/ConversationsMainHomeViewController.swift
@@ -175,6 +175,8 @@ class ConversationsMainHomeViewController: UIViewController {
             conv.lastMessage = LastMessage(text: text, dateStr: membership.lastChatMessageDate)
         } else if let imageUrl = membership.lastChatMessageImageUrl, !imageUrl.isEmpty {
             conv.lastMessage = LastMessage(text: nil, dateStr: membership.lastChatMessageDate)
+        } else if let dateStr = membership.lastChatMessageDate {
+            conv.lastMessage = LastMessage(text: nil, dateStr: dateStr)
         }
         conv.numberUnreadMessages = membership.numberOfUnreadMessages
         conv.members_count = membership.numberOfPeople

--- a/entourage/Tools/Utils.swift
+++ b/entourage/Tools/Utils.swift
@@ -156,11 +156,15 @@ import UIKit
             return nil
         }
 
-        let dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
         let dateFormatter = DateFormatter()
         dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
-        dateFormatter.dateFormat = dateFormat
-        return dateFormatter.date(from: dateStr)
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+        if let d = dateFormatter.date(from: dateStr) { return d }
+
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssXXX"
+        if let d = dateFormatter.date(from: dateStr) { return d }
+
+        return nil
     }
     
     static func formatEventDate(date:Date?) -> String {


### PR DESCRIPTION
Fix last message date parsing and displaying on iOS. Ensures that `lastMessage` object in conversations list preserves the date even if the message itself is empty of text or image. Furthermore, adds a fallback format to date parsing to process WS dates that are missing millisecond information.

---
*PR created automatically by Jules for task [12200787547767745511](https://jules.google.com/task/12200787547767745511) started by @clemPerrousset*