### PR TITLE
Update filter interest subtitles and remove 'other' option

### DIFF
--- a/entourage/Scenes/enhancedOnboarding/EnhancedViewController.swift
+++ b/entourage/Scenes/enhancedOnboarding/EnhancedViewController.swift
@@ -197,8 +197,7 @@ class EnhancedViewController: UIViewController, UIImagePickerControllerDelegate,
             OnboardingChoice(id: "activites", img: "interest_activite-manuelle", title: NSLocalizedString("enhanced_onboarding_interest_manual_activities", comment: "")),
             OnboardingChoice(id: "bien-etre", img: "interest_bien-etre", title: NSLocalizedString("enhanced_onboarding_interest_wellbeing", comment: "")),
             OnboardingChoice(id: "nature", img: "interest_nature", title: NSLocalizedString("enhanced_onboarding_interest_nature", comment: "")),
-            OnboardingChoice(id: "culture", img: "interest_art", title: NSLocalizedString("enhanced_onboarding_interest_art_culture", comment: "")),
-            OnboardingChoice(id: "other", img: "interest_autre", title: NSLocalizedString("enhanced_onboarding_interest_other", comment: ""))
+            OnboardingChoice(id: "culture", img: "interest_art", title: NSLocalizedString("enhanced_onboarding_interest_art_culture", comment: ""))
         ]
 
         let interests = Set(currentUser.interests ?? [])

--- a/entourage/Scenes/mainFilter/MainFilter.swift
+++ b/entourage/Scenes/mainFilter/MainFilter.swift
@@ -93,16 +93,15 @@ class MainFilter: UIViewController, MainFilterLocationCellDelegate {
         switch self.mod {
         case .group, .event:
             let interestChoices = [
-                MainFilterTagItem(id: "sport", title: NSLocalizedString("filter_groupevent_sport", comment: ""), subtitle: ""),
-                MainFilterTagItem(id: "animaux", title: NSLocalizedString("filter_groupevent_animals", comment: ""), subtitle: ""),
-                MainFilterTagItem(id: "marauding", title: NSLocalizedString("filter_groupevent_social_marauding", comment: ""), subtitle: ""),
-                MainFilterTagItem(id: "cuisine", title: NSLocalizedString("filter_groupevent_cooking", comment: ""), subtitle: ""),
-                MainFilterTagItem(id: "jeux", title: NSLocalizedString("filter_groupevent_games", comment: ""), subtitle: ""),
-                MainFilterTagItem(id: "activites", title: NSLocalizedString("filter_groupevent_handicrafts", comment: ""), subtitle: ""),
-                MainFilterTagItem(id: "bien-etre", title: NSLocalizedString("filter_groupevent_wellbeing", comment: ""), subtitle: ""),
-                MainFilterTagItem(id: "nature", title: NSLocalizedString("filter_groupevent_nature", comment: ""), subtitle: ""),
-                MainFilterTagItem(id: "culture", title: NSLocalizedString("filter_groupevent_art_and_culture", comment: ""), subtitle: ""),
-                MainFilterTagItem(id: "other", title: NSLocalizedString("filter_groupevent_other", comment: ""), subtitle: "")
+                MainFilterTagItem(id: "sport", title: NSLocalizedString("filter_groupevent_sport", comment: ""), subtitle: " (" + TagsUtils.showSubTagTranslated("sport") + ")"),
+                MainFilterTagItem(id: "animaux", title: NSLocalizedString("filter_groupevent_animals", comment: ""), subtitle: " (" + TagsUtils.showSubTagTranslated("animaux") + ")"),
+                MainFilterTagItem(id: "marauding", title: NSLocalizedString("filter_groupevent_social_marauding", comment: ""), subtitle: " (" + TagsUtils.showSubTagTranslated("marauding") + ")"),
+                MainFilterTagItem(id: "cuisine", title: NSLocalizedString("filter_groupevent_cooking", comment: ""), subtitle: " (" + TagsUtils.showSubTagTranslated("cuisine") + ")"),
+                MainFilterTagItem(id: "jeux", title: NSLocalizedString("filter_groupevent_games", comment: ""), subtitle: " (" + TagsUtils.showSubTagTranslated("jeux") + ")"),
+                MainFilterTagItem(id: "activites", title: NSLocalizedString("filter_groupevent_handicrafts", comment: ""), subtitle: " (" + TagsUtils.showSubTagTranslated("activites") + ")"),
+                MainFilterTagItem(id: "bien-etre", title: NSLocalizedString("filter_groupevent_wellbeing", comment: ""), subtitle: " (" + TagsUtils.showSubTagTranslated("bien-etre") + ")"),
+                MainFilterTagItem(id: "nature", title: NSLocalizedString("filter_groupevent_nature", comment: ""), subtitle: " (" + TagsUtils.showSubTagTranslated("nature") + ")"),
+                MainFilterTagItem(id: "culture", title: NSLocalizedString("filter_groupevent_art_and_culture", comment: ""), subtitle: " (" + TagsUtils.showSubTagTranslated("culture") + ")")
             ]
             
             tableDTO.append(.titleCell(title: NSLocalizedString("filter_groupevent_filters", comment: "")))

--- a/entourage/Scenes/mainFilter/cells/MainFilterTagCell.swift
+++ b/entourage/Scenes/mainFilter/cells/MainFilterTagCell.swift
@@ -21,7 +21,8 @@ class MainFilterTagCell: UITableViewCell {
         // Creating the attributed string for title and subtitle
         let titleAttributes: [NSAttributedString.Key: Any]
         let subtitleAttributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.systemFont(ofSize: ui_title_label.font.pointSize)
+            .font: UIFont.systemFont(ofSize: ui_title_label.font.pointSize - 2),
+            .foregroundColor: UIColor.appGreyOff
         ]
         
         if choice.subtitle.isEmpty {


### PR DESCRIPTION
Removes the 'other' choice from the enhanced onboarding and event filter interest lists. It also adds gray, smaller subtitles to the event list interest filters, matching the onboarding design pattern, as requested by the user.

---
*PR created automatically by Jules for task [16863024341240704384](https://jules.google.com/task/16863024341240704384) started by @clemPerrousset*