### PR TITLE
Add user badges view in profile

### DIFF
--- a/entourage/Assets/ar.lproj/Localizable.strings
+++ b/entourage/Assets/ar.lproj/Localizable.strings
@@ -1764,3 +1764,38 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_small_talk_pending_plus_singular" = "+%d matching";
 "home_small_talk_start_new" = "+ Start a new discussion (%d/3)";
 "home_small_talk_view_button" = "See";
+
+// Badges
+"badges_title" = "Mes badges";
+"badges_subtitle" = "Vos badges Entourage";
+"badges_empty_desc" = "Chaque badge valorise une action concrète qui crée du lien dans la communauté. À vous de jouer !";
+"badges_filled_desc" = "%d obtenus, %d en cours, %d à découvrir. Chaque badge récompense une action concrète dans votre communauté.";
+
+"badges_how_it_works" = "Comment fonctionnent les badges ?";
+"badges_section_obtained" = "Obtenus";
+"badges_section_in_progress" = "En cours";
+"badges_section_not_started" = "Non commencés";
+"badges_section_all" = "Tous les badges";
+"badges_obtained_date" = "Obtenu le %@";
+
+"badge_premier_contact_name" = "Premier pas";
+"badge_premier_contact_desc" = "Terminez votre onboarding et faites votre première action — réaction, post, rejoindre un groupe ou participer à un événement — pour obtenir ce badge.";
+
+"badge_bienvenue_name" = "Premier lien";
+"badge_bienvenue_desc" = "Échangez un premier message en privé avec un autre membre";
+
+"badge_moteur_rencontres_name" = "Diffuseur de liens";
+"badge_moteur_rencontres_desc" = "Créez 3 événements sur 90 jours";
+"badge_moteur_rencontres_desc_short" = "Créez %d événements pour le décrocher";
+
+"badge_fidele_papotages_name" = "As du papotage";
+"badge_fidele_papotages_desc" = "Participez à 3 Papotages solidaires sur 90 jours";
+"badge_fidele_papotages_desc_short" = "Plus qu'1 Papotage pour décrocher";
+
+"badge_voix_presente_name" = "Tisseur de liens";
+"badge_voix_presente_desc" = "Soyez actif·ve (en postant, commentant, réagissant) dans vos groupes 3 semaines sur 4";
+"badge_voix_presente_desc_short" = "%d semaines actives sur 4 dernières";
+
+"badges_start_with" = "COMMENCEZ PAR";
+"badges_start_with_name" = "Le badge Premier pas 👣";
+"badges_start_with_button" = "Je me lance";

--- a/entourage/Assets/de.lproj/Localizable.strings
+++ b/entourage/Assets/de.lproj/Localizable.strings
@@ -1825,3 +1825,38 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_small_talk_pending_plus_singular" = "+%d matching";
 "home_small_talk_start_new" = "+ Start a new discussion (%d/3)";
 "home_small_talk_view_button" = "See";
+
+// Badges
+"badges_title" = "Mes badges";
+"badges_subtitle" = "Vos badges Entourage";
+"badges_empty_desc" = "Chaque badge valorise une action concrète qui crée du lien dans la communauté. À vous de jouer !";
+"badges_filled_desc" = "%d obtenus, %d en cours, %d à découvrir. Chaque badge récompense une action concrète dans votre communauté.";
+
+"badges_how_it_works" = "Comment fonctionnent les badges ?";
+"badges_section_obtained" = "Obtenus";
+"badges_section_in_progress" = "En cours";
+"badges_section_not_started" = "Non commencés";
+"badges_section_all" = "Tous les badges";
+"badges_obtained_date" = "Obtenu le %@";
+
+"badge_premier_contact_name" = "Premier pas";
+"badge_premier_contact_desc" = "Terminez votre onboarding et faites votre première action — réaction, post, rejoindre un groupe ou participer à un événement — pour obtenir ce badge.";
+
+"badge_bienvenue_name" = "Premier lien";
+"badge_bienvenue_desc" = "Échangez un premier message en privé avec un autre membre";
+
+"badge_moteur_rencontres_name" = "Diffuseur de liens";
+"badge_moteur_rencontres_desc" = "Créez 3 événements sur 90 jours";
+"badge_moteur_rencontres_desc_short" = "Créez %d événements pour le décrocher";
+
+"badge_fidele_papotages_name" = "As du papotage";
+"badge_fidele_papotages_desc" = "Participez à 3 Papotages solidaires sur 90 jours";
+"badge_fidele_papotages_desc_short" = "Plus qu'1 Papotage pour décrocher";
+
+"badge_voix_presente_name" = "Tisseur de liens";
+"badge_voix_presente_desc" = "Soyez actif·ve (en postant, commentant, réagissant) dans vos groupes 3 semaines sur 4";
+"badge_voix_presente_desc_short" = "%d semaines actives sur 4 dernières";
+
+"badges_start_with" = "COMMENCEZ PAR";
+"badges_start_with_name" = "Le badge Premier pas 👣";
+"badges_start_with_button" = "Je me lance";

