### PR TITLE
Use SwiftUI ConversationListMainCellSwiftUI in ConversationsMainHomeViewController

### DIFF
--- a/entourage.xcodeproj/project.pbxproj
+++ b/entourage.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		24EE59DE2FC092F2008E7291 /* ConversationListMainSwiftUICell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24EE59DD2FC092F2008E7291 /* ConversationListMainSwiftUICell.swift */; };
 		0203685127FEE55A00FABCBB /* EditProfileInterestCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0203685027FEE55A00FABCBB /* EditProfileInterestCell.swift */; };
 		02040CF2288E8C2E00AB1FBB /* EventParamsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02040CF1288E8C2E00AB1FBB /* EventParamsViewController.swift */; };
 		02040CF5288E97E000AB1FBB /* EventParamTopCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02040CF4288E97E000AB1FBB /* EventParamTopCell.swift */; };
@@ -644,6 +645,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		24EE59DD2FC092F2008E7291 /* ConversationListMainSwiftUICell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListMainSwiftUICell.swift; sourceTree = "<group>"; };
 		0203685027FEE55A00FABCBB /* EditProfileInterestCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileInterestCell.swift; sourceTree = "<group>"; };
 		02040CF1288E8C2E00AB1FBB /* EventParamsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventParamsViewController.swift; sourceTree = "<group>"; };
 		02040CF4288E97E000AB1FBB /* EventParamTopCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventParamTopCell.swift; sourceTree = "<group>"; };
@@ -2204,6 +2206,7 @@
 			isa = PBXGroup;
 			children = (
 				24EE59DB2FC092F1008E7291 /* ConversationListMainCellSwiftUI.swift */,
+				24EE59DD2FC092F2008E7291 /* ConversationListMainSwiftUICell.swift */,
 				24EE59AF2FC09292008E7291 /* ImageCache.swift */,
 				24EE59B02FC09292008E7291 /* ImageGridCell.swift */,
 				24EE59B12FC09292008E7291 /* ImageListViewController.swift */,
@@ -3138,6 +3141,7 @@
 				02D64F4D2799D5E000F6C4BD /* InviteSourceViewController.swift in Sources */,
 				02C91A29278F335000305E0B /* MainTabbarViewController.swift in Sources */,
 				24EE59DC2FC092F1008E7291 /* ConversationListMainCellSwiftUI.swift in Sources */,
+				24EE59DE2FC092F2008E7291 /* ConversationListMainSwiftUICell.swift in Sources */,
 				02040CFD288ED75100AB1FBB /* EventParamsCGUViewController.swift in Sources */,
 				02A3DD3927FDC72C0060EC2E /* NeighborhoodCreatePageViewController.swift in Sources */,
 				02EB4B542892B9C400CC977E /* EventDetailMessagesViewController.swift in Sources */,

--- a/entourage/Scenes/Conversations/ConversationsMainHomeViewController.swift
+++ b/entourage/Scenes/Conversations/ConversationsMainHomeViewController.swift
@@ -41,6 +41,7 @@ class ConversationsMainHomeViewController: UIViewController {
         
         ui_tableview.register(UINib(nibName: "ConversationNotifAskViewCell", bundle: nil), forCellReuseIdentifier: "ConversationNotifAskViewCell")
         ui_tableview.register(UINib(nibName: "FilterDiscussionCell", bundle: nil), forCellReuseIdentifier: "FilterDiscussionCell")
+        ui_tableview.register(ConversationListMainSwiftUICell.self, forCellReuseIdentifier: ConversationListMainSwiftUICell.identifier)
 
         setupViews()
         checkNotificationStatus()
@@ -256,12 +257,13 @@ extension ConversationsMainHomeViewController: UITableViewDataSource, UITableVie
             return cell
 
         case .conversation(let conversation):
-            let cell = tableView.dequeueReusableCell(withIdentifier: "cell_user", for: indexPath) as! ConversationListMainCell
-            cell.populateCell(message: conversation, delegate: self, position: indexPath.row)
+            let cell = tableView.dequeueReusableCell(withIdentifier: ConversationListMainSwiftUICell.identifier, for: indexPath) as! ConversationListMainSwiftUICell
+            let currentUserId = UserDefaults.currentUser?.sid
+            cell.configure(conversation: conversation, currentUserId: currentUserId, isSmallTalk: false)
             return cell
 
         case .smalltalk(let smallTalk):
-            let cell = tableView.dequeueReusableCell(withIdentifier: "cell_user", for: indexPath) as! ConversationListMainCell
+            let cell = tableView.dequeueReusableCell(withIdentifier: ConversationListMainSwiftUICell.identifier, for: indexPath) as! ConversationListMainSwiftUICell
             var conversation = Conversation(from: smallTalk)
 
             let currentUserId = UserDefaults.currentUser?.sid
@@ -275,7 +277,7 @@ extension ConversationsMainHomeViewController: UITableViewDataSource, UITableVie
                 conversation.title = memberNames
             }
 
-            cell.populateCell(message: conversation, delegate: self, position: indexPath.row)
+            cell.configure(conversation: conversation, currentUserId: currentUserId, isSmallTalk: true)
             return cell
 
         case .filter(_):

--- a/entourage/Scenes/Conversations/imagelist/ConversationListMainSwiftUICell.swift
+++ b/entourage/Scenes/Conversations/imagelist/ConversationListMainSwiftUICell.swift
@@ -1,0 +1,49 @@
+import UIKit
+import SwiftUI
+
+class ConversationListMainSwiftUICell: UITableViewCell {
+    class var identifier: String {
+        return String(describing: self)
+    }
+
+    private var hostingController: UIHostingController<ConversationListMainCellSwiftUI>?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.selectionStyle = .none
+        self.backgroundColor = .clear
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.selectionStyle = .none
+        self.backgroundColor = .clear
+    }
+
+    func configure(conversation: Conversation, currentUserId: Int?, isSmallTalk: Bool) {
+        let swiftUIView = ConversationListMainCellSwiftUI(
+            conversation: conversation,
+            currentUserId: currentUserId,
+            isSmallTalk: isSmallTalk
+        )
+
+        if let hostingController = hostingController {
+            hostingController.rootView = swiftUIView
+        } else {
+            let host = UIHostingController(rootView: swiftUIView)
+            host.view.translatesAutoresizingMaskIntoConstraints = false
+            host.view.backgroundColor = .clear
+
+            contentView.addSubview(host.view)
+
+            NSLayoutConstraint.activate([
+                host.view.topAnchor.constraint(equalTo: contentView.topAnchor),
+                host.view.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+                host.view.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                host.view.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+            ])
+
+            self.hostingController = host
+        }
+    }
+}


### PR DESCRIPTION
- Created `ConversationListMainSwiftUICell` to wrap `ConversationListMainCellSwiftUI` in a `UIHostingController`.
- Replaced `ConversationListMainCell` with `ConversationListMainSwiftUICell` in `ConversationsMainHomeViewController` for the `.conversation` and `.smalltalk` sections.
- Registered the new cell in `ConversationsMainHomeViewController`.
- Added the new file to `project.pbxproj`.

---
*PR created automatically by Jules for task [8019442139261404355](https://jules.google.com/task/8019442139261404355) started by @clemPerrousset*