### PR TITLE
Fix: Enforce 16:9 crop ratio for event images

### DIFF
--- a/entourage/Scenes/Events/Create/EventChoosePictureViewController.swift
+++ b/entourage/Scenes/Events/Create/EventChoosePictureViewController.swift
@@ -191,6 +191,7 @@ extension EventChoosePictureViewController: UIImagePickerControllerDelegate, UIN
         if let image = info[.originalImage] as? UIImage {
             var config = Mantis.Config()
             config.cropViewConfig.cropShapeType = .rect
+            config.presetFixedRatioType = .alwaysUsingOnePresetFixedRatio(ratio: 16.0 / 9.0)
             let cropViewController = Mantis.cropViewController(image: image, config: config)
             cropViewController.delegate = self
             cropViewController.modalPresentationStyle = .fullScreen


### PR DESCRIPTION
Configures Mantis crop view in `EventChoosePictureViewController` to always use a fixed 16:9 aspect ratio, per user request.

---
*PR created automatically by Jules for task [6077655945736726359](https://jules.google.com/task/6077655945736726359) started by @clemPerrousset*