--- a/entourage/Assets/en.lproj/Localizable.strings
+++ b/entourage/Assets/en.lproj/Localizable.strings
@@ -2044,3 +2044,38 @@
 "home_v2_welcome_national_title" = "Join a group that suits you";
 "home_v2_welcome_national_subtitle" = "Members all over France share your interests. Join them.";
 "home_v2_welcome_national_btn" = "Discover groups";
+
+// Badges
+"badges_title" = "Mes badges";
+"badges_subtitle" = "Vos badges Entourage";
+"badges_empty_desc" = "Chaque badge valorise une action concrète qui crée du lien dans la communauté. À vous de jouer !";
+"badges_filled_desc" = "%d obtenus, %d en cours, %d à découvrir. Chaque badge récompense une action concrète dans votre communauté.";
+
+"badges_how_it_works" = "Comment fonctionnent les badges ?";
+"badges_section_obtained" = "Obtenus";
+"badges_section_in_progress" = "En cours";
+"badges_section_not_started" = "Non commencés";
+"badges_section_all" = "Tous les badges";
+"badges_obtained_date" = "Obtenu le %@";
+
+"badge_premier_contact_name" = "Premier pas";
+"badge_premier_contact_desc" = "Terminez votre onboarding et faites votre première action — réaction, post, rejoindre un groupe ou participer à un événement — pour obtenir ce badge.";
+
+"badge_bienvenue_name" = "Premier lien";
+"badge_bienvenue_desc" = "Échangez un premier message en privé avec un autre membre";
+
+"badge_moteur_rencontres_name" = "Diffuseur de liens";
+"badge_moteur_rencontres_desc" = "Créez 3 événements sur 90 jours";
+"badge_moteur_rencontres_desc_short" = "Créez %d événements pour le décrocher";
+
+"badge_fidele_papotages_name" = "As du papotage";
+"badge_fidele_papotages_desc" = "Participez à 3 Papotages solidaires sur 90 jours";
+"badge_fidele_papotages_desc_short" = "Plus qu'1 Papotage pour décrocher";
+
+"badge_voix_presente_name" = "Tisseur de liens";
+"badge_voix_presente_desc" = "Soyez actif·ve (en postant, commentant, réagissant) dans vos groupes 3 semaines sur 4";
+"badge_voix_presente_desc_short" = "%d semaines actives sur 4 dernières";
+
+"badges_start_with" = "COMMENCEZ PAR";
+"badges_start_with_name" = "Le badge Premier pas 👣";
+"badges_start_with_button" = "Je me lance";

--- a/entourage/Assets/es.lproj/Localizable.strings
+++ b/entourage/Assets/es.lproj/Localizable.strings
@@ -3248,3 +3248,38 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_small_talk_pending_plus_singular" = "+%d matching";
 "home_small_talk_start_new" = "+ Start a new discussion (%d/3)";
 "home_small_talk_view_button" = "See";
+
+// Badges
+"badges_title" = "Mes badges";
+"badges_subtitle" = "Vos badges Entourage";
+"badges_empty_desc" = "Chaque badge valorise une action concrète qui crée du lien dans la communauté. À vous de jouer !";
+"badges_filled_desc" = "%d obtenus, %d en cours, %d à découvrir. Chaque badge récompense une action concrète dans votre communauté.";
+
+"badges_how_it_works" = "Comment fonctionnent les badges ?";
+"badges_section_obtained" = "Obtenus";
+"badges_section_in_progress" = "En cours";
+"badges_section_not_started" = "Non commencés";
+"badges_section_all" = "Tous les badges";
+"badges_obtained_date" = "Obtenu le %@";
+
+"badge_premier_contact_name" = "Premier pas";
+"badge_premier_contact_desc" = "Terminez votre onboarding et faites votre première action — réaction, post, rejoindre un groupe ou participer à un événement — pour obtenir ce badge.";
+
+"badge_bienvenue_name" = "Premier lien";
+"badge_bienvenue_desc" = "Échangez un premier message en privé avec un autre membre";
+
+"badge_moteur_rencontres_name" = "Diffuseur de liens";
+"badge_moteur_rencontres_desc" = "Créez 3 événements sur 90 jours";
+"badge_moteur_rencontres_desc_short" = "Créez %d événements pour le décrocher";
+
+"badge_fidele_papotages_name" = "As du papotage";
+"badge_fidele_papotages_desc" = "Participez à 3 Papotages solidaires sur 90 jours";
+"badge_fidele_papotages_desc_short" = "Plus qu'1 Papotage pour décrocher";
+
+"badge_voix_presente_name" = "Tisseur de liens";
+"badge_voix_presente_desc" = "Soyez actif·ve (en postant, commentant, réagissant) dans vos groupes 3 semaines sur 4";
+"badge_voix_presente_desc_short" = "%d semaines actives sur 4 dernières";
+
+"badges_start_with" = "COMMENCEZ PAR";
+"badges_start_with_name" = "Le badge Premier pas 👣";
+"badges_start_with_button" = "Je me lance";

--- a/entourage/Assets/fr.lproj/Localizable.strings
+++ b/entourage/Assets/fr.lproj/Localizable.strings
@@ -2064,3 +2064,38 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_v2_welcome_national_subtitle" = "Des membres partout en France partagent vos centres d'intérêt. Rejoignez-les.";
 "home_v2_welcome_national_btn" = "Découvrir les groupes";
 
