### PR TITLE
Fix validation for custom photo uploads in Event Creation

### DIFF
--- a/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
+++ b/entourage/Scenes/Events/Create/EventCreateMainViewController.swift
@@ -393,7 +393,7 @@ extension EventCreateMainViewController: EventCreateMainDelegate {
         switch currentPhasePosition {
         case 1:
             //Check name / desc + img
-            if newEvent.title.count >= 2 && newEvent.descriptionEvent?.count ?? 0 > 2 && newEvent.imageId != nil {
+            if newEvent.title.count >= 2 && newEvent.descriptionEvent?.count ?? 0 > 2 && (newEvent.imageId != nil || newEvent.entourage_image_url != nil) {
                 isValid = true
             }
             message = "eventCreatePhase1_error".localized
@@ -467,7 +467,7 @@ extension EventCreateMainViewController: EventCreateMainDelegate {
     }
     
     func hasNoInput() -> Bool {
-        return newEvent.title.count == 0 && newEvent.descriptionEvent?.count ?? 0 == 0 && newEvent.imageId == nil
+        return newEvent.title.count == 0 && newEvent.descriptionEvent?.count ?? 0 == 0 && newEvent.imageId == nil && newEvent.entourage_image_url == nil
     }
 }
 


### PR DESCRIPTION
Fixes an issue where the "Next" button does not activate after uploading a custom photo from the gallery during Event Creation (Phase 1).

**Changes:**
- Updated `checkValidation()` in `EventCreateMainViewController` to check for `newEvent.entourage_image_url != nil` in addition to `newEvent.imageId != nil`.
- Updated `hasNoInput()` to also check `newEvent.entourage_image_url == nil`.

---
*PR created automatically by Jules for task [9827106721317251984](https://jules.google.com/task/9827106721317251984) started by @clemPerrousset*