### PR TITLE
Fix missing add photo button in event discussion

### DIFF
--- a/entourage/Scenes/Events/EventDetailFeedViewController.swift
+++ b/entourage/Scenes/Events/EventDetailFeedViewController.swift
@@ -399,6 +399,7 @@ class EventDetailFeedViewController: UIViewController {
                         let sb = UIStoryboard.init(name: StoryboardName.messages, bundle: nil)
                         if let vc = sb.instantiateViewController(withIdentifier: "detailMessagesVC") as? ConversationDetailMessagesViewController {
                             vc.setupFromOtherVC(conversationId: convId, title: self.event?.title, isOneToOne: true, conversation: conversation)
+                            vc.type = "outing"
                             self.present(vc, animated: true)
                         }
                     }
@@ -418,6 +419,7 @@ class EventDetailFeedViewController: UIViewController {
                     let sb = UIStoryboard.init(name: StoryboardName.messages, bundle: nil)
                     if let vc = sb.instantiateViewController(withIdentifier: "detailMessagesVC") as? ConversationDetailMessagesViewController {
                         vc.setupFromOtherVC(conversationId: convId, title: self.event?.title, isOneToOne: true, conversation: conversation)
+                        vc.type = "outing"
                         self.present(vc, animated: true)
                     }
                 }
@@ -818,6 +820,7 @@ extension EventDetailFeedViewController: EventDetailTopCellDelegate {
                 let sb = UIStoryboard.init(name: StoryboardName.messages, bundle: nil)
                 if let vc = sb.instantiateViewController(withIdentifier: "detailMessagesVC") as? ConversationDetailMessagesViewController {
                     vc.setupFromOtherVC(conversationId: convId, title: self.event?.title, isOneToOne: false, conversation: conversation)
+                    vc.type = "outing"
 
                     if let presentedVC = self.presentedViewController {
                         if presentedVC is ConversationDetailMessagesViewController { return }


### PR DESCRIPTION
The "+" button to add photos was missing when users entered a conversation from the event page. This issue was caused by omitting the `vc.type = "outing"` assignment before navigating to `ConversationDetailMessagesViewController`. I have updated all occurrences in `EventDetailFeedViewController.swift` where the conversation screen is instantiated so that it sets the correct type and the view displays the option to attach photos properly.

---
*PR created automatically by Jules for task [14553088838822553497](https://jules.google.com/task/14553088838822553497) started by @clemPerrousset*