+
+// Badges
+"badges_title" = "Mes badges";
+"badges_subtitle" = "Vos badges Entourage";
+"badges_empty_desc" = "Chaque badge valorise une action concrète qui crée du lien dans la communauté. À vous de jouer !";
+"badges_filled_desc" = "%d obtenus, %d en cours, %d à découvrir. Chaque badge récompense une action concrète dans votre communauté.";
+
+"badges_how_it_works" = "Comment fonctionnent les badges ?";
+"badges_section_obtained" = "Obtenus";
+"badges_section_in_progress" = "En cours";
+"badges_section_not_started" = "Non commencés";
+"badges_section_all" = "Tous les badges";
+"badges_obtained_date" = "Obtenu le %@";
+
+"badge_premier_contact_name" = "Premier pas";
+"badge_premier_contact_desc" = "Terminez votre onboarding et faites votre première action — réaction, post, rejoindre un groupe ou participer à un événement — pour obtenir ce badge.";
+
+"badge_bienvenue_name" = "Premier lien";
+"badge_bienvenue_desc" = "Échangez un premier message en privé avec un autre membre";
+
+"badge_moteur_rencontres_name" = "Diffuseur de liens";
+"badge_moteur_rencontres_desc" = "Créez 3 événements sur 90 jours";
+"badge_moteur_rencontres_desc_short" = "Créez %d événements pour le décrocher";
+
+"badge_fidele_papotages_name" = "As du papotage";
+"badge_fidele_papotages_desc" = "Participez à 3 Papotages solidaires sur 90 jours";
+"badge_fidele_papotages_desc_short" = "Plus qu'1 Papotage pour décrocher";
+
+"badge_voix_presente_name" = "Tisseur de liens";
+"badge_voix_presente_desc" = "Soyez actif·ve (en postant, commentant, réagissant) dans vos groupes 3 semaines sur 4";
+"badge_voix_presente_desc_short" = "%d semaines actives sur 4 dernières";
+
+"badges_start_with" = "COMMENCEZ PAR";
+"badges_start_with_name" = "Le badge Premier pas 👣";
+"badges_start_with_button" = "Je me lance";

--- a/entourage/Assets/hr.lproj/Localizable.strings
+++ b/entourage/Assets/hr.lproj/Localizable.strings
@@ -1454,3 +1454,38 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_small_talk_pending_plus_singular" = "+%d matching";
 "home_small_talk_start_new" = "+ Start a new discussion (%d/3)";
 "home_small_talk_view_button" = "See";
+
+// Badges
+"badges_title" = "Mes badges";
+"badges_subtitle" = "Vos badges Entourage";
+"badges_empty_desc" = "Chaque badge valorise une action concrète qui crée du lien dans la communauté. À vous de jouer !";
+"badges_filled_desc" = "%d obtenus, %d en cours, %d à découvrir. Chaque badge récompense une action concrète dans votre communauté.";
+
+"badges_how_it_works" = "Comment fonctionnent les badges ?";
+"badges_section_obtained" = "Obtenus";
+"badges_section_in_progress" = "En cours";
+"badges_section_not_started" = "Non commencés";
+"badges_section_all" = "Tous les badges";
+"badges_obtained_date" = "Obtenu le %@";
+
+"badge_premier_contact_name" = "Premier pas";
+"badge_premier_contact_desc" = "Terminez votre onboarding et faites votre première action — réaction, post, rejoindre un groupe ou participer à un événement — pour obtenir ce badge.";
+
+"badge_bienvenue_name" = "Premier lien";
+"badge_bienvenue_desc" = "Échangez un premier message en privé avec un autre membre";
+
+"badge_moteur_rencontres_name" = "Diffuseur de liens";
+"badge_moteur_rencontres_desc" = "Créez 3 événements sur 90 jours";
+"badge_moteur_rencontres_desc_short" = "Créez %d événements pour le décrocher";
+
+"badge_fidele_papotages_name" = "As du papotage";
+"badge_fidele_papotages_desc" = "Participez à 3 Papotages solidaires sur 90 jours";
+"badge_fidele_papotages_desc_short" = "Plus qu'1 Papotage pour décrocher";
+
+"badge_voix_presente_name" = "Tisseur de liens";
+"badge_voix_presente_desc" = "Soyez actif·ve (en postant, commentant, réagissant) dans vos groupes 3 semaines sur 4";
+"badge_voix_presente_desc_short" = "%d semaines actives sur 4 dernières";
+
+"badges_start_with" = "COMMENCEZ PAR";
+"badges_start_with_name" = "Le badge Premier pas 👣";
+"badges_start_with_button" = "Je me lance";

--- a/entourage/Assets/pl.lproj/Localizable.strings
+++ b/entourage/Assets/pl.lproj/Localizable.strings
@@ -1839,3 +1839,38 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_small_talk_pending_plus_singular" = "+%d matching";
 "home_small_talk_start_new" = "+ Start a new discussion (%d/3)";
 "home_small_talk_view_button" = "See";
