### PR TITLE
Update smalltalk waiting icon

### DIFF
--- a/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/HomeSmallTalkCardView.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/HomeSmallTalkCardView.swift
@@ -65,10 +65,16 @@ struct HomeSmallTalkCardView: View {
 
     private func pendingView(count: Int) -> some View {
         HStack(alignment: .center, spacing: 15) {
-            Image("ic_waiting_home")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 50, height: 50)
+            ZStack {
+                Circle()
+                    .fill(Color("orange_app").opacity(0.15))
+                    .frame(width: 50, height: 50)
+                Image(systemName: "hourglass")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 24, height: 24)
+                    .foregroundColor(Color("orange_app"))
+            }
 
             VStack(alignment: .leading, spacing: 6) {
                 Text("small_talk_title_waiting".localized)


### PR DESCRIPTION
Update the smalltalk pending view icon to use the system hourglass icon in a circular background, based on the design screenshot provided.

---
*PR created automatically by Jules for task [5305501115070673901](https://jules.google.com/task/5305501115070673901) started by @clemPerrousset*