### PR TITLE
UI: Reduce button size in full-screen photo view

### DIFF
--- a/entourage/Scenes/Conversations/FullScreenImageView.swift
+++ b/entourage/Scenes/Conversations/FullScreenImageView.swift
@@ -109,10 +109,9 @@ struct FullScreenImageView: View {
                         dismissAction()
                     }) {
                         Image(systemName: "chevron.left")
-                            .font(.system(size: 24, weight: .bold))
+                            .font(.system(size: 16, weight: .bold))
                             .foregroundColor(.white)
-                            .frame(width: 25, height: 25)
-                            .padding()
+                            .frame(width: 35, height: 35)
                             .background(Color.black.opacity(0.4))
                             .clipShape(Circle())
                     }
@@ -124,10 +123,9 @@ struct FullScreenImageView: View {
                             saveImage()
                         }) {
                             Image(systemName: "square.and.arrow.down")
-                                .font(.system(size: 24, weight: .bold))
+                                .font(.system(size: 16, weight: .bold))
                                 .foregroundColor(.white)
-                                .frame(width: 30, height: 30)
-                                .padding()
+                                .frame(width: 35, height: 35)
                                 .background(Color.black.opacity(0.4))
                                 .clipShape(Circle())
                         }


### PR DESCRIPTION
Reduced the size of the close and download buttons in the `FullScreenImageView` to make them less intrusive.
Adjusted the font size to 16pt and set the frame to 35x35 without extra padding to ensure a good balance between visual size and tap target area.

---
*PR created automatically by Jules for task [2897403538865665464](https://jules.google.com/task/2897403538865665464) started by @clemPerrousset*