+
+// Badges
+"badges_title" = "Mes badges";
+"badges_subtitle" = "Vos badges Entourage";
+"badges_empty_desc" = "Chaque badge valorise une action concrète qui crée du lien dans la communauté. À vous de jouer !";
+"badges_filled_desc" = "%d obtenus, %d en cours, %d à découvrir. Chaque badge récompense une action concrète dans votre communauté.";
+
+"badges_how_it_works" = "Comment fonctionnent les badges ?";
+"badges_section_obtained" = "Obtenus";
+"badges_section_in_progress" = "En cours";
+"badges_section_not_started" = "Non commencés";
+"badges_section_all" = "Tous les badges";
+"badges_obtained_date" = "Obtenu le %@";
+
+"badge_premier_contact_name" = "Premier pas";
+"badge_premier_contact_desc" = "Terminez votre onboarding et faites votre première action — réaction, post, rejoindre un groupe ou participer à un événement — pour obtenir ce badge.";
+
+"badge_bienvenue_name" = "Premier lien";
+"badge_bienvenue_desc" = "Échangez un premier message en privé avec un autre membre";
+
+"badge_moteur_rencontres_name" = "Diffuseur de liens";
+"badge_moteur_rencontres_desc" = "Créez 3 événements sur 90 jours";
+"badge_moteur_rencontres_desc_short" = "Créez %d événements pour le décrocher";
+
+"badge_fidele_papotages_name" = "As du papotage";
+"badge_fidele_papotages_desc" = "Participez à 3 Papotages solidaires sur 90 jours";
+"badge_fidele_papotages_desc_short" = "Plus qu'1 Papotage pour décrocher";
+
+"badge_voix_presente_name" = "Tisseur de liens";
+"badge_voix_presente_desc" = "Soyez actif·ve (en postant, commentant, réagissant) dans vos groupes 3 semaines sur 4";
+"badge_voix_presente_desc_short" = "%d semaines actives sur 4 dernières";
+
+"badges_start_with" = "COMMENCEZ PAR";
+"badges_start_with_name" = "Le badge Premier pas 👣";
+"badges_start_with_button" = "Je me lance";

--- a/entourage/Assets/ro.lproj/Localizable.strings
+++ b/entourage/Assets/ro.lproj/Localizable.strings
@@ -1728,3 +1728,38 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_small_talk_pending_plus_singular" = "+%d matching";
 "home_small_talk_start_new" = "+ Start a new discussion (%d/3)";
 "home_small_talk_view_button" = "See";
+
+// Badges
+"badges_title" = "Mes badges";
+"badges_subtitle" = "Vos badges Entourage";
+"badges_empty_desc" = "Chaque badge valorise une action concrète qui crée du lien dans la communauté. À vous de jouer !";
+"badges_filled_desc" = "%d obtenus, %d en cours, %d à découvrir. Chaque badge récompense une action concrète dans votre communauté.";
+
+"badges_how_it_works" = "Comment fonctionnent les badges ?";
+"badges_section_obtained" = "Obtenus";
+"badges_section_in_progress" = "En cours";
+"badges_section_not_started" = "Non commencés";
+"badges_section_all" = "Tous les badges";
+"badges_obtained_date" = "Obtenu le %@";
+
+"badge_premier_contact_name" = "Premier pas";
+"badge_premier_contact_desc" = "Terminez votre onboarding et faites votre première action — réaction, post, rejoindre un groupe ou participer à un événement — pour obtenir ce badge.";
+
+"badge_bienvenue_name" = "Premier lien";
+"badge_bienvenue_desc" = "Échangez un premier message en privé avec un autre membre";
+
+"badge_moteur_rencontres_name" = "Diffuseur de liens";
+"badge_moteur_rencontres_desc" = "Créez 3 événements sur 90 jours";
+"badge_moteur_rencontres_desc_short" = "Créez %d événements pour le décrocher";
+
+"badge_fidele_papotages_name" = "As du papotage";
+"badge_fidele_papotages_desc" = "Participez à 3 Papotages solidaires sur 90 jours";
+"badge_fidele_papotages_desc_short" = "Plus qu'1 Papotage pour décrocher";
+
+"badge_voix_presente_name" = "Tisseur de liens";
+"badge_voix_presente_desc" = "Soyez actif·ve (en postant, commentant, réagissant) dans vos groupes 3 semaines sur 4";
+"badge_voix_presente_desc_short" = "%d semaines actives sur 4 dernières";
+
+"badges_start_with" = "COMMENCEZ PAR";
+"badges_start_with_name" = "Le badge Premier pas 👣";
+"badges_start_with_button" = "Je me lance";

--- a/entourage/Assets/uk.lproj/Localizable.strings
+++ b/entourage/Assets/uk.lproj/Localizable.strings
@@ -1805,3 +1805,38 @@ Il semble qu'elle n'ait pas sa place sur le réseau,\nmais vous pouvez toujours 
 "home_small_talk_pending_plus_singular" = "+%d matching";
 "home_small_talk_start_new" = "+ Start a new discussion (%d/3)";
 "home_small_talk_view_button" = "See";
