### PR TITLE
Refactor ConversationsList to SwiftUI and fix event date presentation

### DIFF
--- a/entourage.xcodeproj/project.pbxproj
+++ b/entourage.xcodeproj/project.pbxproj
@@ -636,7 +636,13 @@
 		26F2278B2CE73BEE009EABA7 /* HighlightOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F2278A2CE73BEE009EABA7 /* HighlightOverlayView.swift */; };
 		26F4C7812B485D4E0084070D /* NeighborhoodPostTranslationCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26F4C7802B485D4E0084070D /* NeighborhoodPostTranslationCell.xib */; };
 		44FB28AB84FE1C35684C3B5E /* FullScreenImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AB8181698E450A4449D42 /* FullScreenImageView.swift */; };
+		4508652EF5ADE09EE8C04623 /* ConversationsMainHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FFB7F09AD97DF19C9B3C28E /* ConversationsMainHomeView.swift */; };
 		A21749A2A93E5648C02B4A5B /* EventCreatePhase3View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F024A7293C2D6D6B59A5288 /* EventCreatePhase3View.swift */; };
+		B5DFA31F559B0DD131071B22 /* ConversationFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7BA03D9C67EF073BEEC601 /* ConversationFilterView.swift */; };
+		C3C73D95E128427274B44194 /* ConversationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55E9A1A44A4D5B722B5C109 /* ConversationsViewModel.swift */; };
+		D539FA8A98C24409A13712DA /* ConversationListMainCellSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987208D95D44965720398373 /* ConversationListMainCellSwiftUI.swift */; };
+		E71D33E52CB7FBE9D7732EAE /* ConversationNotifAskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CAFE62DCEBA298C105FB09E /* ConversationNotifAskView.swift */; };
+		ED13ACB34F217E1E4836F2EA /* ConversationMainDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A62EFA54C5927D8F54BDCDB /* ConversationMainDTO.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -1002,6 +1008,7 @@
 		02FCC3162812DDA500578407 /* NeighborhoodHomeGroupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeighborhoodHomeGroupCell.swift; sourceTree = "<group>"; };
 		02FE55B42939F6020076F57A /* OnboardingEndCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingEndCell.swift; sourceTree = "<group>"; };
 		02FE55B6293A20030076F57A /* OnboardingEndViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingEndViewController.swift; sourceTree = "<group>"; };
+		0FFB7F09AD97DF19C9B3C28E /* ConversationsMainHomeView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConversationsMainHomeView.swift; path = SwiftUI/ConversationsMainHomeView.swift; sourceTree = "<group>"; };
 		241A6AE82F6C3229005BF63B /* HomeWelcomeJourneyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWelcomeJourneyCell.swift; sourceTree = "<group>"; };
 		241A6AE92F6C3229005BF63B /* HomeWelcomeJourneyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWelcomeJourneyView.swift; sourceTree = "<group>"; };
 		241A6AEA2F6C3229005BF63B /* WelcomeJourneyCelebrationPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeJourneyCelebrationPopupViewController.swift; sourceTree = "<group>"; };
@@ -1276,6 +1283,11 @@
 		26F2278A2CE73BEE009EABA7 /* HighlightOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightOverlayView.swift; sourceTree = "<group>"; };
 		26F4C7802B485D4E0084070D /* NeighborhoodPostTranslationCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NeighborhoodPostTranslationCell.xib; sourceTree = "<group>"; };
 		4F024A7293C2D6D6B59A5288 /* EventCreatePhase3View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EventCreatePhase3View.swift; path = entourage/Scenes/Events/Create/EventCreatePhase3View.swift; sourceTree = SOURCE_ROOT; };
+		6A62EFA54C5927D8F54BDCDB /* ConversationMainDTO.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationMainDTO.swift; sourceTree = "<group>"; };
+		6CAFE62DCEBA298C105FB09E /* ConversationNotifAskView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConversationNotifAskView.swift; path = SwiftUI/ConversationNotifAskView.swift; sourceTree = "<group>"; };
+		987208D95D44965720398373 /* ConversationListMainCellSwiftUI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConversationListMainCellSwiftUI.swift; path = SwiftUI/ConversationListMainCellSwiftUI.swift; sourceTree = "<group>"; };
+		CD7BA03D9C67EF073BEEC601 /* ConversationFilterView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConversationFilterView.swift; path = SwiftUI/ConversationFilterView.swift; sourceTree = "<group>"; };
+		E55E9A1A44A4D5B722B5C109 /* ConversationsViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConversationsViewModel.swift; path = SwiftUI/ConversationsViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1406,6 +1418,7 @@
 				26D13E2D2BA43F9900CAD4F7 /* Survey.swift */,
 				268ADBBD2DD1D80100031C6F /* SmallTalksModels.swift */,
 				2667575E2E856FCC0039FF88 /* PreOnboardingModels.swift */,
+				6A62EFA54C5927D8F54BDCDB /* ConversationMainDTO.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1503,6 +1516,7 @@
 				2693F8A52D68CE6F002726FD /* MentionCell.swift */,
 				2693F8A72D68CF35002726FD /* MentionCell.xib */,
 				262AB8181698E450A4449D42 /* FullScreenImageView.swift */,
+				27FA241A0CBB35B8624C07E0 /* SwiftUI */,
 			);
 			path = Conversations;
 			sourceTree = "<group>";
@@ -2670,6 +2684,18 @@
 			path = imagelist;
 			sourceTree = "<group>";
 		};
