### PR TITLE
Add Universal Link for Welcome Video

### DIFF
--- a/entourage/Managers/DeeplinkManager.swift
+++ b/entourage/Managers/DeeplinkManager.swift
@@ -340,6 +340,50 @@ struct DeepLinkManager {
         }
     }
 
+    static func showWelcomeVideoUniversalLink() {
+        DispatchQueue.main.async {
+            if let vc = AppState.getTopViewController() {
+                if let _tabbar = vc.tabBarController as? MainTabbarViewController {
+                    _tabbar.showHome()
+
+                    let modalVC = WelcomeVideoModalViewController()
+                    modalVC.modalPresentationStyle = .overFullScreen
+                    modalVC.modalTransitionStyle = .crossDissolve
+                    if let homeVC = AppState.getTopViewController() as? HomeV2ViewController {
+                        modalVC.onComplete = { [weak homeVC] in
+                            homeVC?.initHome()
+                        }
+                        modalVC.onDismissOnly = { [weak homeVC] in
+                            homeVC?.initHome()
+                        }
+                    }
+                    AppState.getTopViewController()?.present(modalVC, animated: true)
+                }
+                else {
+                    vc.dismiss(animated: true) {
+                        if let _currentVc = AppState.getTopViewController() {
+                            if let _tabbar = _currentVc.tabBarController as? MainTabbarViewController {
+                                _tabbar.showHome()
+                            }
+                            let modalVC = WelcomeVideoModalViewController()
+                            modalVC.modalPresentationStyle = .overFullScreen
+                            modalVC.modalTransitionStyle = .crossDissolve
+                            if let homeVC = AppState.getTopViewController() as? HomeV2ViewController {
+                                modalVC.onComplete = { [weak homeVC] in
+                                    homeVC?.initHome()
+                                }
+                                modalVC.onDismissOnly = { [weak homeVC] in
+                                    homeVC?.initHome()
+                                }
+                            }
+                            AppState.getTopViewController()?.present(modalVC, animated: true)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     static func showWelcomeEvent() {
         DispatchQueue.main.async {
             let vc = WelcomeEventsListViewController()

--- a/entourage/Managers/UniversalLinkManager.swift
+++ b/entourage/Managers/UniversalLinkManager.swift
@@ -153,6 +153,19 @@ struct UniversalLinkManager {
         // --- CGU / Charte ---
         case "chart-event":
             DeepLinkManager.showCGU()
+
+        // --- Home ---
+        case "home":
+            if pathElements.count > 1 {
+                let subEntity = pathElements[1]
+                if subEntity == "welcome-video" {
+                    DeepLinkManager.showWelcomeVideoUniversalLink()
+                } else {
+                    DeepLinkManager.showHomeUniversalLink()
+                }
+            } else {
+                DeepLinkManager.showHomeUniversalLink()
+            }
             
         // --- Fallback ---
         default:


### PR DESCRIPTION
This pull request adds support for a universal link pointing directly to the app's welcome video modal (`/app/home/welcome-video`). 
    
    When clicked:
    1. `UniversalLinkManager` will parse `home/welcome-video`.
    2. `DeepLinkManager.showWelcomeVideoUniversalLink()` will be triggered.
    3. The app will ensure the user is directed to the root `HomeV2ViewController` (dismissing any existing modals and changing the active tab if necessary).
    4. The `WelcomeVideoModalViewController` will be presented on top.

---
*PR created automatically by Jules for task [14185285875653044448](https://jules.google.com/task/14185285875653044448) started by @clemPerrousset*