+
+// Badges
+"badges_title" = "Mes badges";
+"badges_subtitle" = "Vos badges Entourage";
+"badges_empty_desc" = "Chaque badge valorise une action concrète qui crée du lien dans la communauté. À vous de jouer !";
+"badges_filled_desc" = "%d obtenus, %d en cours, %d à découvrir. Chaque badge récompense une action concrète dans votre communauté.";
+
+"badges_how_it_works" = "Comment fonctionnent les badges ?";
+"badges_section_obtained" = "Obtenus";
+"badges_section_in_progress" = "En cours";
+"badges_section_not_started" = "Non commencés";
+"badges_section_all" = "Tous les badges";
+"badges_obtained_date" = "Obtenu le %@";
+
+"badge_premier_contact_name" = "Premier pas";
+"badge_premier_contact_desc" = "Terminez votre onboarding et faites votre première action — réaction, post, rejoindre un groupe ou participer à un événement — pour obtenir ce badge.";
+
+"badge_bienvenue_name" = "Premier lien";
+"badge_bienvenue_desc" = "Échangez un premier message en privé avec un autre membre";
+
+"badge_moteur_rencontres_name" = "Diffuseur de liens";
+"badge_moteur_rencontres_desc" = "Créez 3 événements sur 90 jours";
+"badge_moteur_rencontres_desc_short" = "Créez %d événements pour le décrocher";
+
+"badge_fidele_papotages_name" = "As du papotage";
+"badge_fidele_papotages_desc" = "Participez à 3 Papotages solidaires sur 90 jours";
+"badge_fidele_papotages_desc_short" = "Plus qu'1 Papotage pour décrocher";
+
+"badge_voix_presente_name" = "Tisseur de liens";
+"badge_voix_presente_desc" = "Soyez actif·ve (en postant, commentant, réagissant) dans vos groupes 3 semaines sur 4";
+"badge_voix_presente_desc_short" = "%d semaines actives sur 4 dernières";
+
+"badges_start_with" = "COMMENCEZ PAR";
+"badges_start_with_name" = "Le badge Premier pas 👣";
+"badges_start_with_button" = "Je me lance";

--- a/entourage/Models/Badge.swift
+++ b/entourage/Models/Badge.swift
@@ -1,0 +1,40 @@
+//
+//  Badge.swift
+//  entourage
+//
+
+import Foundation
+
+struct Badge: Codable {
+    var name: String
+    var date: String?
+    var progression: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case date
+        case progression
+    }
+
+    init(from decoder: Decoder) throws {
+        if let container = try? decoder.singleValueContainer(), let str = try? container.decode(String.self) {
+            self.name = str
+            self.date = nil
+            self.progression = nil
+        } else {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            // Some backends might return a dictionary right away. Let's try to get name
+            // If name is not present as a key, maybe it's just strings.
+            // But we requested it to be "name", "date", "progression".
+            self.name = (try? container.decode(String.self, forKey: .name)) ?? "unknown"
+            self.date = try? container.decode(String.self, forKey: .date)
+            self.progression = try? container.decode(Int.self, forKey: .progression)
+        }
+    }
+
+    init(name: String, date: String? = nil, progression: Int? = nil) {
+        self.name = name
+        self.date = date
+        self.progression = progression
+    }
+}

--- a/entourage/Models/Home.swift
+++ b/entourage/Models/Home.swift
@@ -24,6 +24,8 @@ struct UserHome:Codable {
     var signablePermission:Bool? = nil
     var association:Bool? = false
 
+    var badge: String? = nil
+    var badges: [Badge]? = nil
     
     var congratulations = HomeActions()
     
@@ -52,6 +54,8 @@ struct UserHome:Codable {
         case events = "events"
         case signablePermission = "signable_permission"
         case association
+        case badge = "badge"
+        case badges = "badges"
     }
 }
 

