### PR TITLE
Update home SmallTalk card behavior and layout

### DIFF
--- a/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/HomeSmallTalkCardView.swift
+++ b/entourage/Scenes/HomeV2/homev2cells/cell_small_talks/HomeSmallTalkCardView.swift
@@ -156,6 +156,8 @@ struct HomeSmallTalkCardView: View {
                         Text(textPending)
                             .font(.custom("NunitoSans-Regular", size: 14))
                             .foregroundColor(Color("orange_app"))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.top, 5)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -188,7 +190,7 @@ struct HomeSmallTalkCardView: View {
             }
             
             // --- BLOC DU BAS (Bouton de création centré sur la largeur complète) ---
-            if totalMatches < 3 {
+            if totalMatches < 3 && pendingCount == 0 {
                 Button(action: {
                     actionStart()
                 }) {
@@ -198,6 +200,7 @@ struct HomeSmallTalkCardView: View {
                         .multilineTextAlignment(.center)
                 }
                 .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.top, 5)
             }
             
         }


### PR DESCRIPTION
Update home SmallTalk card behavior and layout

- Hide the "Start new conversation" button if a match is pending or there are 3+ active/pending matches.
- Ensure the "matching in progress" text aligns securely to the left (with the title).
- Ensure the start button stays centered with restricted padding.

---
*PR created automatically by Jules for task [15174216100607349305](https://jules.google.com/task/15174216100607349305) started by @clemPerrousset*