+		27FA241A0CBB35B8624C07E0 /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				CD7BA03D9C67EF073BEEC601 /* ConversationFilterView.swift */,
+				6CAFE62DCEBA298C105FB09E /* ConversationNotifAskView.swift */,
+				987208D95D44965720398373 /* ConversationListMainCellSwiftUI.swift */,
+				E55E9A1A44A4D5B722B5C109 /* ConversationsViewModel.swift */,
+				0FFB7F09AD97DF19C9B3C28E /* ConversationsMainHomeView.swift */,
+			);
+			name = SwiftUI;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -3390,6 +3416,12 @@
 				02DD1E91280853CF00538EF4 /* NeighborhoodEditViewController.swift in Sources */,
 				A21749A2A93E5648C02B4A5B /* EventCreatePhase3View.swift in Sources */,
 				44FB28AB84FE1C35684C3B5E /* FullScreenImageView.swift in Sources */,
+				B5DFA31F559B0DD131071B22 /* ConversationFilterView.swift in Sources */,
+				E71D33E52CB7FBE9D7732EAE /* ConversationNotifAskView.swift in Sources */,
+				D539FA8A98C24409A13712DA /* ConversationListMainCellSwiftUI.swift in Sources */,
+				C3C73D95E128427274B44194 /* ConversationsViewModel.swift in Sources */,
+				ED13ACB34F217E1E4836F2EA /* ConversationMainDTO.swift in Sources */,
+				4508652EF5ADE09EE8C04623 /* ConversationsMainHomeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/entourage/Models/ConversationMainDTO.swift
+++ b/entourage/Models/ConversationMainDTO.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum ConversationMainDTO {
+    case notificationRequest
+    case conversation(conversation: Conversation)
+    case filter(filter: String)
+    case smalltalk(smallTalk: SmallTalk)
+}

--- a/entourage/Scenes/Conversations/ConversationsMainHomeViewController.swift
+++ b/entourage/Scenes/Conversations/ConversationsMainHomeViewController.swift
@@ -1,341 +1,68 @@
 import UIKit
-import SVProgressHUD
-
-enum ConversationMainDTO {
-    case notificationRequest
-    case conversation(conversation: Conversation)
-    case filter(filter: String)
-    case smalltalk(smallTalk: SmallTalk)
-}
+import SwiftUI
 
 class ConversationsMainHomeViewController: UIViewController {
     
-    // MARK: - UI Outlets
-    @IBOutlet weak var ui_image_inside_top_constraint: NSLayoutConstraint!
-    @IBOutlet weak var ui_image_constraint_height: NSLayoutConstraint!
-    @IBOutlet weak var ui_image: UIImageView!
-    @IBOutlet weak var ui_constraint_bottom_label: NSLayoutConstraint!
-    @IBOutlet weak var ui_view_height_constraint: NSLayoutConstraint!
-    @IBOutlet weak var ui_label_title: UILabel!
-    @IBOutlet weak var ui_tableview: UITableView!
-    @IBOutlet weak var ui_view_selector: UIView!
+    private var hostingController: UIHostingController<ConversationsMainHomeView>?
+    private var swiftUIView: ConversationsMainHomeView?
     
-    // MARK: - Properties
-    var dataSource = [ConversationMainDTO]()
-    var notificationsDisabled: Bool = false
-    var selectedFilter: String = "event_conv_filter_all".localized
-    var isLastPage = false
-
-    var currentPage = 1
-    var isFetching = false
-    let perPage = 25
-
-    var maxViewHeight: CGFloat = 109
-    var minViewHeight: CGFloat = 70
-
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        ui_tableview.dataSource = self
-        ui_tableview.delegate = self
-        
-        ui_tableview.register(UINib(nibName: "ConversationNotifAskViewCell", bundle: nil), forCellReuseIdentifier: "ConversationNotifAskViewCell")
-        ui_tableview.register(UINib(nibName: "FilterDiscussionCell", bundle: nil), forCellReuseIdentifier: "FilterDiscussionCell")
-
-        setupViews()
-        checkNotificationStatus()
-        loadConversations(reset: true)
-
-        NotificationCenter.default.addObserver(self, selector: #selector(updateFilterSmallTalk), name: NSNotification.Name(kNotificationMessagesUpdateSmallTalkFilter), object: nil)
-    }
-
-    @objc private func updateFilterSmallTalk() {
-        self.selectedFilter = "event_conv_filter_smalltalks".localized
-        self.loadConversations(reset: true)
-    }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
+        setupSwiftUIView()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        loadConversations(reset: true)
-    }
-
-    func setupViews() {
-        ui_tableview.contentInset = UIEdgeInsets(top: maxViewHeight, left: 0, bottom: 0, right: 0)
-        ui_tableview.scrollIndicatorInsets = UIEdgeInsets(top: maxViewHeight, left: 0, bottom: 0, right: 0)
-
-        ui_view_selector.layer.cornerRadius = ApplicationTheme.bigCornerRadius
-        ui_view_selector.layer.maskedCorners = CACornerMask.radiusTopOnly()
-
-        ui_label_title.font = ApplicationTheme.getFontQuickSandBold(size: 23)
-        ui_label_title.text = "Messages_title".localized
-    }
-
-    func checkNotificationStatus() {
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
-            DispatchQueue.main.async {
-                self.notificationsDisabled = settings.authorizationStatus != .authorized
-                self.loadDTO(conversations: [], reset: true)
-            }
+        self.navigationController?.setNavigationBarHidden(true, animated: animated)
+        // Optionally trigger refresh here if needed, but the view model does it on init
+        if let vm = hostingController?.rootView.viewModel {
+            vm.loadConversations(reset: true)
         }
     }
     
-    private func membershipTypeParam() -> String? {
-        switch selectedFilter {
-        case "event_conv_filter_discussions".localized:
-            return "Conversation"
-        case "event_conv_filter_events".localized:
-            return "Outing"
-        case "event_conv_filter_smalltalks".localized:
-            return "Smalltalk"
-        default:
-            return nil
+    private func setupSwiftUIView() {
+        var view = ConversationsMainHomeView()
+
+        view.onShowConversation = { [weak self] dto in
+            self?.handleShowConversation(dto: dto)
         }
+
+        view.onShowProfile = { [weak self] userId in
+            self?.handleShowProfile(userId: userId)
+        }
+
+        view.onShowWebUrl = { [weak self] url in
+            guard let self = self else { return }
+            WebLinkManager.openUrl(url: url, openInApp: true, presenterViewController: self)
+        }
+
+        view.onRequestNotifications = { [weak self] in
+            self?.handleNotificationRequest()
+        }
+
+        let host = UIHostingController(rootView: view)
+        addChild(host)
+        host.view.frame = self.view.bounds
+        host.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        self.view.addSubview(host.view)
+        host.didMove(toParent: self)
+
+        self.hostingController = host
+        self.swiftUIView = view
     }
 
-    func loadConversations(reset: Bool) {
-        guard !isFetching else { return }
-        isFetching = true
-
-        if reset {
-            currentPage = 1
-            isLastPage = false
-        }
-
-        SVProgressHUD.show()
-
-        // 1️⃣ Si on est sur “Smalltalk”, on utilise l’ancien service
-        if selectedFilter == "event_conv_filter_smalltalks".localized {
-            SmallTalkService.listSmallTalks { smallTalks, error in
-                SVProgressHUD.dismiss()
-                self.isFetching = false
-                guard let smallTalks = smallTalks else { return }
-                // On retourne en DTO .smalltalk pour que cellForRowAt et didSelectRowAt
-                // passent bien par la case .smalltalk
-                self.loadDTO(smallTalks: smallTalks, reset: reset)
-            }
-            return
-        }
-
-        // 2️⃣ Sinon, on utilise le nouvel endpoint memberships
-        let typeParam = membershipTypeParam()
-        MessagingService.getConversationMemberships(type: typeParam,
-                                                   page: currentPage,
-                                                   per: perPage) { memberships, error in
-            SVProgressHUD.dismiss()
-            self.isFetching = false
-            guard let memberships = memberships else { return }
-
-            // pagination
-            self.isLastPage = memberships.count < self.perPage
-
-            // map en Conversation
-            let conversations = memberships.map { self.conversation(from: $0) }
-            // et on recharge via le DTO conversation
-            self.loadDTO(conversations: conversations, reset: reset)
-            self.currentPage += 1
-        }
-    }
-
-    private func conversation(from membership: ConversationMembership) -> Conversation {
-        var conv = Conversation()
-        conv.uid = membership.joinableId ?? 0
-
-        conv.type = {
-            switch membership.joinableType?.lowercased() {
-            case "outing":
-                return "outing"
-            case "conversation":
-                return "private"
-            case "smalltalk":
-                return "small_talk"
-            default:
-                return "group"
-            }
-        }()
-
-        // Formatage de la date ISO (si c'est bien une date)
-        let formattedDate: String? = {
-            guard let subname = membership.subname else { return nil }
-            let isoFormatter = ISO8601DateFormatter()
-            isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-            if let date = isoFormatter.date(from: subname) {
-                return Utils.formatEventDateShort(date: date)
-            }
-            return subname // si ce n'est pas une date, on retourne tel quel
-        }()
-
-        conv.title = membership.name ?? ""
-        conv.subname = formattedDate
-        if let text = membership.lastChatMessageText {
-            conv.lastMessage = LastMessage(text: text, dateStr: membership.lastChatMessageDate)
-        } else if let imageUrl = membership.lastChatMessageImageUrl, !imageUrl.isEmpty {
-            conv.lastMessage = LastMessage(text: nil, dateStr: membership.lastChatMessageDate)
-        } else if let dateStr = membership.lastChatMessageDate {
-            conv.lastMessage = LastMessage(text: nil, dateStr: dateStr)
-        }
-        conv.numberUnreadMessages = membership.numberOfUnreadMessages
-        conv.members_count = membership.numberOfPeople
-        conv.imageUrl = membership.imageUrl
-        conv.lastChatMessageImageUrl = membership.lastChatMessageImageUrl
-
-        // 🔥 RÈGLE : s'il n'y a qu'UNE personne dans la conv -> c'est toi seul => "Vous"
-        if (membership.numberOfPeople ?? 0) <= 1 {
-            conv.title = "Vous"
-        }
-
-        return conv
-    }
-
-
-    func loadDTO(conversations: [Conversation], reset: Bool) {
-        if reset {
-            dataSource.removeAll()
-            dataSource.append(.filter(filter: ""))
-            if notificationsDisabled {
-                dataSource.append(.notificationRequest)
-            }
-        }
-
-        let startIndex = dataSource.count
-        let newItems = conversations.map { ConversationMainDTO.conversation(conversation: $0) }
-        dataSource.append(contentsOf: newItems)
-
-        DispatchQueue.main.async {
-            if reset {
-                self.ui_tableview.reloadData()
-            } else {
-                let indexPaths = (startIndex..<self.dataSource.count).map { IndexPath(row: $0, section: 0) }
-                self.ui_tableview.insertRows(at: indexPaths, with: .fade)
-            }
-        }
-    }
-
-    func loadDTO(smallTalks: [SmallTalk], reset: Bool) {
-        if reset {
-            dataSource.removeAll()
-            dataSource.append(.filter(filter: ""))
-            if notificationsDisabled {
-                dataSource.append(.notificationRequest)
-            }
-        }
-
-        let startIndex = dataSource.count
-        let newItems = smallTalks.map { ConversationMainDTO.smalltalk(smallTalk: $0) }
-        dataSource.append(contentsOf: newItems)
-
-        DispatchQueue.main.async {
-            if reset {
-                self.ui_tableview.reloadData()
-            } else {
-                let indexPaths = (startIndex..<self.dataSource.count).map { IndexPath(row: $0, section: 0) }
-                self.ui_tableview.insertRows(at: indexPaths, with: .fade)
-            }
-        }
-    }
-}
-
-// MARK: - Table View
-extension ConversationsMainHomeViewController: UITableViewDataSource, UITableViewDelegate {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return dataSource.count
-    }
-
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let dto = dataSource[indexPath.row]
-
+    private func handleShowConversation(dto: ConversationMainDTO) {
         switch dto {
-        case .notificationRequest:
-            let cell = tableView.dequeueReusableCell(withIdentifier: "ConversationNotifAskViewCell", for: indexPath) as! ConversationNotifAskViewCell
-            cell.configureText()
-            cell.selectionStyle = .none
-            return cell
-
         case .conversation(let conversation):
-            let cell = tableView.dequeueReusableCell(withIdentifier: "cell_user", for: indexPath) as! ConversationListMainCell
-            cell.populateCell(message: conversation, delegate: self, position: indexPath.row)
-            return cell
-
-        case .smalltalk(let smallTalk):
-            let cell = tableView.dequeueReusableCell(withIdentifier: "cell_user", for: indexPath) as! ConversationListMainCell
-            var conversation = Conversation(from: smallTalk)
-
-            let currentUserId = UserDefaults.currentUser?.sid
-            let filteredMembers = conversation.members?.filter { $0.uid != currentUserId } ?? []
-
-            if filteredMembers.isEmpty {
-                // 👇 Aucun autre membre que moi
-                conversation.title = "Vous"
-            } else {
-                let memberNames = filteredMembers.compactMap { $0.username }.joined(separator: " • ")
-                conversation.title = memberNames
-            }
-
-            cell.populateCell(message: conversation, delegate: self, position: indexPath.row)
-            return cell
-
-        case .filter(_):
-            let cell = tableView.dequeueReusableCell(withIdentifier: "FilterDiscussionCell", for: indexPath) as! FilterDiscussionCell
-            let filters = [
-                "event_conv_filter_all".localized,
-                "event_conv_filter_discussions".localized,
-                "event_conv_filter_events".localized,
-                "event_conv_filter_smalltalks".localized
-            ]
-            cell.configure(filters: filters, selectedFilter: selectedFilter)
-            cell.delegate = self
-            cell.selectionStyle = .none
-            return cell
-        }
-    }
-
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let dto = dataSource[indexPath.row]
-
-        switch dto {
-        case .filter(_):
-            return
-            
-        case .notificationRequest:
-            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-                DispatchQueue.main.async {
-                    if granted {
-                        self.notificationsDisabled = false
-                        self.loadConversations(reset: true)
-                    } else {
-                        // Navigation vers l'écran de réglages de notifications dans l'app
-                        let sb = UIStoryboard(name: StoryboardName.profileParams, bundle: nil)
-                        let vc = sb.instantiateViewController(withIdentifier: "paramsNotifsVC")
-                        self.present(vc, animated: true, completion: nil)
-                    }
-                }
-            }
-            return
-
-        case .conversation(let conversation):
-            // si small_talk, on appelle la bonne méthode
             if conversation.type == "small_talk" {
-                if let vc = storyboard?
-                    .instantiateViewController(withIdentifier: "detailMessagesVC")
-                    as? ConversationDetailMessagesViewController {
+                if let vc = storyboard?.instantiateViewController(withIdentifier: "detailMessagesVC") as? ConversationDetailMessagesViewController {
                     vc.type = "small_talk"
-                    vc.setupFromSmallTalk(
-                        smallTalkId: conversation.uid,
-                        title: conversation.title,
-                        delegate: self
-                    )
+                    vc.setupFromSmallTalk(smallTalkId: conversation.uid, title: conversation.title, delegate: self)
                     present(vc, animated: true)
                 }
-            }
-            else {
-                // comportement « historique » pour events/discussions
-                if let vc = storyboard?
-                    .instantiateViewController(withIdentifier: "detailMessagesVC")
-                    as? ConversationDetailMessagesViewController {
+            } else {
+                if let vc = storyboard?.instantiateViewController(withIdentifier: "detailMessagesVC") as? ConversationDetailMessagesViewController {
                     vc.type = conversation.type ?? ""
                     vc.setupFromOtherVC(
                         conversationId: conversation.uid,
@@ -343,7 +70,7 @@ extension ConversationsMainHomeViewController: UITableViewDataSource, UITableVie
                         isOneToOne: conversation.isOneToOne(),
                         conversation: conversation,
                         delegate: self,
-                        selectedIndexPath: indexPath
+                        selectedIndexPath: nil
                     )
                     present(vc, animated: true)
                 }
@@ -354,64 +81,38 @@ extension ConversationsMainHomeViewController: UITableViewDataSource, UITableVie
                 vc.setupFromSmallTalk(smallTalkId: smallTalk.id, title: smallTalk.name ?? "", delegate: self)
                 present(vc, animated: true)
             }
+        default:
+            break
         }
     }
 
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let offsetY = scrollView.contentOffset.y
-        let contentHeight = scrollView.contentSize.height
-        let frameHeight = scrollView.frame.size.height
-
-        if offsetY > contentHeight - frameHeight - 100 && !isLastPage {
-            loadConversations(reset: false)
+    private func handleShowProfile(userId: Int) {
+        if let profileVC = UIStoryboard(name: StoryboardName.profileParams, bundle: nil)
+            .instantiateViewController(withIdentifier: "profileFull") as? ProfilFullViewController {
+            profileVC.userIdToDisplay = "\(userId)"
+            profileVC.modalPresentationStyle = .fullScreen
+            self.present(profileVC, animated: true)
         }
     }
-}
 
-// MARK: - ConversationListMainCellDelegate
-extension ConversationsMainHomeViewController: ConversationListMainCellDelegate {
-    func showWebUrl(url: URL) {
-        WebLinkManager.openUrl(url: url, openInApp: true, presenterViewController: self)
-    }
-
-    func showUserDetail(_ position: Int) {
-        if case let .conversation(conversation) = dataSource[position] {
-            guard let userId = conversation.user?.uid else { return }
-
-            if let profileVC = UIStoryboard(name: StoryboardName.profileParams, bundle: nil)
-                .instantiateViewController(withIdentifier: "profileFull") as? ProfilFullViewController {
-                profileVC.userIdToDisplay = "\(userId)"
-                profileVC.modalPresentationStyle = .fullScreen
-                self.present(profileVC, animated: true)
+    private func handleNotificationRequest() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            DispatchQueue.main.async {
+                if granted {
+                    self.hostingController?.rootView.viewModel.notificationsDisabled = false
+                    self.hostingController?.rootView.viewModel.loadConversations(reset: true)
+                } else {
+                    let sb = UIStoryboard(name: StoryboardName.profileParams, bundle: nil)
+                    let vc = sb.instantiateViewController(withIdentifier: "paramsNotifsVC")
+                    self.present(vc, animated: true, completion: nil)
+                }
             }
         }
     }
 }
 
-// MARK: - UpdateUnreadCountDelegate
 extension ConversationsMainHomeViewController: UpdateUnreadCountDelegate {
     func updateUnreadCount(conversationId: Int, currentIndexPathSelected: IndexPath?) {
-        guard let currentIndexPathSelected = currentIndexPathSelected else { return }
-
-        if case var .conversation(conversation) = dataSource[currentIndexPathSelected.row] {
-            conversation.numberUnreadMessages = 0
-            dataSource[currentIndexPathSelected.row] = .conversation(conversation: conversation)
-        }
-
-        DispatchQueue.main.async {
-            if self.ui_tableview.numberOfRows(inSection: currentIndexPathSelected.section) > currentIndexPathSelected.row {
-                self.ui_tableview.reloadRows(at: [currentIndexPathSelected], with: .none)
-            } else {
-                self.ui_tableview.reloadData()
-            }
-        }
-    }
-}
-
-// MARK: - FilterDiscussionCellDelegate
-extension ConversationsMainHomeViewController: FilterDiscussionCellDelegate {
-    func onFilterClick(filter: String) {
-        self.selectedFilter = filter
-        loadConversations(reset: true)
+        hostingController?.rootView.viewModel.updateUnreadCount(conversationId: conversationId)
     }
 }

--- a/entourage/Scenes/Conversations/SwiftUI/ConversationFilterView.swift
+++ b/entourage/Scenes/Conversations/SwiftUI/ConversationFilterView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct ConversationFilterView: View {
+    let filters: [String]
+    @Binding var selectedFilter: String
+    var onFilterSelected: ((String) -> Void)?
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 10) {
+                ForEach(filters, id: \.self) { filter in
+                    Button(action: {
+                        selectedFilter = filter
+                        onFilterSelected?(filter)
+                    }) {
+                        Text(filter)
+                            .font(.custom("Quicksand-Bold", size: 13))
+                            .padding(.vertical, 0)
+                            .padding(.horizontal, 20)
+                            .frame(height: 40)
+                            .foregroundColor(filter == selectedFilter ? .white : Color("orange_app"))
+                            .background(filter == selectedFilter ? Color("orange_app_conv_event_clicked") : Color("orange_app_conv_event_unclicked"))
+                            .cornerRadius(20)
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 15)
+        }
+    }
+}

--- a/entourage/Scenes/Conversations/SwiftUI/ConversationListMainCellSwiftUI.swift
+++ b/entourage/Scenes/Conversations/SwiftUI/ConversationListMainCellSwiftUI.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+
+struct ConversationListMainCellSwiftUI: View {
+    var conversation: Conversation
+    var currentUserId: Int?
+    var isSmallTalk: Bool = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            // Avatar
+            ZStack {
+                if let urlString = isEvent ? conversation.imageUrl : conversation.user?.imageUrl,
+                   let url = URL(string: urlString), !urlString.isEmpty {
+                    AsyncImage(url: url) { phase in
+                        switch phase {
+                        case .empty:
+                            avatarPlaceholder
+                        case .success(let image):
+                            image
+                                .resizable()
+                                .scaledToFill()
+                        case .failure:
+                            avatarPlaceholder
+                        @unknown default:
+                            avatarPlaceholder
+                        }
+                    }
+                } else {
+                    avatarPlaceholder
+                }
+            }
+            .frame(width: 50, height: 50)
+            .clipShape(isEvent ? AnyShape(RoundedRectangle(cornerRadius: 10)) : AnyShape(Circle()))
+            .background(Color("Beige")) // fallback background
+
+            // Content
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(alignment: .top) {
+                    Text(title)
+                        .font(.custom("Quicksand-Bold", size: 15))
+                        .foregroundColor(.black)
+                        .lineLimit(1)
+
+                    Spacer(minLength: 8)
+
+                    if !isEvent, !conversation.hasUnread {
+                        Text(conversation.createdDateFormatted)
+                            .font(.custom("NunitoSans-Regular", size: 13))
+                            .foregroundColor(Color("gris_sombre_40"))
+                            .lineLimit(1)
+                    } else if !isEvent, conversation.hasUnread {
+                        Text(conversation.createdDateFormatted)
+                            .font(.custom("NunitoSans-Regular", size: 13))
+                            .foregroundColor(Color("orange_app"))
+                            .lineLimit(1)
+                    }
+                }
+
+                if isEvent, let role = conversation.subname {
+                    Text(role)
+                        .font(.custom("NunitoSans-Regular", size: 11))
+                        .foregroundColor(Color("orange_light"))
+                        .lineLimit(1)
+                } else if !isEvent, let rolesText = conversation.getRolesWithPartnerFormated(), !rolesText.isEmpty {
+                    Text(rolesText)
+                        .font(.custom("NunitoSans-Regular", size: 11))
+                        .foregroundColor(Color("orange_light"))
+                        .lineLimit(1)
+                }
+
+                HStack(alignment: .top) {
+                    Text(detailMessage)
+                        .font(conversation.hasUnread ? .custom("NunitoSans-SemiBold", size: 13) : .custom("NunitoSans-Regular", size: 13))
+                        .foregroundColor(detailMessageColor)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    if conversation.hasUnread {
+                        Text("\(conversation.numberUnreadMessages ?? 0)")
+                            .font(.custom("NunitoSans-Bold", size: 12))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color("orange_app"))
+                            .clipShape(Capsule())
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(Color.white)
+    }
+
+    // Properties
+
+    private var isEvent: Bool {
+        return conversation.type == "outing"
+    }
+
+    private var title: String {
+        if isSmallTalk {
+            let filteredMembers = conversation.members?.filter { $0.uid != currentUserId } ?? []
+            if filteredMembers.isEmpty {
+                return "Vous"
+            } else {
+                return filteredMembers.compactMap { $0.username }.joined(separator: " • ")
+            }
+        }
+
+        if let count = conversation.members_count, count > 2, let members = conversation.members {
+            let currentUsername = UserDefaults.currentUser?.displayName
+            let trimmedNames = members
+                .compactMap { $0.username }
+                .filter { $0 != currentUsername }
+                .prefix(5)
+                .map { username -> String in
+                    let end = username.index(username.endIndex, offsetBy: -2, limitedBy: username.startIndex) ?? username.startIndex
+                    let trimmed = String(username[..<end]).trimmingCharacters(in: .whitespaces)
+                    return trimmed
+                }
+            return trimmedNames.joined(separator: ", ")
+        }
+        return conversation.title ?? ""
+    }
+
+    private var detailMessage: String {
+        if conversation.imBlocker() {
+            return "message_user_blocked_by_me_list".localized
+        }
+        if let imgUrl = conversation.lastChatMessageImageUrl, !imgUrl.isEmpty {
+            return "📷 " + "photo".localized
+        }
+        return conversation.getLastMessage ?? ""
+    }
+
+    private var detailMessageColor: Color {
+        if conversation.imBlocker() {
+            return Color.red // .rougeErreur equivalent
+        }
+        if conversation.hasUnread {
+            return .black
+        }
+        return Color("gris_sombre_40")
+    }
+
+    @ViewBuilder
+    private var avatarPlaceholder: some View {
+        if isEvent {
+            Image("ic_placeholder_my_event")
+                .resizable()
+                .scaledToFit()
+                .padding(10)
+        } else {
+            Image("placeholder_user")
+                .resizable()
+                .scaledToFill()
+        }
+    }
+}

--- a/entourage/Scenes/Conversations/SwiftUI/ConversationNotifAskView.swift
+++ b/entourage/Scenes/Conversations/SwiftUI/ConversationNotifAskView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct ConversationNotifAskView: View {
+    var onRequestSelected: (() -> Void)?
+
+    var body: some View {
+        Button(action: {
+            onRequestSelected?()
+        }) {
+            HStack(alignment: .center, spacing: 10) {
+                Image("ic_notif_ask")
+                    .resizable()
+                    .frame(width: 20, height: 20)
+                    .padding(.leading, 10)
+
+                // For proper formatting we use a fallback or simply standard text because iOS 15+ supports Markdown in Text
+                // We'll mimic the underlined text
+                Text(getAttributedString())
+                    .font(.custom("NunitoSans-Regular", size: 15))
+                    .foregroundColor(.black)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(15)
+            .background(Color("Beige")) // Beige background like the original
+            .cornerRadius(15)
+        }
+        .padding(.horizontal, 15)
+        .padding(.vertical, 10)
+    }
+
+    private func getAttributedString() -> AttributedString {
+        let fullText = "conversation_notif_text".localized
+        let highlightedText = "conversation_notif_highlight".localized
+
+        var attributed = AttributedString(fullText)
+
+        if let range = attributed.range(of: highlightedText) {
+            attributed[range].font = Font.custom("NunitoSans-Bold", size: 15)
+            attributed[range].underlineStyle = .single
+        }
+
+        return attributed
+    }
+}

--- a/entourage/Scenes/Conversations/SwiftUI/ConversationsMainHomeView.swift
+++ b/entourage/Scenes/Conversations/SwiftUI/ConversationsMainHomeView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+struct ConversationsMainHomeView: View {
+    @StateObject var viewModel = ConversationsViewModel()
+
+    var onShowConversation: ((ConversationMainDTO) -> Void)?
+    var onShowProfile: ((Int) -> Void)?
+    var onShowWebUrl: ((URL) -> Void)?
+    var onRequestNotifications: (() -> Void)?
+
+    private let filters = [
+        "event_conv_filter_all".localized,
+        "event_conv_filter_discussions".localized,
+        "event_conv_filter_events".localized,
+        "event_conv_filter_smalltalks".localized
+    ]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header Image
+            Image("header_orange_light")
+                .resizable()
+                .scaledToFill()
+                .frame(height: 109)
+                .clipped()
+                .overlay(
+                    Text("Messages_title".localized)
+                        .font(.custom("Quicksand-Bold", size: 23))
+                        .foregroundColor(.black)
+                        .padding(.leading, 20)
+                        .padding(.bottom, 16),
+                    alignment: .bottomLeading
+                )
+                .background(Color.white)
+
+            // Selector View
+            ZStack(alignment: .top) {
+                Color.white
+
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(viewModel.dataSource, id: \.self) { dto in
+                            switch dto {
+                            case .filter:
+                                ConversationFilterView(
+                                    filters: filters,
+                                    selectedFilter: $viewModel.selectedFilter,
+                                    onFilterSelected: { filter in
+                                        viewModel.onFilterClick(filter: filter)
+                                    }
+                                )
+                                .padding(.bottom, 10)
+
+                            case .notificationRequest:
+                                ConversationNotifAskView {
+                                    onRequestNotifications?()
+                                }
+                                .padding(.bottom, 10)
+
+                            case .conversation(let conversation):
+                                ConversationListMainCellSwiftUI(
+                                    conversation: conversation,
+                                    currentUserId: UserDefaults.currentUser?.sid,
+                                    isSmallTalk: false
+                                )
+                                .onAppear {
+                                    viewModel.loadMoreIfNeeded(currentItem: dto)
+                                }
+                                .onTapGesture {
+                                    onShowConversation?(dto)
+                                }
+                                Divider().padding(.horizontal, 16)
+
+                            case .smalltalk(let smallTalk):
+                                ConversationListMainCellSwiftUI(
+                                    conversation: Conversation(from: smallTalk),
+                                    currentUserId: UserDefaults.currentUser?.sid,
+                                    isSmallTalk: true
+                                )
+                                .onAppear {
+                                    viewModel.loadMoreIfNeeded(currentItem: dto)
+                                }
+                                .onTapGesture {
+                                    onShowConversation?(dto)
+                                }
+                                Divider().padding(.horizontal, 16)
+                            }
+                        }
+                    }
+                    .padding(.top, 10)
+                }
+                .refreshable {
+                    viewModel.loadConversations(reset: true)
+                }
+                .background(Color.white)
+                .cornerRadius(ApplicationTheme.bigCornerRadius, corners: [.topLeft, .topRight]) // we'll use a custom corner shape or standard cornerRadius if the extension is not accessible in SwiftUI
+            }
+            .offset(y: -20)
+            .padding(.bottom, -20)
+        }
+        .background(Color.white)
+        .edgesIgnoringSafeArea(.top)
+    }
+}
+
+extension View {
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape(RoundedCorner(radius: radius, corners: corners))
+    }
+}
+
+struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
+}

--- a/entourage/Scenes/Conversations/SwiftUI/ConversationsViewModel.swift
+++ b/entourage/Scenes/Conversations/SwiftUI/ConversationsViewModel.swift
@@ -1,0 +1,190 @@
+import Foundation
+import Combine
+import SwiftUI
+
+class ConversationsViewModel: ObservableObject {
+    @Published var dataSource: [ConversationMainDTO] = []
+    @Published var notificationsDisabled: Bool = false
+    @Published var selectedFilter: String = "event_conv_filter_all".localized
+    @Published var isFetching = false
+
+    var isLastPage = false
+    var currentPage = 1
+    let perPage = 25
+
+    init() {
+        checkNotificationStatus()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(updateFilterSmallTalk), name: NSNotification.Name(kNotificationMessagesUpdateSmallTalkFilter), object: nil)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func updateFilterSmallTalk() {
+        self.selectedFilter = "event_conv_filter_smalltalks".localized
+        self.loadConversations(reset: true)
+    }
+
+    func checkNotificationStatus() {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                self.notificationsDisabled = settings.authorizationStatus != .authorized
+                // Reload DTO if needed to show/hide the notif cell
+                self.loadConversations(reset: true)
+            }
+        }
+    }
+
+    func onFilterClick(filter: String) {
+        self.selectedFilter = filter
+        loadConversations(reset: true)
+    }
+
+    private func membershipTypeParam() -> String? {
+        switch selectedFilter {
+        case "event_conv_filter_discussions".localized:
+            return "Conversation"
+        case "event_conv_filter_events".localized:
+            return "Outing"
+        case "event_conv_filter_smalltalks".localized:
+            return "Smalltalk"
+        default:
+            return nil
+        }
+    }
+
+    func loadConversations(reset: Bool) {
+        guard !isFetching else { return }
+        isFetching = true
+
+        if reset {
+            currentPage = 1
+            isLastPage = false
+            DispatchQueue.main.async {
+                self.dataSource.removeAll()
+                self.dataSource.append(.filter(filter: ""))
+                if self.notificationsDisabled {
+                    self.dataSource.append(.notificationRequest)
+                }
+            }
+        }
+
+        if selectedFilter == "event_conv_filter_smalltalks".localized {
+            SmallTalkService.listSmallTalks { [weak self] smallTalks, error in
+                guard let self = self else { return }
+                DispatchQueue.main.async {
+                    self.isFetching = false
+                    guard let smallTalks = smallTalks else { return }
+                    self.loadDTO(smallTalks: smallTalks, reset: reset)
+                }
+            }
+            return
+        }
+
+        let typeParam = membershipTypeParam()
+        MessagingService.getConversationMemberships(type: typeParam, page: currentPage, per: perPage) { [weak self] memberships, error in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                self.isFetching = false
+                guard let memberships = memberships else { return }
+
+                self.isLastPage = memberships.count < self.perPage
+                let conversations = memberships.map { self.conversation(from: $0) }
+                self.loadDTO(conversations: conversations, reset: reset)
+                self.currentPage += 1
+            }
+        }
+    }
+
+    func loadMoreIfNeeded(currentItem dto: ConversationMainDTO) {
+        guard !isLastPage, !isFetching else { return }
+        let thresholdIndex = dataSource.index(dataSource.endIndex, offsetBy: -5)
+        if let index = dataSource.firstIndex(where: {
+            if case .conversation(let c1) = $0, case .conversation(let c2) = dto { return c1.uid == c2.uid }
+            if case .smalltalk(let s1) = $0, case .smalltalk(let s2) = dto { return s1.id == s2.id }
+            return false
+        }), index >= thresholdIndex {
+            loadConversations(reset: false)
+        }
+    }
+
+    private func loadDTO(conversations: [Conversation], reset: Bool) {
+        let newItems = conversations.map { ConversationMainDTO.conversation(conversation: $0) }
+        dataSource.append(contentsOf: newItems)
+    }
+
+    private func loadDTO(smallTalks: [SmallTalk], reset: Bool) {
+        let newItems = smallTalks.map { ConversationMainDTO.smalltalk(smallTalk: $0) }
+        dataSource.append(contentsOf: newItems)
+    }
+
+    private func conversation(from membership: ConversationMembership) -> Conversation {
+        var conv = Conversation()
+        conv.uid = membership.id ?? 0
+        conv.type = membership.type
+        conv.title = membership.name
+        conv.subname = membership.subname
+
+        if let lastMessage = membership.lastMessage {
+            conv.lastMessage = lastMessage
+            conv.lastMessage?.dateStr = membership.lastChatMessageDate
+        } else if let dateStr = membership.lastChatMessageDate {
+            conv.lastMessage = LastMessage(text: nil, dateStr: dateStr)
+        }
+        conv.numberUnreadMessages = membership.numberOfUnreadMessages
+        conv.members_count = membership.numberOfPeople
+        conv.imageUrl = membership.imageUrl
+        conv.lastChatMessageImageUrl = membership.lastChatMessageImageUrl
+
+        if (membership.numberOfPeople ?? 0) <= 1 {
+            conv.title = "Vous"
+        }
+
+        return conv
+    }
+
+    func updateUnreadCount(conversationId: Int) {
+        if let index = dataSource.firstIndex(where: {
+            if case .conversation(let c) = $0 { return c.uid == conversationId }
+            return false
+        }) {
+            if case var .conversation(conv) = dataSource[index] {
+                conv.numberUnreadMessages = 0
+                dataSource[index] = .conversation(conversation: conv)
+            }
+        }
+    }
+}
+
+extension ConversationMainDTO: Hashable {
+    func hash(into hasher: inout Hasher) {
+        switch self {
+        case .notificationRequest:
+            hasher.combine("notificationRequest")
+        case .conversation(let conversation):
+            hasher.combine(conversation.uid)
+        case .filter(let filter):
+            hasher.combine("filter")
+            hasher.combine(filter)
+        case .smalltalk(let smallTalk):
+            hasher.combine(smallTalk.id)
+        }
+    }
+
+    static func == (lhs: ConversationMainDTO, rhs: ConversationMainDTO) -> Bool {
+        switch (lhs, rhs) {
+        case (.notificationRequest, .notificationRequest):
+            return true
+        case (.conversation(let lConv), .conversation(let rConv)):
+            return lConv.uid == rConv.uid
+        case (.filter(let lFilt), .filter(let rFilt)):
+            return lFilt == rFilt
+        case (.smalltalk(let lSt), .smalltalk(let rSt)):
+            return lSt.id == rSt.id
+        default:
+            return false
+        }
+    }
+}

--- a/entourage/Storyboards/Messages.storyboard
+++ b/entourage/Storyboards/Messages.storyboard
@@ -181,15 +181,15 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <outlet property="ui_bt_user" destination="XeF-8s-oP9" id="Yzm-Rd-sU7"/>
-                                            <outlet property="ui_date" destination="PAA-hS-bMj" id="73d-hP-rd6"/>
-                                            <outlet property="ui_detail_message" destination="VSX-1z-7hS" id="afn-n0-KZa"/>
-                                            <outlet property="ui_image" destination="SJz-D4-oGH" id="eKN-lv-CnQ"/>
-                                            <outlet property="ui_nb_unread" destination="HsN-gm-L3v" id="dlt-o4-q5d"/>
-                                            <outlet property="ui_picto_cat" destination="3os-WI-k5h" id="6cq-2y-Jmj"/>
-                                            <outlet property="ui_role" destination="Daz-jr-FTw" id="8Sc-RT-egc"/>
-                                            <outlet property="ui_username" destination="pVM-TK-TLe" id="wc7-cH-bk6"/>
-                                            <outlet property="ui_view_separator" destination="IXb-1d-soe" id="Yhh-8t-S4t"/>
+
+
+
+
+
+
+
+
+
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>
@@ -264,14 +264,14 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="ui_constraint_bottom_label" destination="6rN-8y-LCP" id="HzD-zJ-KGk"/>
-                        <outlet property="ui_image" destination="cRZ-PA-DJe" id="CNv-Mr-PIR"/>
-                        <outlet property="ui_image_constraint_height" destination="t3j-NT-qTz" id="GRM-SY-f7I"/>
-                        <outlet property="ui_image_inside_top_constraint" destination="haF-q3-TpP" id="a6s-Zs-rzg"/>
-                        <outlet property="ui_label_title" destination="kTZ-7t-qL7" id="YpQ-7A-WP9"/>
-                        <outlet property="ui_tableview" destination="QLq-8b-Nyr" id="Ijx-aX-jCJ"/>
-                        <outlet property="ui_view_height_constraint" destination="7nb-uA-6wa" id="23D-AT-koq"/>
-                        <outlet property="ui_view_selector" destination="6Rf-5V-aAC" id="mWO-P1-HIc"/>
+
+
+
+
+
+
+
+
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lIl-WD-LER" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
Refactored `ConversationsMainHomeViewController` and its cells to be 100% SwiftUI. This allowed us to cleanly manage UI states such as the "Event" cell hiding the last message date and moving the event sub-date under the title, while standard "Discussions" keep their normal behavior. Removed unused table view elements in the storyboard specifically for `ConversationsMainHomeViewController` while keeping everything intact for other controllers in the same storyboard. Added `SDWebImageSwiftUI` style `AsyncImage` for asynchronous image fetching with placeholders.

---
*PR created automatically by Jules for task [7672053727666132528](https://jules.google.com/task/7672053727666132528) started by @clemPerrousset*