--- a/entourage/Scenes/Badges/BadgesView.swift
+++ b/entourage/Scenes/Badges/BadgesView.swift
@@ -1,0 +1,301 @@
+import SwiftUI
+
+struct BadgesView: View {
+    @StateObject private var viewModel = BadgesViewModel()
+    @Environment(\.presentationMode) var presentationMode
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Custom Navigation Bar
+            HStack {
+                Button(action: {
+                    presentationMode.wrappedValue.dismiss()
+                }) {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.black)
+                        .font(.system(size: 18, weight: .bold))
+                }
+                .padding(.leading, 16)
+
+                Spacer()
+
+                Text("badges_title".localized)
+                    .font(Font(UIFont(name: "NunitoSans-Bold", size: 16) ?? UIFont.systemFont(ofSize: 16, weight: .bold)))
+                    .foregroundColor(.black)
+
+                Spacer()
+
+                // Placeholder to balance the chevron
+                Image(systemName: "chevron.left")
+                    .foregroundColor(.clear)
+                    .padding(.trailing, 16)
+            }
+            .frame(height: 50)
+            .background(Color.white)
+
+            if viewModel.isLoading {
+                Spacer()
+                ProgressView()
+                Spacer()
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 24) {
+                        if viewModel.hasAnyProgression {
+                            filledHeaderView
+                        } else {
+                            emptyHeaderView
+                        }
+
+                        if viewModel.hasAnyProgression {
+                            if !viewModel.obtainedBadges.isEmpty {
+                                badgeSection(title: "badges_section_obtained".localized, count: viewModel.obtainedBadges.count, total: 5, badges: viewModel.obtainedBadges, type: .obtained)
+                            }
+                            if !viewModel.inProgressBadges.isEmpty {
+                                badgeSection(title: "badges_section_in_progress".localized, count: viewModel.inProgressBadges.count, total: 5, badges: viewModel.inProgressBadges, type: .inProgress)
+                            }
+                            if !viewModel.notStartedBadges.isEmpty {
+                                badgeSection(title: "badges_section_not_started".localized, count: viewModel.notStartedBadges.count, total: 5, badges: viewModel.notStartedBadges, type: .notStarted)
+                            }
+                        } else {
+                            badgeSection(title: "badges_section_all".localized, count: 0, total: 5, badges: viewModel.badges, type: .notStarted)
+                        }
+
+                        // Footer Link
+                        Button(action: {
+                            // Link to help if needed
+                        }) {
+                            Text("badges_how_it_works".localized)
+                                .font(Font(UIFont(name: "NunitoSans-Bold", size: 14) ?? UIFont.systemFont(ofSize: 14, weight: .bold)))
+                                .foregroundColor(Color(red: 0.94, green: 0.44, blue: 0.17)) // Entourage orange
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding(.top, 16)
+                        }
+
+                        Spacer().frame(height: 40)
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 24)
+                }
+                .background(Color(red: 0.98, green: 0.98, blue: 0.98)) // light gray background
+            }
+        }
+        .onAppear {
+            viewModel.fetchBadges()
+        }
+    }
+
+    // MARK: - Header Views
+
+    var emptyHeaderView: some View {
+        VStack(spacing: 24) {
+            // Emjois at top
+            HStack(spacing: 16) {
+                Text("👣").font(.system(size: 24))
+                Text("🤝").font(.system(size: 24))
+                Text("💫").font(.system(size: 32)) // bigger center
+                Text("💬").font(.system(size: 24))
+                Text("🌱").font(.system(size: 24))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 16)
+
+            VStack(spacing: 8) {
+                Text("badges_subtitle".localized)
+                    .font(Font(UIFont(name: "NunitoSans-Bold", size: 24) ?? UIFont.systemFont(ofSize: 24, weight: .bold)))
+                    .foregroundColor(Color(red: 0.2, green: 0.2, blue: 0.2)) // dark gray
+
+                Text("badges_empty_desc".localized)
+                    .font(Font(UIFont(name: "NunitoSans-Regular", size: 14) ?? UIFont.systemFont(ofSize: 14)))
+                    .foregroundColor(Color(red: 0.4, green: 0.4, blue: 0.4))
+                    .multilineTextAlignment(.center)
+            }
+
+            // Orange Box
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .top, spacing: 12) {
+                    Circle()
+                        .fill(Color.white)
+                        .frame(width: 48, height: 48)
+                        .overlay(Text("👣").font(.system(size: 24)))
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("badges_start_with".localized)
+                            .font(Font(UIFont(name: "NunitoSans-Bold", size: 12) ?? UIFont.systemFont(ofSize: 12, weight: .bold)))
+                            .foregroundColor(Color(red: 0.94, green: 0.44, blue: 0.17))
+
+                        Text("badges_start_with_name".localized)
+                            .font(Font(UIFont(name: "NunitoSans-Bold", size: 16) ?? UIFont.systemFont(ofSize: 16, weight: .bold)))
+                            .foregroundColor(.black)
+                    }
+                }
+
+                Text("badge_premier_contact_desc".localized)
+                    .font(Font(UIFont(name: "NunitoSans-Regular", size: 14) ?? UIFont.systemFont(ofSize: 14)))
+                    .foregroundColor(Color(red: 0.4, green: 0.4, blue: 0.4))
+
+                Button(action: {
+                    // Do nothing for now
+                }) {
+                    Text("badges_start_with_button".localized)
+                        .font(Font(UIFont(name: "NunitoSans-Bold", size: 14) ?? UIFont.systemFont(ofSize: 14, weight: .bold)))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 12)
+                        .background(Color(red: 0.94, green: 0.44, blue: 0.17))
+                        .cornerRadius(24)
+                }
+            }
+            .padding(16)
+            .background(Color.appBeige)
+            .cornerRadius(16)
+        }
+        .padding(.bottom, 8)
+    }
+
+    var filledHeaderView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("badges_subtitle".localized)
+                .font(Font(UIFont(name: "NunitoSans-Bold", size: 24) ?? UIFont.systemFont(ofSize: 24, weight: .bold)))
+                .foregroundColor(Color(red: 0.2, green: 0.2, blue: 0.2)) // dark gray
+
+            Text(String(format: "badges_filled_desc".localized, viewModel.obtainedBadges.count, viewModel.inProgressBadges.count, viewModel.notStartedBadges.count))
+                .font(Font(UIFont(name: "NunitoSans-Regular", size: 14) ?? UIFont.systemFont(ofSize: 14)))
+                .foregroundColor(Color(red: 0.4, green: 0.4, blue: 0.4))
+        }
+    }
+
+    // MARK: - Badge Sections
+
+    enum BadgeSectionType {
+        case obtained, inProgress, notStarted
+    }
+
+    func badgeSection(title: String, count: Int, total: Int, badges: [Badge], type: BadgeSectionType) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 8) {
+                Text(title)
+                    .font(Font(UIFont(name: "NunitoSans-Bold", size: 16) ?? UIFont.systemFont(ofSize: 16, weight: .bold)))
+                    .foregroundColor(.black)
+                Text("\(count)/\(total)")
+                    .font(Font(UIFont(name: "NunitoSans-Regular", size: 16) ?? UIFont.systemFont(ofSize: 16)))
+                    .foregroundColor(Color(red: 0.6, green: 0.6, blue: 0.6))
+            }
+
+            VStack(spacing: 12) {
+                ForEach(badges, id: \.name) { badge in
+                    badgeCard(for: badge, type: type)
+                }
+            }
+        }
+    }
+
+    func badgeCard(for badge: Badge, type: BadgeSectionType) -> some View {
+        let isNotStarted = (type == .notStarted)
+
+        return HStack(alignment: .top, spacing: 16) {
+            // Icon
+            Circle()
+                .fill(isNotStarted ? Color(red: 0.95, green: 0.95, blue: 0.95) : Color.appBeige)
+                .frame(width: 48, height: 48)
+                .overlay(Text(getEmoji(for: badge.name)).font(.system(size: 24)).grayscale(isNotStarted ? 0.99 : 0.0).opacity(isNotStarted ? 0.5 : 1.0))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("badge_\(badge.name)_name".localized)
+                    .font(Font(UIFont(name: "NunitoSans-Bold", size: 14) ?? UIFont.systemFont(ofSize: 14, weight: .bold)))
+                    .foregroundColor(isNotStarted ? Color(red: 0.4, green: 0.4, blue: 0.4) : .black)
+
+                if type == .obtained {
+                    Text(String(format: "badges_obtained_date".localized, badge.date ?? ""))
+                        .font(Font(UIFont(name: "NunitoSans-Regular", size: 12) ?? UIFont.systemFont(ofSize: 12)))
+                        .foregroundColor(Color(red: 0.4, green: 0.4, blue: 0.4))
+                } else if type == .notStarted {
+                    Text("badge_\(badge.name)_desc".localized)
+                        .font(Font(UIFont(name: "NunitoSans-Regular", size: 12) ?? UIFont.systemFont(ofSize: 12)))
+                        .foregroundColor(Color(red: 0.6, green: 0.6, blue: 0.6))
+                } else {
+                    // in progress short desc
+                    Text("badge_\(badge.name)_desc_short".localized)
+                        .font(Font(UIFont(name: "NunitoSans-Regular", size: 12) ?? UIFont.systemFont(ofSize: 12)))
+                        .foregroundColor(Color(red: 0.6, green: 0.6, blue: 0.6))
+                }
+
+                // Progress bar
+                if type == .obtained || type == .inProgress {
+                    HStack(spacing: 8) {
+                        GeometryReader { geometry in
+                            ZStack(alignment: .leading) {
+                                Capsule().fill(Color(red: 0.95, green: 0.95, blue: 0.95))
+                                    .frame(height: 6)
+
+                                let progress = type == .obtained ? 1.0 : min(1.0, Double(badge.progression ?? 0) / getMaxProgression(for: badge.name))
+
+                                Capsule().fill(type == .obtained ? Color(red: 0.16, green: 0.5, blue: 0.3) : Color(red: 0.94, green: 0.44, blue: 0.17))
+                                    .frame(width: geometry.size.width * CGFloat(progress), height: 6)
+                            }
+                        }
+                        .frame(height: 6)
+                        .padding(.top, 8)
+
+                        if type == .obtained {
+                            Image(systemName: "checkmark")
+                                .foregroundColor(Color(red: 0.16, green: 0.5, blue: 0.3))
+                                .font(.system(size: 10, weight: .bold))
+                                .padding(.top, 8)
+                        } else {
+                            Text("\(badge.progression ?? 0)/\(Int(getMaxProgression(for: badge.name)))")
+                                .font(Font(UIFont(name: "NunitoSans-Bold", size: 12) ?? UIFont.systemFont(ofSize: 12, weight: .bold)))
+                                .foregroundColor(Color(red: 0.94, green: 0.44, blue: 0.17))
+                                .padding(.top, 8)
+                        }
+                    }
+                }
+
+                // For not started, show 0/X logic inside if needed? Actually in mockups it's on the right bottom
+                if type == .notStarted && viewModel.hasAnyProgression {
+                    HStack {
+                        Spacer()
+                        Text("0/\(Int(getMaxProgression(for: badge.name)))")
+                            .font(Font(UIFont(name: "NunitoSans-Bold", size: 12) ?? UIFont.systemFont(ofSize: 12, weight: .bold)))
+                            .foregroundColor(Color(red: 0.6, green: 0.6, blue: 0.6))
+                    }
+                } else if type == .notStarted && !viewModel.hasAnyProgression {
+                   HStack {
+                       Spacer()
+                       Text("0/\(Int(getMaxProgression(for: badge.name)))")
+                           .font(Font(UIFont(name: "NunitoSans-Bold", size: 12) ?? UIFont.systemFont(ofSize: 12, weight: .bold)))
+                           .foregroundColor(Color(red: 0.6, green: 0.6, blue: 0.6))
+                   }
+                }
+            }
+        }
+        .padding(16)
+        .background(Color.white)
+        .cornerRadius(12)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(isNotStarted ? Color(red: 0.95, green: 0.95, blue: 0.95) : (type == .inProgress ? Color.appBeige : Color(red: 0.9, green: 0.9, blue: 0.9)), lineWidth: 1)
+        )
+    }
+
+    func getEmoji(for name: String) -> String {
+        switch name {
+        case "premier_contact": return "👣"
+        case "bienvenue": return "🤝"
+        case "moteur_rencontres": return "💫"
+        case "fidele_papotages": return "💬"
+        case "voix_presente": return "🌱"
+        default: return "✨"
+        }
+    }
+
+    func getMaxProgression(for name: String) -> Double {
+        switch name {
+        case "premier_contact": return 1
+        case "bienvenue": return 1
+        case "moteur_rencontres": return 3
+        case "fidele_papotages": return 3
+        case "voix_presente": return 3
+        default: return 1
+        }
+    }
+}

--- a/entourage/Scenes/Badges/BadgesViewModel.swift
+++ b/entourage/Scenes/Badges/BadgesViewModel.swift
@@ -1,0 +1,70 @@
+import Foundation
+import SwiftUI
+
+class BadgesViewModel: ObservableObject {
+    @Published var badges: [Badge] = []
+    @Published var isLoading = true
+    @Published var error: Error?
+
+    // We mock the badge info as the back doesn't send progression/dates yet in most environments
+    // But we still parse and merge with the known keys to map them correctly.
+
+    // All known badges
+    let allBadgeKeys = [
+        "premier_contact",
+        "bienvenue",
+        "moteur_rencontres",
+        "fidele_papotages",
+        "voix_presente"
+    ]
+
+    func fetchBadges() {
+        self.isLoading = true
+        HomeService.getUserHome { [weak self] userHome, error in
+            guard let self = self else { return }
+            self.isLoading = false
+
+            if let error = error {
+                self.error = error
+                return
+            }
+
+            if let fetchedBadges = userHome?.badges {
+                // Merge fetched badges with our known full list
+                var mergedBadges = [Badge]()
+
+                let fetchedNames = Set(fetchedBadges.map { $0.name })
+
+                for key in self.allBadgeKeys {
+                    if let fetchedBadge = fetchedBadges.first(where: { $0.name == key }) {
+                        mergedBadges.append(fetchedBadge)
+                    } else {
+                        // Badge not started
+                        mergedBadges.append(Badge(name: key, date: nil, progression: 0))
+                    }
+                }
+
+                self.badges = mergedBadges
+            } else {
+                // If userHome?.badges is nil, populate with empty badges
+                self.badges = self.allBadgeKeys.map { Badge(name: $0, date: nil, progression: 0) }
+            }
+        }
+    }
+
+    var hasAnyProgression: Bool {
+        return badges.contains(where: { $0.date != nil || ($0.progression ?? 0) > 0 })
+    }
+
+    var obtainedBadges: [Badge] {
+        return badges.filter { $0.date != nil }
+    }
+
+    var inProgressBadges: [Badge] {
+        return badges.filter { $0.date == nil && ($0.progression ?? 0) > 0 }
+    }
+
+    var notStartedBadges: [Badge] {
+        return badges.filter { $0.date == nil && ($0.progression ?? 0) == 0 }
+    }
+}

--- a/entourage/Scenes/ProfileFull/ProfileViewControllerSwiftUI.swift
+++ b/entourage/Scenes/ProfileFull/ProfileViewControllerSwiftUI.swift
@@ -84,6 +84,7 @@ struct PartnerLogoView: UIViewRepresentable {
 struct ProfileView: View {
     @StateObject var viewModel: ProfileViewModel
     @State private var scrollOffset: CGFloat = 0
+    @State private var showBadges: Bool = false
 
     var body: some View {
         print("DEBUG: ProfileView body called")
@@ -176,6 +177,11 @@ struct ProfileView: View {
                             .font(Font(UIFont(name: "Quicksand-Bold", size: 15) ?? UIFont.systemFont(ofSize: 15)))
                             .foregroundColor(.black)
                             .frame(maxWidth: .infinity, alignment: .center)
+                            .onLongPressGesture {
+                                if viewModel.isMe {
+                                    showBadges = true
+                                }
+                            }
                     }
 
                     // Roles and Partner stack (beige pills with orange text)
@@ -356,6 +362,9 @@ struct ProfileView: View {
         .onAppear {
             print("DEBUG: ProfileView onAppear called")
             viewModel.loadData()
+        }
+        .fullScreenCover(isPresented: $showBadges) {
+            BadgesView()
         }
     }
 }


### PR DESCRIPTION
Added a new SwiftUI package to show user badges. The view can be accessed via a long press on the display name in the user's own profile. Includes parsing logic for upcoming API format change.

---
*PR created automatically by Jules for task [16019407838238799463](https://jules.google.com/task/16019407838238799463) started by @clemPerrousset*